### PR TITLE
feat(finances): improve transfer detection and add manual linking UI

### DIFF
--- a/apps/finances-frontend/src/app/dashboard/transactions/transactions.component.scss
+++ b/apps/finances-frontend/src/app/dashboard/transactions/transactions.component.scss
@@ -745,3 +745,137 @@
     }
   }
 }
+
+// ── Transfer linking UI ──
+
+.transfer-card {
+  background: rgba(var(--mat-sys-tertiary-rgb), 0.06);
+  border: 1px solid rgba(var(--mat-sys-tertiary-rgb), 0.2);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+
+  .transfer-card-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-sm);
+    font-weight: 600;
+    color: var(--mat-sys-tertiary);
+
+    mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .transfer-card-body {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--spacing-xs) var(--spacing-md);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  .transfer-detail {
+    display: flex;
+    flex-direction: column;
+
+    .transfer-label {
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      color: var(--mat-sys-on-surface-variant);
+      letter-spacing: 0.04em;
+      font-weight: 600;
+    }
+  }
+
+  .unlink-btn {
+    margin-top: var(--spacing-xs);
+    width: 100%;
+    color: var(--mat-sys-error);
+  }
+}
+
+.confidence-badge {
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 12px;
+  background: rgba(var(--mat-sys-tertiary-rgb), 0.12);
+  color: var(--mat-sys-tertiary);
+  font-weight: 600;
+  margin-left: auto;
+}
+
+.transfer-suggestions {
+  background: rgba(var(--mat-sys-tertiary-rgb), 0.04);
+  border: 1px solid rgba(var(--mat-sys-tertiary-rgb), 0.15);
+  border-radius: var(--border-radius-md);
+  padding: var(--spacing-md);
+  margin-bottom: var(--spacing-md);
+
+  .transfer-suggestions-header {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-sm);
+    font-weight: 600;
+    color: var(--mat-sys-tertiary);
+
+    mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+    }
+  }
+
+  .suggestion-row {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-xs) 0;
+    border-bottom: 1px solid rgba(var(--mat-sys-outline-rgb), 0.08);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    .suggestion-info {
+      flex: 1;
+      min-width: 0;
+
+      .suggestion-name {
+        display: block;
+        font-weight: 500;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .suggestion-meta {
+        display: block;
+        font-size: 0.75rem;
+        color: var(--mat-sys-on-surface-variant);
+      }
+    }
+
+    .suggestion-amount {
+      font-weight: 600;
+      white-space: nowrap;
+    }
+  }
+}
+
+.transfer-loading {
+  display: flex;
+  align-items: center;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm) 0;
+  margin-bottom: var(--spacing-md);
+  color: var(--mat-sys-on-surface-variant);
+  font-size: 0.85rem;
+}
+
+.tx-amount.transfer-amount {
+  color: var(--mat-sys-tertiary);
+}

