### PR TITLE
feat(aritzia-scanner): AI integration, performance, pagination & favorites

### DIFF
--- a/apps/aritzia-scanner/src/ai-routes.ts
+++ b/apps/aritzia-scanner/src/ai-routes.ts
@@ -1,0 +1,619 @@
+import { Router, Request, Response } from 'express';
+import { getOllamaClient, Message } from './ollama';
+import { allPromise, getDB, getPromise, runPromise } from './db';
+import dayjs from 'dayjs';
+
+const router = Router();
+
+// ==================== HELPER: SSE Stream ====================
+
+function setupSSE(res: Response) {
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+  res.flushHeaders();
+}
+
+function sendSSE(res: Response, event: string, data: any) {
+  res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+}
+
+// Helper to get last scan time
+async function getLastScanTime(db: any): Promise<string> {
+  const lastScanRow = await getPromise.call(
+    db,
+    'SELECT MAX(last_seen_at) as max_time FROM variants'
+  );
+  return lastScanRow ? lastScanRow.max_time : new Date().toISOString();
+}
+
+// ==================== AI Product Summary (Streaming) ====================
+
+router.get('/api/ai/summary/:productId', async (req: Request, res: Response) => {
+  const { productId } = req.params;
+  const db = getDB();
+
+  try {
+    // Check cache first
+    const cached = await getPromise.call(
+      db,
+      'SELECT summary, created_at FROM ai_summaries WHERE product_id = ?',
+      [productId]
+    );
+    
+    // Cache valid for 24 hours
+    if (cached && cached.summary) {
+      const cacheAge = dayjs().diff(dayjs(cached.created_at), 'hour');
+      if (cacheAge < 24) {
+        setupSSE(res);
+        sendSSE(res, 'content', { content: cached.summary, done: false, thinking: false, cached: true });
+        sendSSE(res, 'done', { done: true });
+        res.end();
+        return;
+      }
+    }
+
+    // Fetch product data
+    const product = await getPromise.call(db, 'SELECT * FROM products WHERE id = ?', [productId]);
+    if (!product) {
+      res.status(404).json({ error: 'Product not found' });
+      return;
+    }
+
+    // Fetch variant price range
+    const priceInfo = await getPromise.call(
+      db,
+      `SELECT MIN(price) as min_price, MAX(price) as max_price, MIN(list_price) as min_list, MAX(list_price) as max_list
+       FROM variants WHERE product_id = ?`,
+      [productId]
+    );
+
+    // Fetch price history for trend analysis
+    const priceHistory = await allPromise.call(
+      db,
+      `SELECT p.price, p.timestamp FROM prices p
+       JOIN variants v ON p.variant_id = v.id
+       WHERE v.product_id = ?
+       ORDER BY p.timestamp DESC LIMIT 20`,
+      [productId]
+    );
+
+    const fabric = product.fabric ? JSON.parse(product.fabric) : [];
+    const category = product.category ? JSON.parse(product.category) : [];
+    const sustainability = product.sustainability ? JSON.parse(product.sustainability) : [];
+
+    const systemPrompt = `You are a fashion-savvy shopping assistant for Aritzia products. Give concise, opinionated, helpful summaries. Be honest about value. Use 2-3 short paragraphs max. Include: what the product is best for, value assessment, and any notable features. Do NOT use markdown headers.`;
+
+    const userPrompt = `Analyze this Aritzia product:
+
+**${product.display_name || product.name}**
+- Brand: ${product.brand || 'Aritzia'}
+- Category: ${category.join(', ') || 'N/A'}
+- Fabric: ${fabric.join(', ') || 'N/A'}
+- Current price: $${priceInfo?.min_price || 'N/A'}${priceInfo?.min_price !== priceInfo?.max_price ? ` - $${priceInfo?.max_price}` : ''}
+- List price: $${priceInfo?.min_list || 'N/A'}${priceInfo?.min_list !== priceInfo?.max_list ? ` - $${priceInfo?.max_list}` : ''}
+${priceInfo?.min_price < priceInfo?.min_list ? `- ON SALE: ${Math.round((1 - priceInfo.min_price / priceInfo.min_list) * 100)}% off` : ''}
+- Rating: ${product.rating || 'N/A'}/5 (${product.review_count || 0} reviews)
+- Sustainability: ${sustainability.length > 0 ? sustainability.join(', ') : 'None listed'}
+- Description: ${product.description || 'N/A'}
+${product.designers_notes ? `- Designer's notes: ${product.designers_notes}` : ''}
+- Price trend: ${priceHistory.length > 1 ? `${priceHistory.length} price points recorded` : 'No history yet'}
+
+Give a quick, opinionated summary: is this worth buying? What's it best for? Any concerns?`;
+
+    const messages: Message[] = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ];
+
+    setupSSE(res);
+    const ollama = getOllamaClient();
+    let fullContent = '';
+
+    for await (const chunk of ollama.chatStream(messages, { temperature: 0.7 })) {
+      fullContent += chunk.content;
+      sendSSE(res, 'content', {
+        content: chunk.content,
+        done: chunk.done,
+        thinking: chunk.thinking || false,
+      });
+    }
+
+    // Cache the result (strip thinking blocks for cache)
+    const cleanContent = fullContent.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
+    if (cleanContent) {
+      await runPromise.call(
+        db,
+        `INSERT OR REPLACE INTO ai_summaries (product_id, summary, created_at) VALUES (?, ?, ?)`,
+        [productId, cleanContent, new Date().toISOString()]
+      );
+    }
+
+    sendSSE(res, 'done', { done: true });
+    res.end();
+  } catch (error: any) {
+    console.error('AI Summary error:', error.message);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'AI service unavailable' });
+    } else {
+      sendSSE(res, 'error', { error: error.message });
+      res.end();
+    }
+  }
+});
+
+// ==================== AI Natural Language Search (Streaming) ====================
+
+router.get('/api/ai/search', async (req: Request, res: Response) => {
+  const query = (req.query.q as string) || '';
+  const db = getDB();
+
+  if (!query || query.length < 3) {
+    res.status(400).json({ error: 'Query must be at least 3 characters' });
+    return;
+  }
+
+  try {
+    const lastScanTime = await getLastScanTime(db);
+
+    // Get summary of what's in the database for context
+    const brands = await allPromise.call(db, `SELECT DISTINCT brand FROM products WHERE brand IS NOT NULL ORDER BY brand`);
+    const categoryRows = await allPromise.call(db, `SELECT DISTINCT category FROM products WHERE category IS NOT NULL`);
+    const categoriesSet = new Set<string>();
+    categoryRows.forEach((r: any) => {
+      try { JSON.parse(r.category).forEach((c: string) => categoriesSet.add(c)); } catch {}
+    });
+
+    const priceRange = await getPromise.call(db, `SELECT MIN(price) as min_price, MAX(price) as max_price FROM variants WHERE last_seen_at = ?`, [lastScanTime]);
+
+    const systemPrompt = `You are a search query parser for an Aritzia clothing database. Extract structured filters from natural language queries.
+
+Available brands: ${brands.map((b: any) => b.brand).join(', ')}
+Available categories: ${Array.from(categoriesSet).join(', ')}
+Price range in database: $${priceRange?.min_price} - $${priceRange?.max_price}
+Available sizes: 2XS, XS, S, M, L, XL, 2XL, 3XL
+Color examples: Black, White, Heather Birch, Deep Camel, etc.
+
+IMPORTANT: Respond with ONLY valid JSON, no other text. Use this exact schema:`;
+
+    const userPrompt = `Parse this shopping query: "${query}"
+
+Return JSON:
+{
+  "searchTerms": ["keyword1", "keyword2"],
+  "brand": "brand name or null",
+  "category": "category or null",
+  "minPrice": number or null,
+  "maxPrice": number or null,
+  "size": "size or null",
+  "color": "color name or null",
+  "onSale": true/false/null,
+  "sortBy": "price-low" | "price-high" | "rating" | "newest" | "discount" | null,
+  "explanation": "brief explanation of what you understood from the query"
+}`;
+
+    const messages: Message[] = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ];
+
+    setupSSE(res);
+    const ollama = getOllamaClient();
+
+    // First: stream the AI's interpretation
+    sendSSE(res, 'status', { message: 'Understanding your query...' });
+
+    let fullResponse = '';
+    for await (const chunk of ollama.chatStream(messages, { temperature: 0.1 })) {
+      fullResponse += chunk.content;
+      sendSSE(res, 'thinking', {
+        content: chunk.content,
+        thinking: chunk.thinking || false,
+      });
+    }
+
+    // Parse AI response to extract filters
+    let filters: any = {};
+    try {
+      // Extract JSON from response (may be wrapped in markdown code blocks)
+      const jsonMatch = fullResponse.match(/\{[\s\S]*\}/);
+      if (jsonMatch) {
+        filters = JSON.parse(jsonMatch[0]);
+      }
+    } catch (parseErr) {
+      console.error('Failed to parse AI search response:', parseErr);
+    }
+
+    sendSSE(res, 'filters', { filters });
+
+    // Build SQL query from parsed filters
+    let sql = `
+      SELECT v.id, v.color, v.color_id, v.length, v.price, v.list_price,
+             v.available_sizes, v.swatch, v.ref_color,
+             p.name, p.display_name, p.brand, p.id as product_id, p.slug,
+             p.rating, p.review_count, p.category, p.sustainability,
+             COALESCE(
+               (SELECT id FROM images WHERE variant_id = v.id LIMIT 1),
+               (SELECT i.id FROM images i JOIN variants v2 ON i.variant_id = v2.id WHERE v2.product_id = v.product_id AND v2.color = v.color LIMIT 1)
+             ) as thumbnail_id
+      FROM variants v
+      JOIN products p ON v.product_id = p.id
+      WHERE v.last_seen_at = ?
+    `;
+    const params: any[] = [lastScanTime];
+
+    // Apply search terms
+    if (filters.searchTerms && filters.searchTerms.length > 0) {
+      const termConditions = filters.searchTerms.map(() => `(p.name LIKE ? OR p.display_name LIKE ? OR p.description LIKE ? OR v.color LIKE ?)`);
+      sql += ` AND (${termConditions.join(' OR ')})`;
+      filters.searchTerms.forEach((term: string) => {
+        params.push(`%${term}%`, `%${term}%`, `%${term}%`, `%${term}%`);
+      });
+    }
+
+    if (filters.brand) {
+      sql += ` AND p.brand = ?`;
+      params.push(filters.brand);
+    }
+
+    if (filters.category) {
+      sql += ` AND p.category LIKE ?`;
+      params.push(`%${filters.category}%`);
+    }
+
+    if (filters.color) {
+      sql += ` AND v.color LIKE ?`;
+      params.push(`%${filters.color}%`);
+    }
+
+    if (filters.size) {
+      sql += ` AND v.available_sizes LIKE ?`;
+      params.push(`%${filters.size}%`);
+    }
+
+    if (filters.minPrice != null) {
+      sql += ` AND v.price >= ?`;
+      params.push(filters.minPrice);
+    }
+
+    if (filters.maxPrice != null) {
+      sql += ` AND v.price <= ?`;
+      params.push(filters.maxPrice);
+    }
+
+    if (filters.onSale === true) {
+      sql += ` AND v.price < v.list_price`;
+    }
+
+    // Sorting
+    switch (filters.sortBy) {
+      case 'price-low': sql += ` ORDER BY v.price ASC`; break;
+      case 'price-high': sql += ` ORDER BY v.price DESC`; break;
+      case 'rating': sql += ` ORDER BY p.rating DESC, p.review_count DESC`; break;
+      case 'discount': sql += ` ORDER BY ((v.list_price - v.price) / v.list_price) DESC`; break;
+      case 'newest': sql += ` ORDER BY v.added_at DESC`; break;
+      default: sql += ` ORDER BY p.review_count DESC`; break;
+    }
+
+    sql += ` LIMIT 50`;
+
+    const results = await allPromise.call(db, sql, params);
+
+    results.forEach((v: any) => {
+      v.available_sizes_arr = v.available_sizes ? JSON.parse(v.available_sizes) : [];
+      v.category_arr = v.category ? JSON.parse(v.category) : [];
+      v.sustainability_arr = v.sustainability ? JSON.parse(v.sustainability) : [];
+    });
+
+    sendSSE(res, 'results', { products: results, count: results.length, explanation: filters.explanation || '' });
+    sendSSE(res, 'done', { done: true });
+    res.end();
+  } catch (error: any) {
+    console.error('AI Search error:', error.message);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'AI service unavailable' });
+    } else {
+      sendSSE(res, 'error', { error: error.message });
+      res.end();
+    }
+  }
+});
+
+// ==================== AI Style Advisor (Streaming) ====================
+
+router.get('/api/ai/style', async (req: Request, res: Response) => {
+  const occasion = (req.query.occasion as string) || '';
+  const db = getDB();
+
+  if (!occasion || occasion.length < 3) {
+    res.status(400).json({ error: 'Please describe an occasion or style' });
+    return;
+  }
+
+  try {
+    const lastScanTime = await getLastScanTime(db);
+
+    // Get a diverse sample of current products for the AI to choose from
+    const sampleProducts = await allPromise.call(
+      db,
+      `SELECT p.id, p.name, p.display_name, p.brand, p.category, p.fabric,
+              p.rating, p.review_count, p.sustainability, p.warmth,
+              MIN(v.price) as price, MAX(v.list_price) as list_price,
+              GROUP_CONCAT(DISTINCT v.color) as colors
+       FROM products p
+       JOIN variants v ON p.id = v.product_id
+       WHERE v.last_seen_at = ? AND v.available_sizes != '[]'
+       GROUP BY p.id
+       ORDER BY p.review_count DESC
+       LIMIT 80`,
+      [lastScanTime]
+    );
+
+    const productList = sampleProducts.map((p: any, i: number) => {
+      const cats = p.category ? JSON.parse(p.category) : [];
+      const fab = p.fabric ? JSON.parse(p.fabric) : [];
+      return `[${i}] ${p.display_name || p.name} | ${p.brand || 'Aritzia'} | $${p.price}${p.price < p.list_price ? ` (sale from $${p.list_price})` : ''} | ${cats.join(', ')} | Fabric: ${fab.join(', ')} | Rating: ${p.rating}/5 | Colors: ${p.colors}`;
+    }).join('\n');
+
+    const systemPrompt = `You are a fashion stylist assistant for Aritzia. The user will describe an occasion, vibe, or style goal. Recommend 3-5 products from the available inventory that would work well together as an outfit or collection.
+
+For each recommendation, explain WHY it works for their needs. Be specific about colors and styling tips. Be enthusiastic but honest.
+
+Format your response as natural prose with product names in **bold**. At the end, include a JSON block with the product indices like: <!--PICKS:[0,5,12]-->`;
+
+    const userPrompt = `I need outfit recommendations for: "${occasion}"
+
+Here are the products currently available:
+${productList}
+
+Recommend 3-5 items that work together. Explain your styling choices.`;
+
+    const messages: Message[] = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ];
+
+    setupSSE(res);
+    const ollama = getOllamaClient();
+    let fullResponse = '';
+
+    sendSSE(res, 'status', { message: 'Curating your style recommendations...' });
+
+    for await (const chunk of ollama.chatStream(messages, { temperature: 0.8 })) {
+      fullResponse += chunk.content;
+      sendSSE(res, 'content', {
+        content: chunk.content,
+        done: chunk.done,
+        thinking: chunk.thinking || false,
+      });
+    }
+
+    // Extract product picks from response
+    const picksMatch = fullResponse.match(/<!--PICKS:\[([\d,\s]+)\]-->/);
+    if (picksMatch) {
+      try {
+        const indices = JSON.parse(`[${picksMatch[1]}]`);
+        const picks = indices
+          .filter((i: number) => i >= 0 && i < sampleProducts.length)
+          .map((i: number) => {
+            const p = sampleProducts[i];
+            return {
+              id: p.id,
+              name: p.display_name || p.name,
+              price: p.price,
+              list_price: p.list_price,
+              brand: p.brand,
+              rating: p.rating,
+              colors: p.colors,
+            };
+          });
+        sendSSE(res, 'picks', { products: picks });
+      } catch {}
+    }
+
+    sendSSE(res, 'done', { done: true });
+    res.end();
+  } catch (error: any) {
+    console.error('AI Style error:', error.message);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'AI service unavailable' });
+    } else {
+      sendSSE(res, 'error', { error: error.message });
+      res.end();
+    }
+  }
+});
+
+// ==================== AI Outfit Builder (Streaming) ====================
+
+router.get('/api/ai/outfit/:productId', async (req: Request, res: Response) => {
+  const { productId } = req.params;
+  const db = getDB();
+
+  try {
+    const lastScanTime = await getLastScanTime(db);
+
+    const product = await getPromise.call(db, 'SELECT * FROM products WHERE id = ?', [productId]);
+    if (!product) {
+      res.status(404).json({ error: 'Product not found' });
+      return;
+    }
+
+    // Get other available products for pairing
+    const otherProducts = await allPromise.call(
+      db,
+      `SELECT p.id, p.name, p.display_name, p.brand, p.category, p.fabric,
+              p.rating, p.review_count, p.sustainability, p.warmth,
+              MIN(v.price) as price, MAX(v.list_price) as list_price,
+              GROUP_CONCAT(DISTINCT v.color) as colors
+       FROM products p
+       JOIN variants v ON p.id = v.product_id
+       WHERE v.last_seen_at = ? AND p.id != ? AND v.available_sizes != '[]'
+       GROUP BY p.id
+       ORDER BY p.review_count DESC
+       LIMIT 60`,
+      [lastScanTime, productId]
+    );
+
+    const productList = otherProducts.map((p: any, i: number) => {
+      const cats = p.category ? JSON.parse(p.category) : [];
+      const fab = p.fabric ? JSON.parse(p.fabric) : [];
+      return `[${i}] ${p.display_name || p.name} | $${p.price} | ${cats.join(', ')} | ${fab.join(', ')} | Colors: ${p.colors}`;
+    }).join('\n');
+
+    const fabric = product.fabric ? JSON.parse(product.fabric) : [];
+    const category = product.category ? JSON.parse(product.category) : [];
+
+    const systemPrompt = `You are a fashion stylist for Aritzia. The user has selected a product and wants to know what else to pair with it for a complete outfit. Suggest 2-4 complementary pieces from the available inventory.
+
+Consider: color coordination, style cohesion, occasion versatility, and layering. Be specific about which colors to pair.
+
+Format naturally with product names in **bold**. End with: <!--PICKS:[indices]-->`;
+
+    const userPrompt = `I just picked: **${product.display_name || product.name}** (${category.join(', ')}, ${fabric.join(', ')}, $${product.price || 'N/A'})
+
+What should I pair it with from these available items?
+${productList}`;
+
+    const messages: Message[] = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ];
+
+    setupSSE(res);
+    const ollama = getOllamaClient();
+    let fullResponse = '';
+
+    sendSSE(res, 'status', { message: `Finding pieces to pair with ${product.display_name || product.name}...` });
+
+    for await (const chunk of ollama.chatStream(messages, { temperature: 0.8 })) {
+      fullResponse += chunk.content;
+      sendSSE(res, 'content', {
+        content: chunk.content,
+        done: chunk.done,
+        thinking: chunk.thinking || false,
+      });
+    }
+
+    // Extract picks
+    const picksMatch = fullResponse.match(/<!--PICKS:\[([\d,\s]+)\]-->/);
+    if (picksMatch) {
+      try {
+        const indices = JSON.parse(`[${picksMatch[1]}]`);
+        const picks = indices
+          .filter((i: number) => i >= 0 && i < otherProducts.length)
+          .map((i: number) => {
+            const p = otherProducts[i];
+            return {
+              id: p.id,
+              name: p.display_name || p.name,
+              price: p.price,
+              list_price: p.list_price,
+              rating: p.rating,
+            };
+          });
+        sendSSE(res, 'picks', { products: picks });
+      } catch {}
+    }
+
+    sendSSE(res, 'done', { done: true });
+    res.end();
+  } catch (error: any) {
+    console.error('AI Outfit error:', error.message);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'AI service unavailable' });
+    } else {
+      sendSSE(res, 'error', { error: error.message });
+      res.end();
+    }
+  }
+});
+
+// ==================== AI Deals Report (Streaming) ====================
+
+router.get('/api/ai/deals', async (req: Request, res: Response) => {
+  const db = getDB();
+
+  try {
+    const lastScanTime = await getLastScanTime(db);
+
+    // Get biggest price drops (comparing current price to historical max)
+    const bigDeals = await allPromise.call(
+      db,
+      `SELECT p.id, p.name, p.display_name, p.brand, p.category, p.rating, p.review_count,
+              v.color, v.price, v.list_price, v.id as variant_id,
+              (SELECT MAX(pr.price) FROM prices pr WHERE pr.variant_id = v.id) as highest_price,
+              (SELECT MIN(pr.price) FROM prices pr WHERE pr.variant_id = v.id) as lowest_ever
+       FROM variants v
+       JOIN products p ON v.product_id = p.id
+       WHERE v.last_seen_at = ? AND v.price < v.list_price
+       ORDER BY ((v.list_price - v.price) / v.list_price) DESC
+       LIMIT 20`,
+      [lastScanTime]
+    );
+
+    // Get recent restocks
+    const recentRestocks = await allPromise.call(
+      db,
+      `SELECT p.name, p.display_name, v.color, v.price, r.timestamp
+       FROM restocks r
+       JOIN variants v ON r.variant_id = v.id
+       JOIN products p ON v.product_id = p.id
+       ORDER BY r.timestamp DESC
+       LIMIT 10`
+    );
+
+    const dealsInfo = bigDeals.map((d: any) => {
+      const discount = Math.round((1 - d.price / d.list_price) * 100);
+      return `- ${d.display_name || d.name} in ${d.color}: $${d.price} (was $${d.list_price}, ${discount}% off, lowest ever: $${d.lowest_ever || d.price}) | Rating: ${d.rating}/5 (${d.review_count} reviews)`;
+    }).join('\n');
+
+    const restocksInfo = recentRestocks.map((r: any) =>
+      `- ${r.display_name || r.name} in ${r.color}: $${r.price} (restocked ${dayjs(r.timestamp).fromNow()})`
+    ).join('\n');
+
+    const systemPrompt = `You are a deals analyst for Aritzia shoppers. Write an engaging, concise deals report highlighting the best current values. Be enthusiastic about genuinely good deals, skeptical about marginal ones. Group by theme (best discounts, popular items on sale, recent restocks). Use casual but informative tone. Keep it under 400 words.`;
+
+    const userPrompt = `Write this week's Aritzia deals report.
+
+TOP DEALS (by discount):
+${dealsInfo || 'No items currently on sale.'}
+
+RECENT RESTOCKS:
+${restocksInfo || 'No recent restocks.'}
+
+Write an engaging summary highlighting the best values.`;
+
+    const messages: Message[] = [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: userPrompt },
+    ];
+
+    setupSSE(res);
+    const ollama = getOllamaClient();
+
+    sendSSE(res, 'status', { message: 'Analyzing current deals...' });
+
+    for await (const chunk of ollama.chatStream(messages, { temperature: 0.7 })) {
+      sendSSE(res, 'content', {
+        content: chunk.content,
+        done: chunk.done,
+        thinking: chunk.thinking || false,
+      });
+    }
+
+    sendSSE(res, 'done', { done: true });
+    res.end();
+  } catch (error: any) {
+    console.error('AI Deals error:', error.message);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'AI service unavailable' });
+    } else {
+      sendSSE(res, 'error', { error: error.message });
+      res.end();
+    }
+  }
+});
+
+export default router;