--- a/apps/finances-frontend/src/app/services/finance-api.service.ts
+++ b/apps/finances-frontend/src/app/services/finance-api.service.ts
@@ -138,6 +138,7 @@ export interface Transaction {
   pending: boolean;
   isReviewed: boolean;
   linkedTransferId: string | null;
+  linkedTransferConfidence: number | null;
   paymentChannel: string | null;
   locationCity: string | null;
   locationRegion: string | null;
@@ -151,6 +152,7 @@ export interface TransactionUpdate {
   tags?: string[];
   notes?: string | null;
   isReviewed?: boolean;
+  linkedTransferId?: string | null;
 }
 
 export interface TransactionFilters {
@@ -171,7 +173,13 @@ export interface TransactionStats {
   totalIncome: number;
   totalExpenses: number;
   totalTransfers: number;
+  linkedTransferCount: number;
+  unlinkedTransferCount: number;
   byCategory: Array<{ category: string; amount: number; count: number }>;
+}
+
+export interface TransferSuggestion extends Transaction {
+  confidence: number;
 }
 
 // ==================== Category Types ====================
@@ -467,6 +475,28 @@ export class FinanceApiService {
   getLinkedTransfer(id: string): Observable<Transaction | null> {
     return this._http.get<Transaction | null>(
       `${this.baseUrl}/finances/transactions/${id}/linked-transfer`
+    );
+  }
+
+  linkTransfer(
+    id: string,
+    targetTransactionId: string
+  ): Observable<Transaction> {
+    return this._http.post<Transaction>(
+      `${this.baseUrl}/finances/transactions/${id}/link-transfer`,
+      { targetTransactionId }
+    );
+  }
+
+  unlinkTransfer(id: string): Observable<Transaction> {
+    return this._http.delete<Transaction>(
+      `${this.baseUrl}/finances/transactions/${id}/link-transfer`
+    );
+  }
+
+  getTransferSuggestions(id: string): Observable<TransferSuggestion[]> {
+    return this._http.get<TransferSuggestion[]>(
+      `${this.baseUrl}/finances/transactions/${id}/transfer-suggestions`
     );
   }
 

--- a/apps/finances/src/app/plaid/overview.service.ts
+++ b/apps/finances/src/app/plaid/overview.service.ts
@@ -122,6 +122,11 @@ export class OverviewService {
     for (const txn of filtered) {
       const amount = Math.abs(parseFloat(txn.amount.toString()));
 
+      // Skip linked transfers — they're internal money movements, not income/expenses
+      if (txn.type === TransactionType.TRANSFER && txn.linkedTransferId) {
+        continue;
+      }
+
       if (txn.type === TransactionType.INCOME) {
         totalIncome += amount;
         if (!dayMap.has(txn.date)) {

--- a/apps/finances/src/app/plaid/transaction.entity.ts
+++ b/apps/finances/src/app/plaid/transaction.entity.ts
@@ -105,6 +105,10 @@ export class Transaction {
   @Column('uuid', { nullable: true })
   linkedTransferId?: string;
 
+  // Confidence score for auto-detected transfer links (0-100)
+  @Column('integer', { nullable: true })
+  linkedTransferConfidence?: number;
+
   // Payment metadata
   @Column('text', { nullable: true })
   paymentChannel?: string;
@@ -151,6 +155,7 @@ export const TransactionOutSchema = z.object({
   pending: z.boolean(),
   isReviewed: z.boolean(),
   linkedTransferId: z.string().uuid().nullable(),
+  linkedTransferConfidence: z.number().nullable(),
   paymentChannel: z.string().nullable(),
   locationCity: z.string().nullable(),
   locationRegion: z.string().nullable(),
@@ -166,6 +171,7 @@ export const TransactionUpdateSchema = z.object({
   tags: z.array(z.string()).optional(),
   notes: z.string().nullable().optional(),
   isReviewed: z.boolean().optional(),
+  linkedTransferId: z.string().uuid().nullable().optional(),
 });
 
 export type TransactionUpdate = z.infer<typeof TransactionUpdateSchema>;


### PR DESCRIPTION
## Summary

Improves the transaction transfer detection engine and adds a full manual linking UI to the finances app.

### Backend Changes
- **Rewritten `detectTransfers()`** — fuzzy date matching (±3 days), confidence scoring (0-100), broader candidate pool (scans all unlinked transactions, not just TRANSFER-typed)
- **Improved `determineTransactionType()`** — detects bill payments via Plaid `LOAN_PAYMENTS`/`CREDIT_CARD_PAYMENT` categories and name patterns (VISA PAYMENT, MASTERCARD PYMT, etc.)
- **New `linkedTransferConfidence` column** on transaction entity
- **New API endpoints**: `POST /:id/link-transfer`, `DELETE /:id/link-transfer`, `GET /:id/transfer-suggestions`
- **Updated stats** with `linkedTransferCount` and `unlinkedTransferCount`
- **Fixed spending accuracy** — linked transfers excluded from spending totals in overview

### Frontend Changes
- **Transfer info card** in edit panel showing linked transaction details with confidence badge
- **Transfer suggestions panel** with confidence-ranked matches and one-click linking
- **Context menu actions**: View Transfer, Unlink Transfer, Link as Transfer
- **Inbox workflow**: transfer info display during review
- **Fixed `formatAmount()` and `getAmountClass()`** for TRANSFER type (+/- prefix, tertiary color)

### Files Changed
- `transaction.entity.ts` — new column + schema updates
- `plaid.service.ts` — rewritten transfer detection + confidence scoring
- `transactions.service.ts` — link/unlink/suggestions service methods
- `transactions.router.ts` — 3 new API routes
- `overview.service.ts` — skip linked transfers in spending
- `finance-api.service.ts` — new types + API methods
- `transactions.component.ts/scss` — transfer UI in edit panel + context menu
- `inbox.component.ts` — transfer info in review workflow