--- a/apps/aritzia-scanner/src/main.ts
+++ b/apps/aritzia-scanner/src/main.ts
@@ -132,13 +132,11 @@ async function main() {
     allImages.forEach((img: any) => {
       if (!imagesByVariant.has(img.variant_id))
         imagesByVariant.set(img.variant_id, []);
-      imagesByVariant
-        .get(img.variant_id)!
-        .push({
-          id: img.id,
-          product_id: img.product_id,
-          variant_id: img.variant_id,
-        });
+      imagesByVariant.get(img.variant_id)!.push({
+        id: img.id,
+        product_id: img.product_id,
+        variant_id: img.variant_id,
+      });
     });
 
     for (const variant of variants) {
@@ -1271,6 +1269,26 @@ async function main() {
       title: store.name !== 'Unknown' ? store.name : `Store #${storeId}`,
       stats,
     });
+  });
+
+  // ==================== AI WEB ROUTES ====================
+
+  app.get('/ai/search', async (req, res) => {
+    const db = getDB();
+    const stats = await getStats(db);
+    res.render('ai_search', { stats });
+  });
+
+  app.get('/ai/style', async (req, res) => {
+    const db = getDB();
+    const stats = await getStats(db);
+    res.render('ai_style', { stats });
+  });
+
+  app.get('/ai/deals', async (req, res) => {
+    const db = getDB();
+    const stats = await getStats(db);
+    res.render('ai_deals', { stats });
   });
 
   app.listen(PORT, () => {

--- a/apps/aritzia-scanner/src/main.ts
+++ b/apps/aritzia-scanner/src/main.ts
@@ -239,7 +239,7 @@ async function main() {
 
   // Fetch variants by IDs (for wishlist)
   app.get('/api/variants', async (req, res) => {
-    const ids = (req.query.ids as string || '').split(',').filter(Boolean);
+    const ids = ((req.query.ids as string) || '').split(',').filter(Boolean);
     if (ids.length === 0) {
       res.json([]);
       return;

--- a/apps/aritzia-scanner/src/main.ts
+++ b/apps/aritzia-scanner/src/main.ts
@@ -11,6 +11,7 @@ import { allPromise, closeDB, getDB, getPromise, setupDatabase } from './db';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 import { closeBrowser, updateDatabase } from './scraper';
+import aiRoutes from './ai-routes';
 
 dayjs.extend(relativeTime);
 dayjs.extend(utc);
@@ -69,6 +70,7 @@ async function main() {
   app.set('view engine', 'ejs');
   app.set('views', path.join(__dirname, 'views'));
   app.use(express.static(path.join(__dirname, 'public')));
+  app.use(aiRoutes);
 
   // ==================== API ROUTES ====================
 

--- a/apps/aritzia-scanner/src/ollama.ts
+++ b/apps/aritzia-scanner/src/ollama.ts
@@ -1,0 +1,250 @@
+const OLLAMA_URL = process.env.OLLAMA_URL || 'https://ollama.elliott.haus';
+const DEFAULT_MODEL = process.env.OLLAMA_MODEL || 'qwen3:8b';
+const DEFAULT_TIMEOUT_MS = 180000; // 3 minutes
+
+export interface Message {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface JsonSchema {
+  type: 'object' | 'array' | 'string' | 'number' | 'boolean';
+  properties?: Record<string, JsonSchema>;
+  items?: JsonSchema;
+  required?: string[];
+  enum?: string[];
+  description?: string;
+}
+
+export interface ChatOptions {
+  model?: string;
+  temperature?: number;
+  timeoutMs?: number;
+  format?: JsonSchema;
+}
+
+interface OllamaChatRequest {
+  model: string;
+  messages: Message[];
+  stream: boolean;
+  format?: JsonSchema;
+  options?: {
+    temperature?: number;
+  };
+}
+
+interface OllamaChatResponse {
+  model: string;
+  message: {
+    role: string;
+    content: string;
+  };
+  done: boolean;
+  total_duration?: number;
+  prompt_eval_count?: number;
+  eval_count?: number;
+}
+
+// Streaming chunk from Ollama
+interface OllamaStreamChunk {
+  model: string;
+  message: {
+    role: string;
+    content: string;
+  };
+  done: boolean;
+  total_duration?: number;
+  prompt_eval_count?: number;
+  eval_count?: number;
+}
+
+export class OllamaClient {
+  private baseUrl: string;
+  private defaultModel: string;
+  private defaultTimeoutMs: number;
+
+  constructor(
+    baseUrl: string = OLLAMA_URL,
+    defaultModel: string = DEFAULT_MODEL,
+    defaultTimeoutMs: number = DEFAULT_TIMEOUT_MS
+  ) {
+    this.baseUrl = baseUrl;
+    this.defaultModel = defaultModel;
+    this.defaultTimeoutMs = defaultTimeoutMs;
+  }
+
+  /**
+   * Non-streaming chat request
+   */
+  async chat(messages: Message[], options?: ChatOptions): Promise<string> {
+    const model = options?.model ?? this.defaultModel;
+    const timeoutMs = options?.timeoutMs ?? this.defaultTimeoutMs;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort('Request timeout'),
+      timeoutMs
+    );
+
+    try {
+      const request: OllamaChatRequest = {
+        model,
+        messages,
+        stream: false,
+        ...(options?.format && { format: options.format }),
+        ...(options?.temperature !== undefined && {
+          options: { temperature: options.temperature },
+        }),
+      };
+
+      const response = await fetch(`${this.baseUrl}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `Ollama request failed: ${response.status} - ${errorText}`
+        );
+      }
+
+      const data: OllamaChatResponse = await response.json();
+      return data.message.content;
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.name === 'AbortError') {
+          throw new Error(`Ollama request timed out after ${timeoutMs}ms`);
+        }
+        throw new Error(`Ollama request failed: ${error.message}`);
+      }
+      throw new Error('Ollama request failed: Unknown error');
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  /**
+   * Streaming chat request - yields chunks as they arrive.
+   * Perfect for Server-Sent Events (SSE).
+   */
+  async *chatStream(
+    messages: Message[],
+    options?: ChatOptions
+  ): AsyncGenerator<{ content: string; done: boolean; thinking?: boolean }> {
+    const model = options?.model ?? this.defaultModel;
+    const timeoutMs = options?.timeoutMs ?? this.defaultTimeoutMs;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(
+      () => controller.abort('Request timeout'),
+      timeoutMs
+    );
+
+    try {
+      const request: OllamaChatRequest = {
+        model,
+        messages,
+        stream: true,
+        ...(options?.format && { format: options.format }),
+        ...(options?.temperature !== undefined && {
+          options: { temperature: options.temperature },
+        }),
+      };
+
+      const response = await fetch(`${this.baseUrl}/api/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(
+          `Ollama stream failed: ${response.status} - ${errorText}`
+        );
+      }
+
+      if (!response.body) {
+        throw new Error('No response body for streaming');
+      }
+
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let inThinkBlock = false;
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() || '';
+
+        for (const line of lines) {
+          if (!line.trim()) continue;
+          try {
+            const chunk: OllamaStreamChunk = JSON.parse(line);
+            const content = chunk.message?.content || '';
+
+            // Track <think> blocks for reasoning display
+            if (content.includes('<think>')) {
+              inThinkBlock = true;
+            }
+            if (content.includes('</think>')) {
+              inThinkBlock = false;
+              yield { content, done: false, thinking: true };
+              continue;
+            }
+
+            yield {
+              content,
+              done: chunk.done,
+              thinking: inThinkBlock,
+            };
+          } catch {
+            // Skip malformed JSON lines
+          }
+        }
+      }
+
+      // Process any remaining buffer
+      if (buffer.trim()) {
+        try {
+          const chunk: OllamaStreamChunk = JSON.parse(buffer);
+          yield {
+            content: chunk.message?.content || '',
+            done: chunk.done,
+            thinking: false,
+          };
+        } catch {
+          // Skip
+        }
+      }
+    } catch (error) {
+      if (error instanceof Error) {
+        if (error.name === 'AbortError') {
+          throw new Error(`Ollama stream timed out after ${timeoutMs}ms`);
+        }
+        throw new Error(`Ollama stream failed: ${error.message}`);
+      }
+      throw new Error('Ollama stream failed: Unknown error');
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+// Singleton instance
+let ollamaInstance: OllamaClient | null = null;
+
+export function getOllamaClient(): OllamaClient {
+  if (!ollamaInstance) {
+    ollamaInstance = new OllamaClient();
+  }
+  return ollamaInstance;
+}

--- a/apps/aritzia-scanner/src/public/styles.css
+++ b/apps/aritzia-scanner/src/public/styles.css
@@ -4,11 +4,13 @@
 
 /* Global Styles */
 body {
-  font-family: sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   margin: 0 auto;
   padding: 20px;
-  background-color: light-dark(#fff, #121212);
+  padding-top: 80px; /* Account for sticky nav */
+  background-color: light-dark(#fafafa, #121212);
   color: light-dark(#333, #e0e0e0);
+  max-width: 1600px;
 }
 
 h1 {
@@ -35,19 +37,70 @@ a:hover {
 }
 
 .nav {
-  margin-bottom: 20px;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
+  background-color: light-dark(rgba(255,255,255,0.92), rgba(18,18,18,0.92));
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border-bottom: 1px solid light-dark(#e0e0e0, #333);
+  padding: 0 20px;
+  display: flex;
+  flex-direction: column;
 }
 
-.nav a {
-  margin-right: 15px;
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 10px 0 4px;
+  flex-wrap: wrap;
+}
+
+.nav-links a {
   text-decoration: none;
   color: light-dark(#333, #e0e0e0);
-  font-weight: bold;
+  font-weight: 600;
+  font-size: 0.88em;
+  padding: 4px 8px;
+  border-radius: 6px;
+  transition: background-color 0.15s;
+  white-space: nowrap;
 }
 
-.nav a:hover {
-  text-decoration: underline;
-  color: light-dark(#333, #fff);
+.nav-links a:hover {
+  background-color: light-dark(#f0f0f0, #2a2a2a);
+  text-decoration: none;
+  color: light-dark(#000, #fff);
+}
+
+.nav-divider {
+  color: light-dark(#ccc, #444);
+  margin: 0 4px;
+  user-select: none;
+}
+
+.nav-ai-link {
+  color: light-dark(#7c3aed, #a78bfa) !important;
+  font-weight: 700 !important;
+}
+
+.nav-ai-link:hover {
+  background-color: light-dark(#f3f0ff, #2d1b69) !important;
+}
+
+.nav-stats {
+  display: flex;
+  gap: 16px;
+  padding: 2px 0 8px;
+  font-size: 0.75em;
+  color: light-dark(#888, #777);
+}
+
+.nav-stat {
+  white-space: nowrap;
 }
 
 /* Product Grid */
@@ -1198,9 +1251,21 @@ select {
 /* ==================== */
 
 @media (max-width: 768px) {
-  .nav {
-    flex-wrap: wrap;
-    gap: 10px;
+  body {
+    padding-top: 110px;
+  }
+
+  .nav-links {
+    gap: 2px;
+  }
+
+  .nav-links a {
+    font-size: 0.8em;
+    padding: 3px 6px;
+  }
+
+  .nav-divider {
+    display: none;
   }
 
   .filter-search {
@@ -1215,4 +1280,269 @@ select {
     flex: none;
     width: 100%;
   }
+
+  .ai-search-input {
+    min-width: 0 !important;
+  }
+
+  .ai-quick-prompts {
+    flex-wrap: wrap;
+  }
+}
+
+/* ==================== */
+/* Skeleton Loading     */
+/* ==================== */
+
+.no-image-placeholder {
+  background: linear-gradient(
+    90deg,
+    light-dark(#f0f0f0, #2a2a2a) 25%,
+    light-dark(#e0e0e0, #333) 50%,
+    light-dark(#f0f0f0, #2a2a2a) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: light-dark(#bbb, #555);
+  font-size: 0.85em;
+}
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.product-image img {
+  animation: fadeIn 0.3s ease-in;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ==================== */
+/* AI Styles            */
+/* ==================== */
+
+.ai-subtitle {
+  color: light-dark(#666, #999);
+  margin-top: -10px;
+  margin-bottom: 20px;
+}
+
+.ai-search-input {
+  min-width: 350px;
+  flex: 1;
+}
+
+.ai-stream-container {
+  background-color: light-dark(#f8f6ff, #1a1625);
+  border: 1px solid light-dark(#e0d8f0, #2d2640);
+  border-radius: 12px;
+  padding: 20px;
+  margin-bottom: 24px;
+  overflow: hidden;
+}
+
+.ai-thinking-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: light-dark(#7c3aed, #a78bfa);
+}
+
+.ai-thinking-icon {
+  font-size: 1.3em;
+}
+
+.ai-reasoning {
+  background-color: light-dark(#f0edfa, #15111f);
+  border: 1px solid light-dark(#d8d0ee, #2a2040);
+  border-radius: 8px;
+  padding: 12px 16px;
+  margin-bottom: 12px;
+  font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+  font-size: 0.82em;
+  color: light-dark(#6b5b8a, #8b7bad);
+  max-height: 150px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+.ai-content {
+  font-size: 0.95em;
+  line-height: 1.7;
+  color: light-dark(#333, #ddd);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.ai-content strong {
+  color: light-dark(#1a1a1a, #fff);
+}
+
+.ai-filters-display {
+  background-color: light-dark(#eee8fd, #1f1830);
+  border-radius: 8px;
+  padding: 10px 14px;
+  margin-bottom: 12px;
+  font-size: 0.88em;
+}
+
+.ai-filter-tag {
+  display: inline-block;
+  background-color: light-dark(#7c3aed, #5b21b6);
+  color: #fff;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: 0.85em;
+  margin: 2px 4px;
+}
+
+.ai-explanation {
+  color: light-dark(#666, #999);
+  font-style: italic;
+  margin-bottom: 16px;
+}
+
+.ai-error {
+  background-color: light-dark(#fff0f0, #2a1515);
+  border: 1px solid light-dark(#ffcdd2, #4a2020);
+  border-radius: 8px;
+  padding: 16px;
+  color: light-dark(#c62828, #ef9a9a);
+}
+
+.ai-product-actions {
+  display: flex;
+  gap: 12px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.ai-action-btn {
+  background: linear-gradient(135deg, light-dark(#7c3aed, #5b21b6), light-dark(#a78bfa, #7c3aed));
+  color: #fff;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 8px;
+  font-size: 0.9em;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s, box-shadow 0.15s;
+}
+
+.ai-action-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 12px light-dark(rgba(124, 58, 237, 0.3), rgba(124, 58, 237, 0.5));
+}
+
+.ai-quick-prompts {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 20px;
+  flex-wrap: wrap;
+}
+
+.quick-prompt {
+  background-color: light-dark(#f3f0ff, #1f1830);
+  border: 1px solid light-dark(#d8d0ee, #3d2d5c);
+  color: light-dark(#7c3aed, #a78bfa);
+  padding: 6px 16px;
+  border-radius: 20px;
+  font-size: 0.85em;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.quick-prompt:hover {
+  background-color: light-dark(#7c3aed, #5b21b6);
+  color: #fff;
+  border-color: transparent;
+}
+
+/* ==================== */
+/* Nav Sale Link        */
+/* ==================== */
+
+.nav-sale-link {
+  color: light-dark(#dc2626, #ef4444) !important;
+  font-weight: 700 !important;
+}
+
+/* ==================== */
+/* Discount overlay     */
+/* ==================== */
+
+.product-card {
+  position: relative;
+}
+
+.discount-overlay {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background-color: #dc2626;
+  color: #fff;
+  padding: 2px 8px;
+  border-radius: 4px;
+  font-size: 0.75em;
+  font-weight: 700;
+  z-index: 1;
+}
+
+/* ==================== */
+/* Color swatches in cards */
+/* ==================== */
+
+.card-swatches {
+  display: flex;
+  gap: 3px;
+  margin-top: 6px;
+  flex-wrap: wrap;
+}
+
+.card-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 1px solid light-dark(#ddd, #444);
+  display: inline-block;
+}
+
+/* ==================== */
+/* Dark mode toggle     */
+/* ==================== */
+
+.theme-toggle {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1001;
+  background-color: light-dark(#fff, #1e1e1e);
+  border: 1px solid light-dark(#ddd, #444);
+  border-radius: 50%;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  font-size: 1.3em;
+  box-shadow: 0 2px 8px light-dark(rgba(0,0,0,0.15), rgba(0,0,0,0.5));
+  transition: transform 0.2s;
+}
+
+.theme-toggle:hover {
+  transform: scale(1.1);
 }

--- a/apps/aritzia-scanner/src/public/styles.css
+++ b/apps/aritzia-scanner/src/public/styles.css
@@ -42,7 +42,10 @@ a:hover {
   left: 0;
   right: 0;
   z-index: 1000;
-  background-color: light-dark(rgba(255,255,255,0.92), rgba(18,18,18,0.92));
+  background-color: light-dark(
+    rgba(255, 255, 255, 0.92),
+    rgba(18, 18, 18, 0.92)
+  );
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid light-dark(#e0e0e0, #333);
@@ -468,6 +471,66 @@ select {
 .view-all-container {
   margin-top: 30px;
   text-align: center;
+}
+
+/* Pagination */
+.pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 4px;
+  margin: 32px 0 16px;
+  flex-wrap: wrap;
+}
+
+.page-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid light-dark(#ddd, #444);
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  color: light-dark(#333, #e0e0e0);
+  background: light-dark(#fff, #1e1e1e);
+  text-decoration: none;
+  transition: all 0.15s ease;
+}
+
+.page-link:hover:not(.disabled):not(.active) {
+  background: light-dark(#f0f0f0, #2a2a2a);
+  border-color: light-dark(#999, #666);
+  color: light-dark(#333, #fff);
+}
+
+.page-link:visited {
+  color: light-dark(#333, #e0e0e0);
+}
+
+.page-link.active {
+  background: light-dark(#333, #e0e0e0);
+  color: light-dark(#fff, #121212);
+  border-color: light-dark(#333, #e0e0e0);
+  font-weight: 700;
+}
+
+.page-link.disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+}
+
+.page-ellipsis {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  height: 36px;
+  color: light-dark(#999, #666);
+  font-size: 14px;
 }
 
 /* Badge Styles */
@@ -1313,8 +1376,12 @@ select {
 }
 
 @keyframes shimmer {
-  0% { background-position: 200% 0; }
-  100% { background-position: -200% 0; }
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
 }
 
 .product-image img {
@@ -1322,8 +1389,12 @@ select {
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 /* ==================== */
@@ -1431,7 +1502,11 @@ select {
 }
 
 .ai-action-btn {
-  background: linear-gradient(135deg, light-dark(#7c3aed, #5b21b6), light-dark(#a78bfa, #7c3aed));
+  background: linear-gradient(
+    135deg,
+    light-dark(#7c3aed, #5b21b6),
+    light-dark(#a78bfa, #7c3aed)
+  );
   color: #fff;
   border: none;
   padding: 10px 20px;
@@ -1444,7 +1519,8 @@ select {
 
 .ai-action-btn:hover {
   transform: translateY(-2px);
-  box-shadow: 0 4px 12px light-dark(rgba(124, 58, 237, 0.3), rgba(124, 58, 237, 0.5));
+  box-shadow: 0 4px 12px
+    light-dark(rgba(124, 58, 237, 0.3), rgba(124, 58, 237, 0.5));
 }
 
 .ai-quick-prompts {
@@ -1502,6 +1578,70 @@ select {
 }
 
 /* ==================== */
+/* Favorite button      */
+/* ==================== */
+
+.favorite-btn {
+  position: absolute;
+  top: 8px;
+  left: 8px;
+  z-index: 2;
+  background: light-dark(rgba(255,255,255,0.85), rgba(30,30,30,0.85));
+  border: none;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  font-size: 18px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: light-dark(#999, #666);
+  transition: all 0.2s ease;
+  line-height: 1;
+  padding: 0;
+}
+
+.favorite-btn:hover {
+  color: #e11d48;
+  transform: scale(1.15);
+}
+
+.favorite-btn.favorited {
+  color: #e11d48;
+}
+
+.nav-fav-link {
+  color: light-dark(#e11d48, #fb7185) !important;
+}
+
+.fav-badge {
+  font-size: 0.7em;
+  background: #e11d48;
+  color: #fff;
+  border-radius: 999px;
+  padding: 1px 5px;
+  margin-left: 2px;
+  vertical-align: super;
+}
+
+.fav-badge:empty {
+  display: none;
+}
+
+/* Favorites page */
+.favorites-empty {
+  text-align: center;
+  padding: 60px 20px;
+  color: light-dark(#999, #666);
+}
+
+.favorites-empty .heart-icon-demo {
+  color: #e11d48;
+  font-size: 1.3em;
+}
+
+/* ==================== */
 /* Color swatches in cards */
 /* ==================== */
 
@@ -1539,7 +1679,7 @@ select {
   justify-content: center;
   cursor: pointer;
   font-size: 1.3em;
-  box-shadow: 0 2px 8px light-dark(rgba(0,0,0,0.15), rgba(0,0,0,0.5));
+  box-shadow: 0 2px 8px light-dark(rgba(0, 0, 0, 0.15), rgba(0, 0, 0, 0.5));
   transition: transform 0.2s;
 }
 

--- a/apps/aritzia-scanner/src/public/styles.css
+++ b/apps/aritzia-scanner/src/public/styles.css
@@ -1586,7 +1586,7 @@ select {
   top: 8px;
   left: 8px;
   z-index: 2;
-  background: light-dark(rgba(255,255,255,0.85), rgba(30,30,30,0.85));
+  background: light-dark(rgba(255, 255, 255, 0.85), rgba(30, 30, 30, 0.85));
   border: none;
   border-radius: 50%;
   width: 32px;

--- a/apps/aritzia-scanner/src/scraper.ts
+++ b/apps/aritzia-scanner/src/scraper.ts
@@ -292,7 +292,10 @@ export async function updateDatabase() {
     DB,
     'SELECT id, available_sizes, price, list_price FROM variants'
   );
-  const existingVariantsMap = new Map<string, { sizes: string[]; price: number; listPrice: number }>();
+  const existingVariantsMap = new Map<
+    string,
+    { sizes: string[]; price: number; listPrice: number }
+  >();
   existingVariants.forEach((v: any) => {
     existingVariantsMap.set(v.id, {
       sizes: JSON.parse(v.available_sizes || '[]'),
@@ -385,7 +388,11 @@ export async function updateDatabase() {
 
           // Price history — only insert when price actually changed
           const existingVariant = existingVariantsMap.get(variantId);
-          if (!existingVariant || existingVariant.price !== color.price || existingVariant.listPrice !== color.list_price) {
+          if (
+            !existingVariant ||
+            existingVariant.price !== color.price ||
+            existingVariant.listPrice !== color.list_price
+          ) {
             priceInsertRecords.push([
               variantId,
               color.price,

--- a/apps/aritzia-scanner/src/views/ai_deals.ejs
+++ b/apps/aritzia-scanner/src/views/ai_deals.ejs
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Deals Report - Aritzia Scanner</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/nav') %>
+
+    <h1>AI Deals Report</h1>
+    <p class="ai-subtitle">
+      AI-generated analysis of the best current deals and restocks
+    </p>
+
+    <button
+      id="generate-btn"
+      class="filter-btn"
+      onclick="generateReport()"
+      style="margin-bottom: 20px"
+    >
+      Generate Deals Report
+    </button>
+
+    <div id="ai-stream" class="ai-stream-container" style="display: none">
+      <div class="ai-thinking-header">
+        <span class="ai-thinking-icon">💰</span>
+        <span id="stream-status">Analyzing deals...</span>
+      </div>
+      <div id="ai-reasoning" class="ai-reasoning" style="display: none"></div>
+      <div id="ai-content" class="ai-content"></div>
+    </div>
+
+    <div id="ai-error" class="ai-error" style="display: none"></div>
+
+    <script>
+      function generateReport() {
+        const btn = document.getElementById('generate-btn');
+        btn.disabled = true;
+        btn.textContent = 'Generating...';
+
+        document.getElementById('ai-stream').style.display = 'block';
+        document.getElementById('ai-error').style.display = 'none';
+        document.getElementById('ai-content').innerHTML = '';
+        document.getElementById('ai-reasoning').innerHTML = '';
+        document.getElementById('ai-reasoning').style.display = 'none';
+
+        const evtSource = new EventSource('/api/ai/deals');
+
+        evtSource.addEventListener('status', (e) => {
+          const data = JSON.parse(e.data);
+          document.getElementById('stream-status').textContent = data.message;
+        });
+
+        evtSource.addEventListener('content', (e) => {
+          const data = JSON.parse(e.data);
+          const contentEl = document.getElementById('ai-content');
+          const reasoningEl = document.getElementById('ai-reasoning');
+
+          if (data.thinking) {
+            reasoningEl.style.display = 'block';
+            reasoningEl.innerHTML += escapeHtml(data.content);
+            reasoningEl.scrollTop = reasoningEl.scrollHeight;
+          } else {
+            contentEl.innerHTML += escapeHtml(data.content);
+            contentEl.scrollTop = contentEl.scrollHeight;
+          }
+        });
+
+        evtSource.addEventListener('done', () => {
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Regenerate Report';
+          document.getElementById('stream-status').textContent =
+            'Report complete';
+
+          // Post-process markdown
+          const contentEl = document.getElementById('ai-content');
+          let html = contentEl.innerHTML;
+          html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+          html = html.replace(/\n/g, '<br>');
+          html = html.replace(/#{1,3}\s+(.+?)(<br>)/g, '<h3>$1</h3>');
+          contentEl.innerHTML = html;
+        });
+
+        evtSource.addEventListener('error', (e) => {
+          try {
+            const data = JSON.parse(e.data);
+            document.getElementById('ai-error').style.display = 'block';
+            document.getElementById('ai-error').textContent = data.error;
+          } catch {}
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Generate Deals Report';
+        });
+
+        evtSource.onerror = () => {
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Generate Deals Report';
+        };
+      }
+
+      function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.appendChild(document.createTextNode(text));
+        return div.innerHTML;
+      }
+
+      // Auto-generate on page load
+      generateReport();
+    </script>
+  </body>
+</html>

--- a/apps/aritzia-scanner/src/views/ai_search.ejs
+++ b/apps/aritzia-scanner/src/views/ai_search.ejs
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>AI Search - Aritzia Scanner</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/nav') %>
+
+    <h1>AI Search</h1>
+    <p class="ai-subtitle">
+      Describe what you're looking for in natural language
+    </p>
+
+    <form
+      id="ai-search-form"
+      class="filters-form"
+      onsubmit="return handleSearch(event)"
+    >
+      <input
+        type="text"
+        id="ai-search-input"
+        name="q"
+        placeholder="e.g. warm cozy sweater under $100 in neutral colors..."
+        class="filter-input filter-search ai-search-input"
+        autocomplete="off"
+      />
+      <button type="submit" class="filter-btn" id="ai-search-btn">
+        Search
+      </button>
+    </form>
+
+    <div id="ai-thinking" class="ai-stream-container" style="display: none">
+      <div class="ai-thinking-header">
+        <span class="ai-thinking-icon">🤖</span>
+        <span>Understanding your query...</span>
+      </div>
+      <div id="ai-reasoning" class="ai-reasoning" style="display: none"></div>
+      <div
+        id="ai-filters"
+        class="ai-filters-display"
+        style="display: none"
+      ></div>
+    </div>
+
+    <div id="ai-results" style="display: none">
+      <h2 id="results-heading"></h2>
+      <p id="ai-explanation" class="ai-explanation"></p>
+      <div id="results-grid" class="product-grid"></div>
+    </div>
+
+    <div id="ai-error" class="ai-error" style="display: none"></div>
+
+    <script>
+      function handleSearch(e) {
+        e.preventDefault();
+        const query = document.getElementById('ai-search-input').value.trim();
+        if (query.length < 3) return false;
+
+        const btn = document.getElementById('ai-search-btn');
+        btn.disabled = true;
+        btn.textContent = 'Searching...';
+
+        document.getElementById('ai-thinking').style.display = 'block';
+        document.getElementById('ai-results').style.display = 'none';
+        document.getElementById('ai-error').style.display = 'none';
+        document.getElementById('ai-reasoning').style.display = 'none';
+        document.getElementById('ai-reasoning').innerHTML = '';
+        document.getElementById('ai-filters').style.display = 'none';
+
+        const evtSource = new EventSource(
+          `/api/ai/search?q=${encodeURIComponent(query)}`
+        );
+
+        evtSource.addEventListener('thinking', (e) => {
+          const data = JSON.parse(e.data);
+          const reasoningEl = document.getElementById('ai-reasoning');
+          if (data.thinking) {
+            reasoningEl.style.display = 'block';
+            reasoningEl.classList.add('thinking-active');
+          } else if (
+            reasoningEl.classList.contains('thinking-active') &&
+            data.content
+          ) {
+            // Transition from thinking to regular output
+          }
+          reasoningEl.innerHTML += escapeHtml(data.content);
+          reasoningEl.scrollTop = reasoningEl.scrollHeight;
+        });
+
+        evtSource.addEventListener('filters', (e) => {
+          const data = JSON.parse(e.data);
+          const filtersEl = document.getElementById('ai-filters');
+          if (data.filters && Object.keys(data.filters).length > 0) {
+            filtersEl.style.display = 'block';
+            const f = data.filters;
+            let html = '<strong>Interpreted filters:</strong> ';
+            const parts = [];
+            if (f.searchTerms?.length)
+              parts.push(`Keywords: ${f.searchTerms.join(', ')}`);
+            if (f.brand) parts.push(`Brand: ${f.brand}`);
+            if (f.category) parts.push(`Category: ${f.category}`);
+            if (f.color) parts.push(`Color: ${f.color}`);
+            if (f.size) parts.push(`Size: ${f.size}`);
+            if (f.minPrice != null) parts.push(`Min: $${f.minPrice}`);
+            if (f.maxPrice != null) parts.push(`Max: $${f.maxPrice}`);
+            if (f.onSale) parts.push('On Sale');
+            if (f.sortBy) parts.push(`Sort: ${f.sortBy}`);
+            html += parts
+              .map((p) => `<span class="ai-filter-tag">${p}</span>`)
+              .join(' ');
+            filtersEl.innerHTML = html;
+          }
+        });
+
+        evtSource.addEventListener('results', (e) => {
+          const data = JSON.parse(e.data);
+          const resultsEl = document.getElementById('ai-results');
+          const gridEl = document.getElementById('results-grid');
+          const headingEl = document.getElementById('results-heading');
+          const explanationEl = document.getElementById('ai-explanation');
+
+          resultsEl.style.display = 'block';
+          headingEl.textContent = `Found ${data.count} result${
+            data.count !== 1 ? 's' : ''
+          }`;
+          explanationEl.textContent = data.explanation || '';
+
+          if (data.products.length === 0) {
+            gridEl.innerHTML =
+              '<div class="empty-state">No products matched your search. Try a different description.</div>';
+            return;
+          }
+
+          gridEl.innerHTML = data.products
+            .map(
+              (p) => `
+            <div class="product-card">
+              <a href="/product/${p.product_id}/variant/${
+                p.color_id
+              }" class="product-image">
+                ${
+                  p.thumbnail_id
+                    ? `<img src="/api/images/${
+                        p.thumbnail_id
+                      }" alt="${escapeHtml(
+                        p.display_name || p.name
+                      )}" loading="lazy" />`
+                    : '<span class="no-image-placeholder">No Image</span>'
+                }
+              </a>
+              <div class="product-info">
+                <a href="/product/${p.product_id}/variant/${
+                p.color_id
+              }" class="product-name">${escapeHtml(
+                p.display_name || p.name
+              )}</a>
+                <div class="product-price-container">
+                  ${
+                    p.price < p.list_price
+                      ? `<span class="price-sale">$${p.price}</span> <span class="price-list">$${p.list_price}</span>`
+                      : `<span>$${p.price}</span>`
+                  }
+                </div>
+                <div class="variant-details">${escapeHtml(
+                  p.color
+                )} (${escapeHtml(p.length)})</div>
+                ${
+                  p.rating
+                    ? `<div class="product-meta">${'★'.repeat(
+                        Math.round(p.rating)
+                      )}${'☆'.repeat(
+                        5 - Math.round(p.rating)
+                      )} ${p.rating.toFixed(1)}</div>`
+                    : ''
+                }
+              </div>
+            </div>
+          `
+            )
+            .join('');
+        });
+
+        evtSource.addEventListener('error', (e) => {
+          try {
+            const data = JSON.parse(e.data);
+            document.getElementById('ai-error').style.display = 'block';
+            document.getElementById(
+              'ai-error'
+            ).textContent = `Error: ${data.error}`;
+          } catch {
+            document.getElementById('ai-error').style.display = 'block';
+            document.getElementById('ai-error').textContent =
+              'Connection lost. Please try again.';
+          }
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Search';
+        });
+
+        evtSource.addEventListener('done', () => {
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Search';
+          // Collapse thinking
+          document.querySelector(
+            '.ai-thinking-header span:last-child'
+          ).textContent = 'Query processed';
+        });
+
+        evtSource.onerror = () => {
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Search';
+        };
+
+        return false;
+      }
+
+      function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.appendChild(document.createTextNode(text));
+        return div.innerHTML;
+      }
+    </script>
+  </body>
+</html>

--- a/apps/aritzia-scanner/src/views/ai_style.ejs
+++ b/apps/aritzia-scanner/src/views/ai_style.ejs
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Style Advisor - Aritzia Scanner</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/nav') %>
+
+    <h1>AI Style Advisor</h1>
+    <p class="ai-subtitle">
+      Describe an occasion, vibe, or style goal and get outfit recommendations
+    </p>
+
+    <form
+      id="style-form"
+      class="filters-form"
+      onsubmit="return handleStyle(event)"
+    >
+      <input
+        type="text"
+        id="style-input"
+        placeholder="e.g. business casual winter layering, weekend brunch, cozy work from home..."
+        class="filter-input filter-search ai-search-input"
+        autocomplete="off"
+      />
+      <button type="submit" class="filter-btn" id="style-btn">
+        Get Recommendations
+      </button>
+    </form>
+
+    <div class="ai-quick-prompts">
+      <button
+        class="quick-prompt"
+        onclick="setPrompt('casual weekend brunch outfit')"
+      >
+        Weekend Brunch
+      </button>
+      <button
+        class="quick-prompt"
+        onclick="setPrompt('professional office outfit that is warm for winter')"
+      >
+        Winter Office
+      </button>
+      <button
+        class="quick-prompt"
+        onclick="setPrompt('cozy work from home loungewear')"
+      >
+        WFH Cozy
+      </button>
+      <button
+        class="quick-prompt"
+        onclick="setPrompt('date night outfit, chic and elegant')"
+      >
+        Date Night
+      </button>
+      <button
+        class="quick-prompt"
+        onclick="setPrompt('athleisure for running errands in fall')"
+      >
+        Fall Errands
+      </button>
+      <button
+        class="quick-prompt"
+        onclick="setPrompt('sustainable and eco-friendly outfit')"
+      >
+        Sustainable
+      </button>
+    </div>
+
+    <div id="ai-stream" class="ai-stream-container" style="display: none">
+      <div class="ai-thinking-header">
+        <span class="ai-thinking-icon">👗</span>
+        <span id="stream-status">Curating recommendations...</span>
+      </div>
+      <div id="ai-reasoning" class="ai-reasoning" style="display: none"></div>
+      <div id="ai-content" class="ai-content"></div>
+    </div>
+
+    <div id="ai-picks" style="display: none">
+      <h2>Recommended Products</h2>
+      <div id="picks-grid" class="product-grid"></div>
+    </div>
+
+    <div id="ai-error" class="ai-error" style="display: none"></div>
+
+    <script>
+      function setPrompt(text) {
+        document.getElementById('style-input').value = text;
+        document
+          .getElementById('style-form')
+          .dispatchEvent(new Event('submit'));
+      }
+
+      function handleStyle(e) {
+        e.preventDefault();
+        const occasion = document.getElementById('style-input').value.trim();
+        if (occasion.length < 3) return false;
+
+        const btn = document.getElementById('style-btn');
+        btn.disabled = true;
+        btn.textContent = 'Thinking...';
+
+        document.getElementById('ai-stream').style.display = 'block';
+        document.getElementById('ai-picks').style.display = 'none';
+        document.getElementById('ai-error').style.display = 'none';
+        document.getElementById('ai-content').innerHTML = '';
+        document.getElementById('ai-reasoning').innerHTML = '';
+        document.getElementById('ai-reasoning').style.display = 'none';
+
+        const evtSource = new EventSource(
+          `/api/ai/style?occasion=${encodeURIComponent(occasion)}`
+        );
+
+        evtSource.addEventListener('status', (e) => {
+          const data = JSON.parse(e.data);
+          document.getElementById('stream-status').textContent = data.message;
+        });
+
+        evtSource.addEventListener('content', (e) => {
+          const data = JSON.parse(e.data);
+          const contentEl = document.getElementById('ai-content');
+          const reasoningEl = document.getElementById('ai-reasoning');
+
+          if (data.thinking) {
+            reasoningEl.style.display = 'block';
+            reasoningEl.innerHTML += escapeHtml(data.content);
+            reasoningEl.scrollTop = reasoningEl.scrollHeight;
+          } else {
+            // Convert **bold** to <strong> and handle newlines
+            let html = escapeHtml(data.content);
+            contentEl.innerHTML += html;
+            contentEl.scrollTop = contentEl.scrollHeight;
+          }
+        });
+
+        evtSource.addEventListener('picks', (e) => {
+          const data = JSON.parse(e.data);
+          if (data.products && data.products.length > 0) {
+            const picksEl = document.getElementById('ai-picks');
+            const gridEl = document.getElementById('picks-grid');
+            picksEl.style.display = 'block';
+
+            gridEl.innerHTML = data.products
+              .map(
+                (p) => `
+              <div class="product-card">
+                <div class="product-info">
+                  <a href="/product/${p.id}" class="product-name">${escapeHtml(
+                  p.name
+                )}</a>
+                  <div class="product-price-container">
+                    ${
+                      p.price < p.list_price
+                        ? `<span class="price-sale">$${p.price}</span> <span class="price-list">$${p.list_price}</span>`
+                        : `<span>$${p.price}</span>`
+                    }
+                  </div>
+                  ${
+                    p.brand
+                      ? `<div class="variant-details">${escapeHtml(
+                          p.brand
+                        )}</div>`
+                      : ''
+                  }
+                  ${
+                    p.rating
+                      ? `<div class="product-meta">${'★'.repeat(
+                          Math.round(p.rating)
+                        )}${'☆'.repeat(
+                          5 - Math.round(p.rating)
+                        )} ${p.rating.toFixed(1)}</div>`
+                      : ''
+                  }
+                </div>
+              </div>
+            `
+              )
+              .join('');
+          }
+        });
+
+        evtSource.addEventListener('done', () => {
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Get Recommendations';
+          document.getElementById('stream-status').textContent =
+            'Recommendations ready';
+
+          // Post-process: convert markdown bold in content
+          const contentEl = document.getElementById('ai-content');
+          let html = contentEl.innerHTML;
+          // Remove the <!--PICKS:...--> tag from visible content
+          html = html.replace(/&lt;!--PICKS:\[[\d,\s]*\]--&gt;/g, '');
+          // Convert **text** to bold
+          html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+          // Convert newlines to <br>
+          html = html.replace(/\n/g, '<br>');
+          contentEl.innerHTML = html;
+        });
+
+        evtSource.addEventListener('error', (e) => {
+          try {
+            const data = JSON.parse(e.data);
+            document.getElementById('ai-error').style.display = 'block';
+            document.getElementById('ai-error').textContent = data.error;
+          } catch {}
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Get Recommendations';
+        });
+
+        evtSource.onerror = () => {
+          evtSource.close();
+          btn.disabled = false;
+          btn.textContent = 'Get Recommendations';
+        };
+
+        return false;
+      }
+
+      function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.appendChild(document.createTextNode(text));
+        return div.innerHTML;
+      }
+    </script>
+  </body>
+</html>

--- a/apps/aritzia-scanner/src/views/favorites.ejs
+++ b/apps/aritzia-scanner/src/views/favorites.ejs
@@ -11,18 +11,24 @@
 
     <h1>&#x2764; My Favorites</h1>
 
-    <div id="favorites-empty" class="favorites-empty" style="display: none;">
+    <div id="favorites-empty" class="favorites-empty" style="display: none">
       <p>You haven't saved any favorites yet.</p>
-      <p>Click the <span class="heart-icon-demo">&#x2661;</span> on any product to save it here!</p>
+      <p>
+        Click the <span class="heart-icon-demo">&#x2661;</span> on any product
+        to save it here!
+      </p>
       <a href="/" class="view-all-button">Browse Products</a>
     </div>
 
     <div id="favorites-loading" class="skeleton-container">
-      <div class="skeleton-shimmer" style="height: 200px; border-radius: 8px;"></div>
-      <p style="text-align: center; color: #999;">Loading your favorites...</p>
+      <div
+        class="skeleton-shimmer"
+        style="height: 200px; border-radius: 8px"
+      ></div>
+      <p style="text-align: center; color: #999">Loading your favorites...</p>
     </div>
 
-    <div id="favorites-grid" class="product-grid" style="display: none;"></div>
+    <div id="favorites-grid" class="product-grid" style="display: none"></div>
 
     <script>
       const FAVORITES_KEY = 'aritzia_favorites';
@@ -30,11 +36,13 @@
       function getFavorites() {
         try {
           return JSON.parse(localStorage.getItem(FAVORITES_KEY) || '[]');
-        } catch { return []; }
+        } catch {
+          return [];
+        }
       }
 
       function removeFavorite(variantId) {
-        const favs = getFavorites().filter(id => id !== String(variantId));
+        const favs = getFavorites().filter((id) => id !== String(variantId));
         localStorage.setItem(FAVORITES_KEY, JSON.stringify(favs));
         loadFavorites();
       }
@@ -66,34 +74,68 @@
             return;
           }
 
-          grid.innerHTML = variants.map(v => {
-            const link = '/product/' + v.product_id + '/variant/' + v.color_id;
-            const name = v.display_name || v.name;
-            const hasDiscount = v.price && v.list_price && v.price < v.list_price;
-            const discountPct = hasDiscount ? Math.round((1 - v.price / v.list_price) * 100) : 0;
-            return '<div class="product-card">' +
-              (hasDiscount ? '<span class="discount-overlay">' + discountPct + '% OFF</span>' : '') +
-              '<button class="favorite-btn favorited" onclick="removeFavorite(\'' + v.id + '\')" title="Remove from favorites">&#x2665;</button>' +
-              '<a href="' + link + '" class="product-image">' +
-              (v.thumbnail_id 
-                ? '<img src="/api/images/' + v.thumbnail_id + '" alt="' + name + '" loading="lazy" />'
-                : '<span class="no-image-placeholder">No Image</span>') +
-              '</a>' +
-              '<div class="product-info">' +
-              '<a href="' + link + '" class="product-name">' + name + '</a>' +
-              '<div class="product-price-container">' +
-              (hasDiscount 
-                ? '<span class="price-sale">$' + v.price + '</span><span class="price-list">$' + v.list_price + '</span>'
-                : (v.price ? '<span>$' + v.price + '</span>' : '')) +
-              '</div>' +
-              '<div class="variant-details">' + (v.color || '') + (v.length ? ' (' + v.length + ')' : '') + '</div>' +
-              '</div></div>';
-          }).join('');
+          grid.innerHTML = variants
+            .map((v) => {
+              const link =
+                '/product/' + v.product_id + '/variant/' + v.color_id;
+              const name = v.display_name || v.name;
+              const hasDiscount =
+                v.price && v.list_price && v.price < v.list_price;
+              const discountPct = hasDiscount
+                ? Math.round((1 - v.price / v.list_price) * 100)
+                : 0;
+              return (
+                '<div class="product-card">' +
+                (hasDiscount
+                  ? '<span class="discount-overlay">' +
+                    discountPct +
+                    '% OFF</span>'
+                  : '') +
+                '<button class="favorite-btn favorited" onclick="removeFavorite(\'' +
+                v.id +
+                '\')" title="Remove from favorites">&#x2665;</button>' +
+                '<a href="' +
+                link +
+                '" class="product-image">' +
+                (v.thumbnail_id
+                  ? '<img src="/api/images/' +
+                    v.thumbnail_id +
+                    '" alt="' +
+                    name +
+                    '" loading="lazy" />'
+                  : '<span class="no-image-placeholder">No Image</span>') +
+                '</a>' +
+                '<div class="product-info">' +
+                '<a href="' +
+                link +
+                '" class="product-name">' +
+                name +
+                '</a>' +
+                '<div class="product-price-container">' +
+                (hasDiscount
+                  ? '<span class="price-sale">$' +
+                    v.price +
+                    '</span><span class="price-list">$' +
+                    v.list_price +
+                    '</span>'
+                  : v.price
+                  ? '<span>$' + v.price + '</span>'
+                  : '') +
+                '</div>' +
+                '<div class="variant-details">' +
+                (v.color || '') +
+                (v.length ? ' (' + v.length + ')' : '') +
+                '</div>' +
+                '</div></div>'
+              );
+            })
+            .join('');
 
           loading.style.display = 'none';
           grid.style.display = 'grid';
         } catch (err) {
-          loading.innerHTML = '<p style="color: red;">Failed to load favorites.</p>';
+          loading.innerHTML =
+            '<p style="color: red;">Failed to load favorites.</p>';
         }
       }
 

--- a/apps/aritzia-scanner/src/views/favorites.ejs
+++ b/apps/aritzia-scanner/src/views/favorites.ejs
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Favorites - Aritzia Scanner</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <%- include('partials/nav') %>
+
+    <h1>&#x2764; My Favorites</h1>
+
+    <div id="favorites-empty" class="favorites-empty" style="display: none;">
+      <p>You haven't saved any favorites yet.</p>
+      <p>Click the <span class="heart-icon-demo">&#x2661;</span> on any product to save it here!</p>
+      <a href="/" class="view-all-button">Browse Products</a>
+    </div>
+
+    <div id="favorites-loading" class="skeleton-container">
+      <div class="skeleton-shimmer" style="height: 200px; border-radius: 8px;"></div>
+      <p style="text-align: center; color: #999;">Loading your favorites...</p>
+    </div>
+
+    <div id="favorites-grid" class="product-grid" style="display: none;"></div>
+
+    <script>
+      const FAVORITES_KEY = 'aritzia_favorites';
+
+      function getFavorites() {
+        try {
+          return JSON.parse(localStorage.getItem(FAVORITES_KEY) || '[]');
+        } catch { return []; }
+      }
+
+      function removeFavorite(variantId) {
+        const favs = getFavorites().filter(id => id !== String(variantId));
+        localStorage.setItem(FAVORITES_KEY, JSON.stringify(favs));
+        loadFavorites();
+      }
+
+      async function loadFavorites() {
+        const favs = getFavorites();
+        const loading = document.getElementById('favorites-loading');
+        const empty = document.getElementById('favorites-empty');
+        const grid = document.getElementById('favorites-grid');
+
+        if (favs.length === 0) {
+          loading.style.display = 'none';
+          grid.style.display = 'none';
+          empty.style.display = 'block';
+          return;
+        }
+
+        loading.style.display = 'block';
+        empty.style.display = 'none';
+        grid.style.display = 'none';
+
+        try {
+          const resp = await fetch('/api/variants?ids=' + favs.join(','));
+          const variants = await resp.json();
+
+          if (variants.length === 0) {
+            loading.style.display = 'none';
+            empty.style.display = 'block';
+            return;
+          }
+
+          grid.innerHTML = variants.map(v => {
+            const link = '/product/' + v.product_id + '/variant/' + v.color_id;
+            const name = v.display_name || v.name;
+            const hasDiscount = v.price && v.list_price && v.price < v.list_price;
+            const discountPct = hasDiscount ? Math.round((1 - v.price / v.list_price) * 100) : 0;
+            return '<div class="product-card">' +
+              (hasDiscount ? '<span class="discount-overlay">' + discountPct + '% OFF</span>' : '') +
+              '<button class="favorite-btn favorited" onclick="removeFavorite(\'' + v.id + '\')" title="Remove from favorites">&#x2665;</button>' +
+              '<a href="' + link + '" class="product-image">' +
+              (v.thumbnail_id 
+                ? '<img src="/api/images/' + v.thumbnail_id + '" alt="' + name + '" loading="lazy" />'
+                : '<span class="no-image-placeholder">No Image</span>') +
+              '</a>' +
+              '<div class="product-info">' +
+              '<a href="' + link + '" class="product-name">' + name + '</a>' +
+              '<div class="product-price-container">' +
+              (hasDiscount 
+                ? '<span class="price-sale">$' + v.price + '</span><span class="price-list">$' + v.list_price + '</span>'
+                : (v.price ? '<span>$' + v.price + '</span>' : '')) +
+              '</div>' +
+              '<div class="variant-details">' + (v.color || '') + (v.length ? ' (' + v.length + ')' : '') + '</div>' +
+              '</div></div>';
+          }).join('');
+
+          loading.style.display = 'none';
+          grid.style.display = 'grid';
+        } catch (err) {
+          loading.innerHTML = '<p style="color: red;">Failed to load favorites.</p>';
+        }
+      }
+
+      loadFavorites();
+    </script>
+  </body>
+</html>

--- a/apps/aritzia-scanner/src/views/index.ejs
+++ b/apps/aritzia-scanner/src/views/index.ejs
@@ -70,7 +70,7 @@
     </form>
 
     <% if (activeProducts && activeProducts.length > 0) { %>
-    <h2>Active Products (<%= activeProducts.length %>)</h2>
+    <h2>Active Products (<%= totalCount || activeProducts.length %>)</h2>
     <div class="product-grid">
       <% activeProducts.forEach(product => { %>
       <% 
@@ -87,6 +87,9 @@
       <div class="product-card">
         <% if (product.price && product.list_price && product.price < product.list_price) { %>
         <span class="discount-overlay"><%= Math.round((1 - product.price / product.list_price) * 100) %>% OFF</span>
+        <% } %>
+        <% if (product.isVariant) { %>
+        <button class="favorite-btn" data-id="<%= product.id %>" onclick="toggleFavorite(this)" title="Add to favorites">&#x2661;</button>
         <% } %>
         <a href="<%= link %>" class="product-image">
           <% if (product.thumbnail_id) { %>
@@ -185,5 +188,106 @@
       <a href="/products" class="view-all-button">View All Products</a>
     </div>
     <% } %>
+
+    <% if (locals.totalPages && totalPages > 1) { %>
+    <nav class="pagination" aria-label="Pagination">
+      <%
+        // Build base URL preserving all current filters
+        const baseUrl = title === 'All Products' ? '/products' : '/';
+        const qp = new URLSearchParams();
+        if (searchQuery) qp.set('q', searchQuery);
+        if (currentBrand) qp.set('brand', currentBrand);
+        if (currentFit) qp.set('fit', currentFit);
+        if (currentCategory) qp.set('category', currentCategory);
+        if (locals.currentSize && currentSize) qp.set('size', currentSize);
+        if (currentSort && currentSort !== 'newest' && currentSort !== 'name') qp.set('sort', currentSort);
+        if (locals.minPrice && minPrice) qp.set('minPrice', String(minPrice));
+        if (locals.maxPrice && maxPrice) qp.set('maxPrice', String(maxPrice));
+        
+        function pageUrl(p) {
+          const params = new URLSearchParams(qp);
+          if (p > 1) params.set('page', String(p));
+          const qs = params.toString();
+          return baseUrl + (qs ? '?' + qs : '');
+        }
+        
+        // Calculate page range to show
+        const maxVisible = 7;
+        let startPage = Math.max(1, page - Math.floor(maxVisible / 2));
+        let endPage = Math.min(totalPages, startPage + maxVisible - 1);
+        if (endPage - startPage < maxVisible - 1) {
+          startPage = Math.max(1, endPage - maxVisible + 1);
+        }
+      %>
+      
+      <% if (page > 1) { %>
+      <a href="<%= pageUrl(page - 1) %>" class="page-link" aria-label="Previous">&laquo; Prev</a>
+      <% } else { %>
+      <span class="page-link disabled">&laquo; Prev</span>
+      <% } %>
+
+      <% if (startPage > 1) { %>
+      <a href="<%= pageUrl(1) %>" class="page-link">1</a>
+      <% if (startPage > 2) { %><span class="page-ellipsis">&hellip;</span><% } %>
+      <% } %>
+
+      <% for (let i = startPage; i <= endPage; i++) { %>
+      <% if (i === page) { %>
+      <span class="page-link active"><%= i %></span>
+      <% } else { %>
+      <a href="<%= pageUrl(i) %>" class="page-link"><%= i %></a>
+      <% } %>
+      <% } %>
+
+      <% if (endPage < totalPages) { %>
+      <% if (endPage < totalPages - 1) { %><span class="page-ellipsis">&hellip;</span><% } %>
+      <a href="<%= pageUrl(totalPages) %>" class="page-link"><%= totalPages %></a>
+      <% } %>
+
+      <% if (page < totalPages) { %>
+      <a href="<%= pageUrl(page + 1) %>" class="page-link" aria-label="Next">Next &raquo;</a>
+      <% } else { %>
+      <span class="page-link disabled">Next &raquo;</span>
+      <% } %>
+    </nav>
+    <% } %>
+
+    <script>
+      const FAVORITES_KEY = 'aritzia_favorites';
+      function getFavorites() {
+        try { return JSON.parse(localStorage.getItem(FAVORITES_KEY) || '[]'); }
+        catch { return []; }
+      }
+      function toggleFavorite(btn) {
+        const id = btn.dataset.id;
+        let favs = getFavorites();
+        if (favs.includes(id)) {
+          favs = favs.filter(f => f !== id);
+          btn.innerHTML = '\u2661';
+          btn.classList.remove('favorited');
+        } else {
+          favs.push(id);
+          btn.innerHTML = '\u2665';
+          btn.classList.add('favorited');
+        }
+        localStorage.setItem(FAVORITES_KEY, JSON.stringify(favs));
+        updateFavCount();
+      }
+      function updateFavCount() {
+        const badge = document.getElementById('fav-count');
+        if (badge) badge.textContent = getFavorites().length || '';
+      }
+      // Initialize favorite states on page load
+      document.addEventListener('DOMContentLoaded', function() {
+        const favs = getFavorites();
+        document.querySelectorAll('.favorite-btn[data-id]').forEach(btn => {
+          if (favs.includes(btn.dataset.id)) {
+            btn.innerHTML = '\u2665';
+            btn.classList.add('favorited');
+          }
+        });
+        updateFavCount();
+      });
+    </script>
   </body>
 </html>

--- a/apps/aritzia-scanner/src/views/index.ejs
+++ b/apps/aritzia-scanner/src/views/index.ejs
@@ -85,6 +85,9 @@
           : `https://www.aritzia.com/en/product/${product.slug}`;
       %>
       <div class="product-card">
+        <% if (product.price && product.list_price && product.price < product.list_price) { %>
+        <span class="discount-overlay"><%= Math.round((1 - product.price / product.list_price) * 100) %>% OFF</span>
+        <% } %>
         <a href="<%= link %>" class="product-image">
           <% if (product.thumbnail_id) { %>
           <img

--- a/apps/aritzia-scanner/src/views/partials/nav.ejs
+++ b/apps/aritzia-scanner/src/views/partials/nav.ejs
@@ -8,7 +8,9 @@
     <a href="/colors">Colors</a>
     <a href="/stores">Stores</a>
     <a href="/discontinued">Discontinued</a>
-    <a href="/favorites" class="nav-fav-link">&#x2665; Favorites <span id="fav-count" class="fav-badge"></span></a>
+    <a href="/favorites" class="nav-fav-link"
+      >&#x2665; Favorites <span id="fav-count" class="fav-badge"></span
+    ></a>
     <span class="nav-divider">|</span>
     <a href="/ai/search" class="nav-ai-link">🤖 AI Search</a>
     <a href="/ai/style" class="nav-ai-link">👗 Style Advisor</a>

--- a/apps/aritzia-scanner/src/views/partials/nav.ejs
+++ b/apps/aritzia-scanner/src/views/partials/nav.ejs
@@ -21,3 +21,24 @@
   </div>
   <% } %>
 </nav>
+<button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode" id="theme-toggle">🌙</button>
+<script>
+  (function() {
+    const saved = localStorage.getItem('theme');
+    if (saved === 'light') {
+      document.documentElement.style.colorScheme = 'light';
+      document.getElementById('theme-toggle').textContent = '☀️';
+    } else if (saved === 'dark') {
+      document.documentElement.style.colorScheme = 'dark';
+      document.getElementById('theme-toggle').textContent = '🌙';
+    }
+  })();
+  function toggleTheme() {
+    const html = document.documentElement;
+    const current = html.style.colorScheme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    const next = current === 'dark' ? 'light' : 'dark';
+    html.style.colorScheme = next;
+    localStorage.setItem('theme', next);
+    document.getElementById('theme-toggle').textContent = next === 'dark' ? '🌙' : '☀️';
+  }
+</script>

--- a/apps/aritzia-scanner/src/views/partials/nav.ejs
+++ b/apps/aritzia-scanner/src/views/partials/nav.ejs
@@ -1,10 +1,23 @@
 <nav class="nav">
-  <a href="/">Newest</a>
-  <a href="/products">All Products</a>
-  <a href="/sale" class="nav-sale-link">Sale</a>
-  <a href="/categories">Categories</a>
-  <a href="/restocks">Restocks</a>
-  <a href="/colors">Colors</a>
-  <a href="/stores">Stores</a>
-  <a href="/discontinued">Discontinued</a>
+  <div class="nav-links">
+    <a href="/">Newest</a>
+    <a href="/products">All Products</a>
+    <a href="/sale" class="nav-sale-link">Sale</a>
+    <a href="/categories">Categories</a>
+    <a href="/restocks">Restocks</a>
+    <a href="/colors">Colors</a>
+    <a href="/stores">Stores</a>
+    <a href="/discontinued">Discontinued</a>
+    <span class="nav-divider">|</span>
+    <a href="/ai/search" class="nav-ai-link">🤖 AI Search</a>
+    <a href="/ai/style" class="nav-ai-link">👗 Style Advisor</a>
+    <a href="/ai/deals" class="nav-ai-link">💰 Deals Report</a>
+  </div>
+  <% if (typeof stats !== 'undefined' && stats) { %>
+  <div class="nav-stats">
+    <span class="nav-stat"><%= stats.productCount %> products</span>
+    <span class="nav-stat"><%= stats.variantCount %> variants</span>
+    <span class="nav-stat">Scanned <%= stats.lastScanFormatted %></span>
+  </div>
+  <% } %>
 </nav>

--- a/apps/aritzia-scanner/src/views/partials/nav.ejs
+++ b/apps/aritzia-scanner/src/views/partials/nav.ejs
@@ -8,6 +8,7 @@
     <a href="/colors">Colors</a>
     <a href="/stores">Stores</a>
     <a href="/discontinued">Discontinued</a>
+    <a href="/favorites" class="nav-fav-link">&#x2665; Favorites <span id="fav-count" class="fav-badge"></span></a>
     <span class="nav-divider">|</span>
     <a href="/ai/search" class="nav-ai-link">🤖 AI Search</a>
     <a href="/ai/style" class="nav-ai-link">👗 Style Advisor</a>
@@ -21,9 +22,16 @@
   </div>
   <% } %>
 </nav>
-<button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode" id="theme-toggle">🌙</button>
+<button
+  class="theme-toggle"
+  onclick="toggleTheme()"
+  title="Toggle dark/light mode"
+  id="theme-toggle"
+>
+  🌙
+</button>
 <script>
-  (function() {
+  (function () {
     const saved = localStorage.getItem('theme');
     if (saved === 'light') {
       document.documentElement.style.colorScheme = 'light';
@@ -35,10 +43,15 @@
   })();
   function toggleTheme() {
     const html = document.documentElement;
-    const current = html.style.colorScheme || (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+    const current =
+      html.style.colorScheme ||
+      (window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light');
     const next = current === 'dark' ? 'light' : 'dark';
     html.style.colorScheme = next;
     localStorage.setItem('theme', next);
-    document.getElementById('theme-toggle').textContent = next === 'dark' ? '🌙' : '☀️';
+    document.getElementById('theme-toggle').textContent =
+      next === 'dark' ? '🌙' : '☀️';
   }
 </script>

--- a/apps/aritzia-scanner/src/views/product.ejs
+++ b/apps/aritzia-scanner/src/views/product.ejs
@@ -8,7 +8,7 @@
   </head>
   <body>
     <%- include('partials/nav') %>
-    
+
     <div class="product-header">
       <h1><%= product.display_name || product.name %></h1>
     </div>
@@ -17,73 +17,145 @@
       <div class="product-details-box">
         <% if (product.description) { %>
         <p class="product-description"><%= product.description %></p>
-        <% } %>
-        
-        <% if (product.designers_notes) { %>
-        <p class="designers-notes"><%- product.designers_notes.replace(/&mdash;/g, '—').replace(/&rsquo;/g, "'").replace(/&nbsp;/g, ' ') %></p>
-        <% } %>
-        
-        <%
-          const naturalFibers = ['Cotton', 'Wool', 'Silk', 'Linen', 'Cashmere', 'Merino', 'Alpaca'];
-          const isNatural = product.fabric && product.fabric.some(f => naturalFibers.some(nf => f.includes(nf)));
-          const warmthLevels = ['Warmest', 'Warmer', 'Warm'];
-          const warmth = product.warmth && product.warmth.find(w => warmthLevels.some(wl => w.includes(wl)));
-          const hasAttributes = (product.fabric && product.fabric.length > 0) || 
-                                (product.neckline && product.neckline.length > 0) || 
-                                (product.sleeve && product.sleeve.length > 0) || 
-                                (product.style && product.style.length > 0);
-          const hasBadges = product.brand || (product.category && product.category.length > 0) || 
-                           isNatural || (product.sustainability && product.sustainability.length > 0) || warmth;
-        %>
-        
-        <% if (hasAttributes || hasBadges) { %>
+        <% } %> <% if (product.designers_notes) { %>
+        <p class="designers-notes">
+          <%- product.designers_notes.replace(/&mdash;/g,
+          '—').replace(/&rsquo;/g, "'").replace(/&nbsp;/g, ' ') %>
+        </p>
+        <% } %> <% const naturalFibers = ['Cotton', 'Wool', 'Silk', 'Linen',
+        'Cashmere', 'Merino', 'Alpaca']; const isNatural = product.fabric &&
+        product.fabric.some(f => naturalFibers.some(nf => f.includes(nf)));
+        const warmthLevels = ['Warmest', 'Warmer', 'Warm']; const warmth =
+        product.warmth && product.warmth.find(w => warmthLevels.some(wl =>
+        w.includes(wl))); const hasAttributes = (product.fabric &&
+        product.fabric.length > 0) || (product.neckline &&
+        product.neckline.length > 0) || (product.sleeve && product.sleeve.length
+        > 0) || (product.style && product.style.length > 0); const hasBadges =
+        product.brand || (product.category && product.category.length > 0) ||
+        isNatural || (product.sustainability && product.sustainability.length >
+        0) || warmth; %> <% if (hasAttributes || hasBadges) { %>
         <div class="product-attributes">
           <% if (product.brand) { %>
-          <span class="attribute"><strong>Brand:</strong> <%= product.brand %></span>
-          <% } %>
-          <% if (product.category && product.category.length > 0) { %>
-          <span class="attribute"><strong>Category:</strong> <%- product.category.map(cat => `<a href="/categories/${encodeURIComponent(cat)}">${cat}</a>`).join(', ') %></span>
-          <% } %>
-          <% if (product.fabric && product.fabric.length > 0) { %>
-          <span class="attribute"><strong>Fabric:</strong> <%= product.fabric.join(', ') %></span>
-          <% } %>
-          <% if (product.neckline && product.neckline.length > 0) { %>
-          <span class="attribute"><strong>Neckline:</strong> <%= product.neckline.join(', ') %></span>
-          <% } %>
-          <% if (product.sleeve && product.sleeve.length > 0) { %>
-          <span class="attribute"><strong>Sleeve:</strong> <%= product.sleeve.join(', ') %></span>
-          <% } %>
-          <% if (product.style && product.style.length > 0) { %>
-          <span class="attribute"><strong>Style:</strong> <%= product.style.join(', ') %></span>
-          <% } %>
-          <% if (warmth) { %>
+          <span class="attribute"
+            ><strong>Brand:</strong> <%= product.brand %></span
+          >
+          <% } %> <% if (product.category && product.category.length > 0) { %>
+          <span class="attribute"
+            ><strong>Category:</strong> <%- product.category.map(cat => `<a
+              href="/categories/${encodeURIComponent(cat)}"
+              >${cat}</a
+            >`).join(', ') %></span
+          >
+          <% } %> <% if (product.fabric && product.fabric.length > 0) { %>
+          <span class="attribute"
+            ><strong>Fabric:</strong> <%= product.fabric.join(', ') %></span
+          >
+          <% } %> <% if (product.neckline && product.neckline.length > 0) { %>
+          <span class="attribute"
+            ><strong>Neckline:</strong> <%= product.neckline.join(', ') %></span
+          >
+          <% } %> <% if (product.sleeve && product.sleeve.length > 0) { %>
+          <span class="attribute"
+            ><strong>Sleeve:</strong> <%= product.sleeve.join(', ') %></span
+          >
+          <% } %> <% if (product.style && product.style.length > 0) { %>
+          <span class="attribute"
+            ><strong>Style:</strong> <%= product.style.join(', ') %></span
+          >
+          <% } %> <% if (warmth) { %>
           <span class="attribute"><strong>Warmth:</strong> <%= warmth %></span>
-          <% } %>
-          <% if (isNatural) { %>
+          <% } %> <% if (isNatural) { %>
           <span class="attribute badge-natural">Natural Fiber</span>
-          <% } %>
-          <% if (product.sustainability && product.sustainability.length > 0) { %>
+          <% } %> <% if (product.sustainability && product.sustainability.length
+          > 0) { %>
           <span class="attribute badge-sustainable">Sustainable</span>
           <% } %>
         </div>
-        <% } %>
-        
-        <% if (product.rating) { %>
+        <% } %> <% if (product.rating) { %>
         <div class="product-rating-row">
-          <span class="stars"><%= '★'.repeat(Math.round(product.rating)) %><%= '☆'.repeat(5 - Math.round(product.rating)) %></span>
+          <span class="stars"
+            ><%= '★'.repeat(Math.round(product.rating)) %><%= '☆'.repeat(5 -
+            Math.round(product.rating)) %></span
+          >
           <span class="rating-value"><%= product.rating.toFixed(1) %></span>
           <% if (product.review_count) { %>
-          <span class="review-count">(<%= product.review_count.toLocaleString() %> reviews)</span>
+          <span class="review-count"
+            >(<%= product.review_count.toLocaleString() %> reviews)</span
+          >
           <% } %>
         </div>
         <% } %>
-        
+
         <div class="product-meta-row">
-          <span class="meta-item">Added: <%= product.added_at_formatted %></span>
-          <span class="meta-item">Last seen: <%= product.last_seen_at_formatted %></span>
-          <a href="https://www.aritzia.com/en/product/<%= product.slug %>" target="_blank" class="meta-link">View on Aritzia</a>
+          <span class="meta-item"
+            >Added: <%= product.added_at_formatted %></span
+          >
+          <span class="meta-item"
+            >Last seen: <%= product.last_seen_at_formatted %></span
+          >
+          <a
+            href="https://www.aritzia.com/en/product/<%= product.slug %>"
+            target="_blank"
+            class="meta-link"
+            >View on Aritzia</a
+          >
         </div>
       </div>
+    </div>
+
+    <!-- AI Features -->
+    <div class="ai-product-actions">
+      <button
+        class="ai-action-btn"
+        onclick="loadAISummary('<%= product.id %>')"
+      >
+        🤖 AI Summary
+      </button>
+      <button
+        class="ai-action-btn"
+        onclick="loadOutfitBuilder('<%= product.id %>')"
+      >
+        👗 What Goes With This?
+      </button>
+    </div>
+
+    <div
+      id="ai-summary-container"
+      class="ai-stream-container"
+      style="display: none"
+    >
+      <div class="ai-thinking-header">
+        <span class="ai-thinking-icon">🤖</span>
+        <span id="summary-status">Analyzing product...</span>
+      </div>
+      <div
+        id="ai-summary-reasoning"
+        class="ai-reasoning"
+        style="display: none"
+      ></div>
+      <div id="ai-summary-content" class="ai-content"></div>
+    </div>
+
+    <div
+      id="ai-outfit-container"
+      class="ai-stream-container"
+      style="display: none"
+    >
+      <div class="ai-thinking-header">
+        <span class="ai-thinking-icon">👗</span>
+        <span id="outfit-status">Finding complementary pieces...</span>
+      </div>
+      <div
+        id="ai-outfit-reasoning"
+        class="ai-reasoning"
+        style="display: none"
+      ></div>
+      <div id="ai-outfit-content" class="ai-content"></div>
+      <div
+        id="ai-outfit-picks"
+        class="product-grid"
+        style="margin-top: 15px"
+      ></div>
     </div>
 
     <% if (product.allLengths && product.allLengths.length > 1) { %>
@@ -99,14 +171,16 @@
 
     <h2>Variants (<%= product.variants.length %> colors)</h2>
 
-    <% const activeVariants = product.variants.filter(v => v.isActive); 
-       const discontinuedVariants = product.variants.filter(v => !v.isActive); %>
-    
-    <% if (activeVariants.length > 0) { %>
+    <% const activeVariants = product.variants.filter(v => v.isActive); const
+    discontinuedVariants = product.variants.filter(v => !v.isActive); %> <% if
+    (activeVariants.length > 0) { %>
     <h3>Active Variants (<%= activeVariants.length %>)</h3>
     <div class="variant-wrapper">
       <% activeVariants.forEach(variant => { %>
-      <div class="variant" data-lengths="<%= JSON.stringify(variant.lengths) %>">
+      <div
+        class="variant"
+        data-lengths="<%= JSON.stringify(variant.lengths) %>"
+      >
         <% if (variant.thumbnail) { %>
         <a href="/product/<%= product.id %>/variant/<%= variant.color_id %>">
           <img
@@ -116,10 +190,14 @@
           />
         </a>
         <% } %>
-        
+
         <div class="variant-info">
           <h3 class="variant-title">
-            <a href="/product/<%= product.id %>/variant/<%= variant.color_id %>" class="variant-link"><%= variant.color %></a>
+            <a
+              href="/product/<%= product.id %>/variant/<%= variant.color_id %>"
+              class="variant-link"
+              ><%= variant.color %></a
+            >
           </h3>
 
           <% if (variant.price) { %>
@@ -131,30 +209,32 @@
             <span>$<%= variant.price %></span>
             <% } %>
           </div>
-          <% } %>
-          
-          <% if (variant.available_sizes && variant.available_sizes.length > 0) { %>
+          <% } %> <% if (variant.available_sizes &&
+          variant.available_sizes.length > 0) { %>
           <div class="sizes-mini">
             <% variant.all_sizes.forEach(size => { %>
-            <span class="size-tag-mini <%= variant.available_sizes.includes(size) ? 'available' : 'unavailable' %>"><%= size %></span>
+            <span
+              class="size-tag-mini <%= variant.available_sizes.includes(size) ? 'available' : 'unavailable' %>"
+              ><%= size %></span
+            >
             <% }); %>
           </div>
-          <% } %>
-          
-          <% if (product.allLengths && product.allLengths.length > 1) { %>
+          <% } %> <% if (product.allLengths && product.allLengths.length > 1) {
+          %>
           <p class="variant-lengths"><%= variant.lengths.join(', ') %></p>
           <% } %>
         </div>
       </div>
       <% }); %>
     </div>
-    <% } %>
-    
-    <% if (discontinuedVariants.length > 0) { %>
+    <% } %> <% if (discontinuedVariants.length > 0) { %>
     <h3>Discontinued Variants (<%= discontinuedVariants.length %>)</h3>
     <div class="variant-wrapper">
       <% discontinuedVariants.forEach(variant => { %>
-      <div class="variant discontinued" data-lengths="<%= JSON.stringify(variant.lengths) %>">
+      <div
+        class="variant discontinued"
+        data-lengths="<%= JSON.stringify(variant.lengths) %>"
+      >
         <% if (variant.thumbnail) { %>
         <a href="/product/<%= product.id %>/variant/<%= variant.color_id %>">
           <img
@@ -164,10 +244,14 @@
           />
         </a>
         <% } %>
-        
+
         <div class="variant-info">
           <h3 class="variant-title">
-            <a href="/product/<%= product.id %>/variant/<%= variant.color_id %>" class="variant-link"><%= variant.color %></a>
+            <a
+              href="/product/<%= product.id %>/variant/<%= variant.color_id %>"
+              class="variant-link"
+              ><%= variant.color %></a
+            >
           </h3>
 
           <% if (variant.price) { %>
@@ -179,19 +263,18 @@
             <span>$<%= variant.price %></span>
             <% } %>
           </div>
-          <% } %>
-          
-          <% if (product.allLengths && product.allLengths.length > 1) { %>
+          <% } %> <% if (product.allLengths && product.allLengths.length > 1) {
+          %>
           <p class="variant-lengths"><%= variant.lengths.join(', ') %></p>
           <% } %>
-          
+
           <p class="discontinued-label">Discontinued</p>
         </div>
       </div>
       <% }); %>
     </div>
     <% } %>
-    
+
     <script>
       const lengthSelect = document.getElementById('length-select');
       if (lengthSelect) {
@@ -207,6 +290,147 @@
             }
           });
         });
+      }
+
+      function escapeHtml(text) {
+        if (!text) return '';
+        const div = document.createElement('div');
+        div.appendChild(document.createTextNode(text));
+        return div.innerHTML;
+      }
+
+      function loadAISummary(productId) {
+        const container = document.getElementById('ai-summary-container');
+        const content = document.getElementById('ai-summary-content');
+        const reasoning = document.getElementById('ai-summary-reasoning');
+
+        container.style.display = 'block';
+        content.innerHTML = '';
+        reasoning.innerHTML = '';
+        reasoning.style.display = 'none';
+        document.getElementById('summary-status').textContent =
+          'Analyzing product...';
+
+        const evtSource = new EventSource(`/api/ai/summary/${productId}`);
+
+        evtSource.addEventListener('content', (e) => {
+          const data = JSON.parse(e.data);
+          if (data.cached) {
+            content.innerHTML = data.content.replace(/\n/g, '<br>');
+            document.getElementById('summary-status').textContent =
+              'AI Summary (cached)';
+            return;
+          }
+          if (data.thinking) {
+            reasoning.style.display = 'block';
+            reasoning.innerHTML += escapeHtml(data.content);
+            reasoning.scrollTop = reasoning.scrollHeight;
+          } else {
+            content.innerHTML += escapeHtml(data.content);
+          }
+        });
+
+        evtSource.addEventListener('done', () => {
+          evtSource.close();
+          document.getElementById('summary-status').textContent = 'AI Summary';
+          let html = content.innerHTML;
+          html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+          html = html.replace(/\n/g, '<br>');
+          content.innerHTML = html;
+        });
+
+        evtSource.addEventListener('error', (e) => {
+          try {
+            content.textContent = JSON.parse(e.data).error;
+          } catch {}
+          evtSource.close();
+        });
+        evtSource.onerror = () => evtSource.close();
+      }
+
+      function loadOutfitBuilder(productId) {
+        const container = document.getElementById('ai-outfit-container');
+        const content = document.getElementById('ai-outfit-content');
+        const reasoning = document.getElementById('ai-outfit-reasoning');
+        const picks = document.getElementById('ai-outfit-picks');
+
+        container.style.display = 'block';
+        content.innerHTML = '';
+        reasoning.innerHTML = '';
+        reasoning.style.display = 'none';
+        picks.innerHTML = '';
+        document.getElementById('outfit-status').textContent =
+          'Finding complementary pieces...';
+
+        const evtSource = new EventSource(`/api/ai/outfit/${productId}`);
+
+        evtSource.addEventListener('status', (e) => {
+          document.getElementById('outfit-status').textContent = JSON.parse(
+            e.data
+          ).message;
+        });
+
+        evtSource.addEventListener('content', (e) => {
+          const data = JSON.parse(e.data);
+          if (data.thinking) {
+            reasoning.style.display = 'block';
+            reasoning.innerHTML += escapeHtml(data.content);
+          } else {
+            content.innerHTML += escapeHtml(data.content);
+          }
+        });
+
+        evtSource.addEventListener('picks', (e) => {
+          const data = JSON.parse(e.data);
+          if (data.products?.length) {
+            picks.innerHTML = data.products
+              .map(
+                (p) => `
+              <div class="product-card">
+                <div class="product-info">
+                  <a href="/product/${p.id}" class="product-name">${escapeHtml(
+                  p.name
+                )}</a>
+                  <div class="product-price-container">
+                    ${
+                      p.price < p.list_price
+                        ? `<span class="price-sale">$${p.price}</span> <span class="price-list">$${p.list_price}</span>`
+                        : `<span>$${p.price}</span>`
+                    }
+                  </div>
+                  ${
+                    p.rating
+                      ? `<div class="product-meta">${'★'.repeat(
+                          Math.round(p.rating)
+                        )} ${p.rating.toFixed(1)}</div>`
+                      : ''
+                  }
+                </div>
+              </div>
+            `
+              )
+              .join('');
+          }
+        });
+
+        evtSource.addEventListener('done', () => {
+          evtSource.close();
+          document.getElementById('outfit-status').textContent =
+            'Outfit suggestions ready';
+          let html = content.innerHTML;
+          html = html.replace(/&lt;!--PICKS:\[[\d,\s]*\]--&gt;/g, '');
+          html = html.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+          html = html.replace(/\n/g, '<br>');
+          content.innerHTML = html;
+        });
+
+        evtSource.addEventListener('error', (e) => {
+          try {
+            content.textContent = JSON.parse(e.data).error;
+          } catch {}
+          evtSource.close();
+        });
+        evtSource.onerror = () => evtSource.close();
       }
     </script>
   </body>


### PR DESCRIPTION
## Aritzia Scanner Improvements

### Performance
- Add database indexes on all key lookup columns
- Enable WAL mode for better concurrent reads
- Add HTTP caching headers for images (immutable, ETag, 304)
- Fix N+1 queries on product/variant detail pages (batch WHERE IN)
- Price deduplication — only insert when price actually changes

### AI Integration (Ollama streaming)
- OllamaClient with streaming async generator (`chatStream`) targeting `ollama.elliott.haus`
- 5 SSE streaming endpoints: product summary, natural language search, style advisor, outfit builder, deals report
- AI summaries cached 24h in `ai_summaries` table
- Frontend views with live token streaming, reasoning display, and skeleton loading

### Pagination
- Server-side pagination (48 items/page) on homepage and /products
- Pagination controls with ellipsis, prev/next, preserving all active filters

### Wishlist / Favorites
- Client-side localStorage-based favorites with heart toggle on product cards
- Dedicated /favorites page loading saved variants via API
- Nav badge showing favorite count

### Visual
- Sticky nav with backdrop blur, stats bar, AI links
- Dark mode toggle (localStorage-persisted)
- Discount overlay badges on product cards
- Skeleton shimmer loading states for AI content