### PR TITLE
feat(brainctl): add TypeScript/Fastify brainctl service

### DIFF
--- a/apps/brainctl/Dockerfile
+++ b/apps/brainctl/Dockerfile
@@ -1,0 +1,25 @@
+FROM oven/bun:alpine
+
+ENV HOST=0.0.0.0
+ENV PORT=3100
+
+WORKDIR /app
+
+RUN apk add --no-cache python3 make g++ libc6-compat
+
+RUN addgroup --system brainctl && \
+    adduser --system -G brainctl brainctl
+
+COPY dist/apps/brainctl brainctl/
+
+WORKDIR /app/brainctl
+RUN bun install --production
+WORKDIR /app
+
+RUN chown -R brainctl:brainctl .
+
+EXPOSE 3100
+
+USER brainctl
+
+CMD [ "bun", "run", "brainctl" ]

--- a/apps/brainctl/README.md
+++ b/apps/brainctl/README.md
@@ -52,6 +52,293 @@ All state lives in a single SQLite database (via `better-sqlite3`). FTS5 full-te
 
 ---
 
+## Brain Concepts → LLM Concepts
+
+brainctl's data model is a deliberate mapping of cognitive neuroscience onto the constraints of a stateless LLM. Understanding the analogy makes the API much easier to reason about.
+
+### Memory systems
+
+Human memory is not a single store. Cognitive science distinguishes several systems with different properties — and each one maps directly to a brainctl concept.
+
+| Cognitive concept | brainctl implementation | What it means in practice |
+|---|---|---|
+| **Episodic memory** | `memory_type: episodic` | First-person experience records: *"I deployed the service at 14:00 and it failed"*. Tied to a specific moment. Subject to stronger decay. |
+| **Semantic memory** | `memory_type: semantic` | Generalised facts distilled from experience: *"This service requires a warm-up call before traffic"*. Longer-lived. Promoted from episodic during consolidation. |
+| **Procedural memory** | `memory_type: procedural` + `procedures` table | How-to knowledge encoded as reusable steps. Not forgotten easily; updated by feedback scores. |
+| **Working memory** | `workspace` items + the agent's context window | The short-lived scratchpad for in-progress reasoning. Explicitly ephemeral. |
+| **Prospective memory** | `triggers` table | *"Remember to do X when Y happens."* Conditions checked against incoming inputs before reasoning begins. |
+| **Semantic network** | `knowledge_edges` + `entities` | The web of associations between concepts, people, and facts. Traversed via spreading activation. |
+
+### Forgetting and reinforcement
+
+The brain does not keep everything. brainctl models this with two mechanisms:
+
+**Temporal decay.** Every memory carries a `temporal_class` that sets a decay half-life:
+
+| Class | Half-life | Typical use |
+|---|---|---|
+| `ephemeral` | 3.5 days | Transient observations, one-off facts |
+| `short` | 10 days | Session context, project-specific details |
+| `medium` | 23 days | General patterns, recurring decisions |
+| `long` | 69 days | Deep conventions, architectural truths |
+
+The consolidation engine applies `confidence(t) = confidence(0) × e^(−λt)` where `λ = ln2 / half_life`. This directly mirrors the [Ebbinghaus forgetting curve](https://en.wikipedia.org/wiki/Forgetting_curve). Memories recalled frequently are protected from decay (`recalled_count` increments on every `GET /memories/:id`), just as spaced repetition delays forgetting.
+
+**Hebbian reinforcement.** Edges between co-active memories grow stronger over consolidation cycles: *"neurons that fire together, wire together"*. Edges connecting high-confidence nodes (≥ 0.6) are boosted; edges between decayed nodes are pruned. This means the knowledge graph self-organises around what the agent actually uses.
+
+### Consolidation as sleep
+
+Biological sleep does not merely rest the brain — it actively reorganises memory. Slow-wave sleep replays experiences; REM sleep integrates them into semantic structures. brainctl's consolidation engine mirrors this with six sequential passes:
+
+1. **Decay** → the forgetting pass. Low-confidence memories are soft-retired.
+2. **Promote** → the integration pass. Episodic memories replayed often enough become semantic.
+3. **Compress** → the deduplication pass. Near-duplicate memories (vec distance ≤ 0.18 or Jaccard ≥ 0.4) are merged into a single summary — analogous to gist extraction during REM.
+4. **Hebbian** → the reinforcement pass. Active edge paths are strengthened; dormant ones decay.
+5. **Gap scan** → the integrity pass. Orphaned records and broken edges are flagged.
+6. **Entity tiers** → the salience pass. Highly connected entities are promoted to tier 3, making them more likely to surface in PageRank and spreading-activation queries.
+
+This is designed to run overnight (e.g. `BRAIN_CONSOLIDATION_CRON=0 3 * * *`) so the agent starts each day with a leaner, better-organised store.
+
+### Attention and salience
+
+The brain prioritises what to surface through attention. brainctl approximates this with three mechanisms:
+
+- **`importance` score** (0–1): set at write time; influences search ranking.
+- **PageRank** over `knowledge_edges`: records connected to many other important records score higher. Computed on-demand via `GET /graph/pagerank`.
+- **RRF search**: the combined FTS5 + vector search score ensures both keyword relevance (attention to the query) and semantic similarity (conceptual closeness) are weighted.
+
+### Affect
+
+The affect system tracks Valence (pleasant/unpleasant), Arousal (activated/calm), and Dominance (in control/controlled) — the standard [VAD model](https://en.wikipedia.org/wiki/Valence%E2%80%93arousal%E2%80%93dominance_model) used in affective computing. For an LLM agent, affect state acts as a metadata channel: it lets an orchestrator detect when an agent is in a "distressed" or "overloaded" state (low valence + high arousal) and adjust its behaviour — slow down, request human review, or switch to a safer default policy.
+
+### Theory of Mind
+
+ToM is the ability to model what *another* agent believes, desires, or intends. brainctl implements this by: (1) searching the subject agent's memory store, (2) passing that context to an LLM that extracts an estimated belief/intention model, and (3) storing the snapshot so the observer can consult it later. This is useful in multi-agent pipelines where one orchestrator needs to predict the behaviour of a sub-agent before delegating a task.
+
+---
+
+## Integrating with an AI Harness
+
+brainctl is protocol-agnostic. It speaks plain HTTP/JSON, so it can be wired into any agent framework — Claude Code via MCP, LangChain, AutoGen, a bare `fetch` loop, or a custom orchestrator. The core integration model is always the same: **brainctl wraps the agent's context window by enriching inputs before the LLM call and capturing outputs after it.**
+
+### The session lifecycle
+
+A well-integrated agent follows a three-phase loop every session:
+
+```
+┌──────────────────────────────────────────────────────┐
+│  1. ORIENT  (session start)                          │
+│     GET /session/orient?agent_id=my-agent            │
+│     → injects: recent events, last handoff,          │
+│       active triggers, active procedures             │
+│     → append this block to the system prompt         │
+├──────────────────────────────────────────────────────┤
+│  2. ACT  (during session — for each significant      │
+│     observation, decision, or outcome)               │
+│     POST /memories  ← store durable knowledge        │
+│     POST /events    ← log what happened              │
+│     GET  /triggers/check?q=<user input>              │
+│     GET  /memories/search?q=<topic>  ← before        │
+│          calling the LLM on a new topic              │
+│     POST /decisions  ← record major choices          │
+│     POST /reflexion  ← reflect on failures           │
+├──────────────────────────────────────────────────────┤
+│  3. WRAP UP  (session end)                           │
+│     POST /session/wrap-up                            │
+│     → creates handoff + event log entry              │
+│     → next session's orient will surface this        │
+└──────────────────────────────────────────────────────┘
+```
+
+### Pattern 1: System prompt injection
+
+The simplest integration. Before every LLM call, fetch relevant memory and prepend it to the system prompt. No tool use required — works with any model.
+
+```typescript
+async function buildSystemPrompt(agentId: string, userMessage: string): Promise<string> {
+  const base = process.env.BRAINCTL_URL;
+
+  // Fetch memories relevant to the current user message
+  const [memories, triggers, handoff] = await Promise.all([
+    fetch(`${base}/memories/search?q=${encodeURIComponent(userMessage)}&limit=5&agent_id=${agentId}`)
+      .then(r => r.json()),
+    fetch(`${base}/triggers/check?q=${encodeURIComponent(userMessage)}&agent_id=${agentId}`)
+      .then(r => r.json()),
+    fetch(`${base}/session/handoff/latest?agent_id=${agentId}`)
+      .then(r => r.ok ? r.json() : null),
+  ]);
+
+  const sections: string[] = ['You are a helpful assistant with persistent memory.'];
+
+  if (handoff) {
+    sections.push(`## Continuing from last session\n${handoff.current_state}\nOpen: ${handoff.open_loops}\nNext: ${handoff.next_step}`);
+  }
+  if (memories.length) {
+    sections.push(`## Relevant memories\n${memories.map((m: any) => `- ${m.content}`).join('\n')}`);
+  }
+  if (triggers.length) {
+    sections.push(`## Active triggers\n${triggers.map((t: any) => `- ${t.action}`).join('\n')}`);
+  }
+
+  return sections.join('\n\n');
+}
+```
+
+### Pattern 2: Tool use (function calling)
+
+Expose brainctl endpoints as LLM tools. The model decides when to store or retrieve memories as part of its reasoning chain. This gives the agent more control and produces richer retrieval because the model writes its own memory queries.
+
+```typescript
+const brainctlTools = [
+  {
+    name: 'remember',
+    description: 'Store a memory for future sessions. Use for durable facts, decisions, and lessons.',
+    parameters: {
+      type: 'object',
+      properties: {
+        content: { type: 'string' },
+        memory_type: { enum: ['episodic', 'semantic', 'procedural'] },
+        confidence: { type: 'number', minimum: 0, maximum: 1 },
+        temporal_class: { enum: ['ephemeral', 'short', 'medium', 'long'] },
+      },
+      required: ['content'],
+    },
+  },
+  {
+    name: 'recall',
+    description: 'Search memories by semantic similarity and keyword.',
+    parameters: {
+      type: 'object',
+      properties: { query: { type: 'string' }, limit: { type: 'number' } },
+      required: ['query'],
+    },
+  },
+  {
+    name: 'think',
+    description: 'Follow associations from a concept through the knowledge graph.',
+    parameters: {
+      type: 'object',
+      properties: { seed: { type: 'string' }, depth: { type: 'number' } },
+      required: ['seed'],
+    },
+  },
+];
+
+// Tool call handler
+async function handleToolCall(name: string, args: Record<string, unknown>, agentId: string) {
+  const base = process.env.BRAINCTL_URL;
+  if (name === 'remember') {
+    return fetch(`${base}/memories`, {
+      method: 'POST',
+      body: JSON.stringify({ ...args, agent_id: agentId }),
+    }).then(r => r.json());
+  }
+  if (name === 'recall') {
+    return fetch(`${base}/memories/search?q=${encodeURIComponent(args.query as string)}&limit=${args.limit ?? 5}&agent_id=${agentId}`)
+      .then(r => r.json());
+  }
+  if (name === 'think') {
+    return fetch(`${base}/think?q=${encodeURIComponent(args.seed as string)}&depth=${args.depth ?? 2}&agent_id=${agentId}`)
+      .then(r => r.json());
+  }
+}
+```
+
+### Pattern 3: MCP wrapper
+
+brainctl is itself a REST service, not an MCP server. But because it is just HTTP, it is straightforward to wrap it in an MCP server layer using the [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk). Each brainctl endpoint becomes an MCP tool. The original Python brainctl used this pattern natively; the REST rewrite makes it framework-agnostic while preserving the option to re-wrap with MCP if needed.
+
+```typescript
+// Minimal MCP wrapper sketch
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+const server = new Server({ name: 'brainctl', version: '1.0.0' }, { capabilities: { tools: {} } });
+const BASE = process.env.BRAINCTL_URL ?? 'http://localhost:3100';
+
+server.setRequestHandler('tools/call', async ({ params }) => {
+  const { name, arguments: args } = params;
+  // Route tool name → brainctl HTTP call
+  if (name === 'add_memory') {
+    const res = await fetch(`${BASE}/memories`, { method: 'POST', body: JSON.stringify(args) });
+    return { content: [{ type: 'text', text: JSON.stringify(await res.json()) }] };
+  }
+  // ... etc for each tool
+});
+```
+
+### Pattern 4: Middleware / event hooks
+
+In agent frameworks that support middleware (e.g. hooks around LLM calls), brainctl fits cleanly as a pre/post interceptor:
+
+```
+before_llm_call:
+  → GET /session/orient         (first call of session only)
+  → GET /triggers/check?q=<input>
+  → GET /memories/search?q=<input>
+  → GET /affect/state           (detect emotional distress signals)
+  → inject all above into system prompt
+
+after_llm_call:
+  → POST /events                (log what happened)
+  → POST /memories              (if the model output contains durable knowledge)
+  → POST /decisions             (if a decision was made)
+  → POST /affect                (classify the input/output tone)
+
+on_session_end:
+  → POST /session/wrap-up
+```
+
+### Multi-agent wiring
+
+When multiple agents share a brainctl instance, each uses its own `agent_id`. Shared knowledge flows through two mechanisms:
+
+- **`POST /agents/:id/share`** — explicitly copies a subset of memories from agent A to agent B (filtered by query or category).
+- **Theory of Mind** — agent A can call `POST /tom/model` to build a model of what agent B currently believes, without reading B's memories directly.
+
+This separation-with-sharing mirrors how human teams work: private working memory, selective communication, and collaborative reasoning.
+
+### Trigger-driven reactivity
+
+Triggers can make the agent reactive without polling:
+
+```typescript
+// Register once at startup
+await fetch(`${BRAINCTL_URL}/triggers`, {
+  method: 'POST',
+  body: JSON.stringify({
+    condition: 'user mentions production outage',
+    keywords: 'outage,down,incident,p0,pager',
+    action: 'Switch to incident response mode. Load the on-call runbook procedure.',
+    priority: 'critical',
+    agent_id: 'my-agent',
+  }),
+});
+
+// Check on every user input (cheap: pure in-process keyword scan)
+const fired = await fetch(
+  `${BRAINCTL_URL}/triggers/check?q=${encodeURIComponent(userInput)}&agent_id=my-agent`,
+).then(r => r.json());
+
+if (fired.length) {
+  systemPrompt += `\n\n## TRIGGERED\n${fired.map(t => t.action).join('\n')}`;
+}
+```
+
+### Grounded reasoning vs. raw generation
+
+The `/reason`, `/infer`, and `/dream` endpoints implement **retrieval-augmented generation (RAG)** internally. Rather than retrieving context externally and injecting it yourself, you POST a question and receive an answer with citations. Use these when you want brainctl to own the retrieval-augmentation loop; use pattern 1/2 above when you want the orchestrator to control it.
+
+```
+POST /reason
+{ "query": "What do we know about the auth service failures?", "agent_id": "my-agent" }
+
+→ 1. Searches memories + entities + events for relevant context
+→ 2. Assembles a prompt with cited evidence
+→ 3. Calls LiteLLM → returns answer + source_ids
+```
+
+---
+
 ## Quick Start
 
 ### Prerequisites

--- a/apps/brainctl/README.md
+++ b/apps/brainctl/README.md
@@ -157,6 +157,9 @@ Append-only observation log. Events are lighter than memories — they record *w
 | Method | Path | Description | MCP equivalent |
 |--------|------|-------------|----------------|
 | `POST` | `/events` | Log a new event | `log_event` |
+| `GET` | `/events` | List events with optional type/project/pagination filters | _(new)_ |
+| `GET` | `/events/:id` | Retrieve a single event by ID | _(new)_ |
+| `DELETE` | `/events/:id` | Delete an event (also removes its embedding) | _(new)_ |
 | `GET` | `/events/search?q=` | Hybrid event search | `search_events` |
 | `GET` | `/events/recent` | Most recent N events | `get_recent_events` |
 
@@ -184,6 +187,8 @@ Immutable decision records with rationale — useful for audit trails and reason
 |--------|------|-------------|----------------|
 | `POST` | `/decisions` | Record a decision | `record_decision` |
 | `GET` | `/decisions` | List decisions, filter by project | `list_decisions` |
+| `GET` | `/decisions/:id` | Retrieve a single decision by ID | _(new)_ |
+| `DELETE` | `/decisions/:id` | Delete a decision record | _(new)_ |
 
 ---
 
@@ -197,6 +202,8 @@ Session continuity tools: orient at the start of a session, hand off at the end.
 | `POST` | `/session/wrap-up` | Log a summary event and create handoff | `wrap_up` |
 | `POST` | `/session/handoff` | Explicit handoff with goal, state, open loops, next step | `create_handoff` |
 | `GET` | `/session/handoff/latest` | Retrieve latest unconsumed handoff | `get_latest_handoff` |
+| `GET` | `/session/handoffs` | List all handoffs (consumed or pending) | _(new)_ |
+| `POST` | `/session/handoff/:id/consume` | Mark a specific handoff as consumed | _(new)_ |
 
 ---
 
@@ -209,7 +216,10 @@ Prospective memory: register conditions that fire when future inputs match.
 | `POST` | `/triggers` | Create a trigger with keywords and action | `create_trigger` |
 | `GET` | `/triggers` | List active triggers | `list_triggers` |
 | `GET` | `/triggers/check?q=` | Test a string against all active triggers | `check_triggers` |
-| `DELETE` | `/triggers/:id` | Remove a trigger | `delete_trigger` |
+| `GET` | `/triggers/:id` | Retrieve a single trigger by ID | _(new)_ |
+| `PATCH` | `/triggers/:id` | Update trigger active state, expiry, or priority | _(new)_ |
+| `POST` | `/triggers/:id/fire` | Manually fire a trigger (marks fired_at, deactivates) | _(new)_ |
+| `DELETE` | `/triggers/:id` | Soft-delete a trigger (sets active=0) | `delete_trigger` |
 
 ---
 
@@ -223,6 +233,8 @@ Reusable workflows and conventions with confidence scores and execution feedback
 | `GET` | `/procedures/search?q=` | FTS search across goal, title, description | `search_procedures` |
 | `GET` | `/procedures` | List procedures with status/scope filter | `list_procedures` |
 | `GET` | `/procedures/:id` | Retrieve full procedure by ID | `get_procedure` |
+| `PATCH` | `/procedures/:id` | Update procedure fields (goal, steps, status, confidence) | _(new)_ |
+| `DELETE` | `/procedures/:id` | Delete a procedure | _(new)_ |
 | `POST` | `/procedures/:id/feedback` | Record execution feedback (success, usefulness score) | `record_feedback` |
 
 ---
@@ -380,6 +392,7 @@ Long-document ingestion with automatic chunking and per-chunk vector search.
 | `PUT` | `/context/:document` | Ingest/re-ingest a named document; auto-chunks at `chunk_size` words (default 300) with `overlap` (default 50) |
 | `GET` | `/context` | List all documents for an agent |
 | `GET` | `/context/:document` | Retrieve all chunks in order |
+| `GET` | `/context/:document/:chunk_index` | Retrieve a single chunk by zero-based index |
 | `DELETE` | `/context/:document` | Remove all chunks for a document |
 | `POST` | `/context/search` | Hybrid FTS5+vec search across chunks, optionally filtered by document |
 
@@ -406,6 +419,7 @@ Six lightweight in-process "subsystems" that model higher-order cognitive proces
 |--------|------|-------------|----------------|
 | `POST` | `/belief` | Upsert a belief with confidence and evidence | `upsert_belief` |
 | `GET` | `/belief` | List beliefs, optionally filtered by minimum confidence | `list_beliefs` |
+| `DELETE` | `/belief/:id` | Delete a belief by ID | _(new)_ |
 
 #### Trust
 | Method | Path | Description | MCP equivalent |
@@ -428,13 +442,16 @@ Trust score starts at 0.5 and updates: +0.05 for positive, −0.08 for negative,
 | `PUT` | `/workspace/:name` | Create or update a named scratchpad | `upsert_workspace` |
 | `GET` | `/workspace` | List workspace items, optionally filter by status | `list_workspace` |
 | `GET` | `/workspace/:name` | Retrieve a specific workspace item | `get_workspace` |
+| `DELETE` | `/workspace/:name` | Delete a workspace item | _(new)_ |
 
 #### Tasks
 | Method | Path | Description | MCP equivalent |
 |--------|------|-------------|----------------|
 | `POST` | `/tasks` | Create a task with priority (`critical` / `high` / `medium` / `low`) | `create_task` |
-| `PATCH` | `/tasks/:id/status` | Update task status and optional result | `update_task_status` |
 | `GET` | `/tasks` | List tasks, filter by status and assignee | `list_tasks` |
+| `GET` | `/tasks/:id` | Retrieve a single task by ID | _(new)_ |
+| `PATCH` | `/tasks/:id/status` | Update task status and optional result | `update_task_status` |
+| `DELETE` | `/tasks/:id` | Delete a task | _(new)_ |
 
 #### Policies
 | Method | Path | Description | MCP equivalent |
@@ -560,14 +577,14 @@ Every LLM call has a fallback path:
 
 | Category | Endpoints |
 |----------|-----------|
-| Core memory | 4 |
+| Core memory | 6 |
 | Memory lifecycle | 9 |
-| Events | 3 |
-| Entities | 5 |
-| Decisions | 2 |
-| Session | 4 |
-| Triggers | 4 |
-| Procedures | 5 |
+| Events | 6 |
+| Entities | 7 |
+| Decisions | 4 |
+| Session | 6 |
+| Triggers | 7 |
+| Procedures | 7 |
 | Search & reasoning | 9 |
 | Affect | 7 |
 | Consolidation | 8 |
@@ -576,11 +593,11 @@ Every LLM call has a fallback path:
 | Admin | 7 |
 | Multi-agent | 6 |
 | Diagnostics | 2 |
-| Context | 5 |
+| Context | 6 |
 | Analytics | 5 |
-| Subsystems (6 × 2–3) | 17 |
+| Subsystems (6 × 2–5) | 21 |
 | Subsystem meta | 5 |
 | Theory of Mind | 3 |
 | Budget | 4 |
 | Push & webhooks | 5 |
-| **Total** | **153** |
+| **Total** | **170** |

--- a/apps/brainctl/README.md
+++ b/apps/brainctl/README.md
@@ -888,3 +888,93 @@ Every LLM call has a fallback path:
 | Budget | 4 |
 | Push & webhooks | 5 |
 | **Total** | **170** |
+
+---
+
+## Roadmap & Future Improvements
+
+brainctl is feature-complete against the original MCP surface, but there is a large design space ahead. This section is a working backlog — a mix of small polish items, substantial features, and a few research-flavoured ideas. Roughly ordered within each theme from "high-leverage / low-risk" to "ambitious".
+
+### Security & Multi-Tenancy
+
+Authentication was intentionally deferred — this is the largest gap before any non-trusted deployment.
+
+- **API key authentication.** A Fastify `preHandler` hook validating a bearer token, with keys stored in a new `api_keys` table (hashed). Scope keys to one or more `agent_id`s.
+- **Per-agent authorization.** Today any caller can pass any `agent_id`. Bind keys to agents so a token for `agent-a` cannot read or wipe `agent-b`'s data.
+- **Rate limiting.** `@fastify/rate-limit` keyed by API key or IP, with stricter limits on expensive LLM-backed endpoints (`/reason`, `/dream`, `/tom/model`).
+- **Audit log.** An append-only `audit_log` table recording who called destructive endpoints (`/admin/agent`, `/admin/memories/retired`, `DELETE` routes) and when.
+- **Field-level encryption.** Optional at-rest encryption for memory `content` using a key from the environment, for deployments handling sensitive data.
+- **Tenant isolation at the DB level.** Investigate one SQLite file per tenant (or per agent) instead of a shared file, trading a little operational complexity for hard isolation guarantees.
+
+### Search & Retrieval Quality
+
+The RRF hybrid search is solid but untuned. There is meaningful retrieval-quality headroom here.
+
+- **Cross-encoder reranking.** After RRF produces candidates, pass the top ~30 through a reranker model (via LiteLLM) for a final ordering. Cross-encoders consistently beat bi-encoder similarity for the final sort.
+- **Tunable RRF weights.** Expose the FTS-vs-vector balance as a per-request or per-agent parameter instead of the fixed equal weighting, and let `K` be configurable.
+- **Query expansion.** Optionally expand a query with synonyms or LLM-generated paraphrases before searching, improving recall on terse queries.
+- **Maximal Marginal Relevance (MMR).** Diversify results so the top-k aren't near-duplicates of each other — useful for `/reason` context assembly.
+- **Time-decay-aware ranking.** Fold each memory's current decayed `confidence` and recency into the search score, so fresher / stronger memories rank higher without a separate consolidation pass.
+- **Embedding model migration tooling.** When `LITELLM_EMBEDDING_MODEL` changes, vectors are stale. Add a `POST /admin/reembed` that re-embeds everything and a stored `embedding_model` column per vector so mismatches are detectable.
+
+### Memory Model & Cognition
+
+Deeper modelling of the brain analogy.
+
+- **Per-memory adaptive half-life.** Instead of four fixed temporal classes, learn a half-life per memory from its access pattern (frequently recalled → longer half-life), a closer model of spaced-repetition strength.
+- **Novelty / curiosity signal.** Score incoming memories by their distance from existing ones; surface "surprising" memories and use novelty to drive what the agent chooses to explore or ask about.
+- **Emotional tagging of memories.** Link the affect (VAD) state at write time to each memory, so emotionally salient memories resist decay — mirroring how affect strengthens human encoding.
+- **Metacognition endpoint.** A "what do I know about my own knowledge?" summary: confidence distribution, coverage gaps, stale regions, over-represented topics.
+- **Contradiction detection at write time.** Run a lightweight similarity + polarity check when storing a memory, flagging likely contradictions with existing memories before they pile up (rather than only in the conflict-resolution endpoint).
+- **Source provenance & trust propagation.** Tie memory confidence to the `trust` score of its source, and propagate trust changes to dependent memories.
+
+### Consolidation Engine
+
+- **LLM-graded compression quality.** When merging a cluster, have the LLM verify the summary preserves the key facts of its constituents, and fall back to keeping originals if information loss is detected.
+- **Incremental / streaming consolidation.** Today a run processes the whole store. For large DBs, process only memories touched since the last run.
+- **Configurable pass pipeline.** Let an agent define which passes run, in what order, with what thresholds — stored per-agent rather than hardcoded.
+- **Consolidation dry-run mode.** A `preview=true` flag that reports what *would* change (memories to retire, clusters to merge) without mutating anything.
+- **Sleep-cycle simulation.** Alternate "slow-wave" passes (decay, compress) and "REM" passes (promote, dream-style synthesis) across multiple short cycles rather than one linear pass, closer to real sleep architecture.
+
+### Performance & Scale
+
+SQLite + in-process search is the right call for single-node simplicity, but there are known ceilings.
+
+- **Vector index for `sqlite-vec`.** As vector counts grow, brute-force KNN slows down. Evaluate `sqlite-vec`'s ANN options or partition vectors by `agent_id`.
+- **Prepared-statement caching audit.** Ensure hot-path statements are prepared once and reused, not re-prepared per request.
+- **Read replicas / connection strategy.** WAL mode allows concurrent readers; document and test the limits, and consider a read-only connection pool for search-heavy workloads.
+- **Pagination everywhere.** Some list endpoints cap results but don't expose cursors. Add consistent `limit`/`offset` (or keyset) pagination across all list routes.
+- **Batch embedding.** Embed multiple texts per LiteLLM request during bulk import and backfill instead of one call per record.
+- **Optional Postgres backend.** A pluggable storage layer (Postgres + `pgvector`) for deployments that outgrow a single SQLite file, sharing the service/route layer unchanged.
+
+### Observability & Operations
+
+- **Structured metrics.** Prometheus-style `/metrics` endpoint: request counts/latencies per route, LLM call counts and token usage, consolidation timings, DB size.
+- **OpenTelemetry tracing.** Trace a request through service calls, DB queries, and LLM round-trips — invaluable for debugging slow `/reason` calls.
+- **LLM cost accounting.** Extend the budget subsystem to record *actual* token usage returned by LiteLLM per call, attributing cost to agents and endpoints.
+- **Backup automation & restore.** Pair the existing `/admin/backup` with a scheduled backup job and a tested `POST /admin/restore` path.
+- **Health-check depth.** Add readiness vs. liveness distinction and an optional deep check that pings LiteLLM.
+
+### Developer Experience
+
+- **Typed client SDK.** Generate a TypeScript (and Python) client from the Zod/OpenAPI schemas so consumers get autocomplete and type safety for free.
+- **First-party MCP server package.** Ship the MCP wrapper sketched in the integration guide as a maintained package, so brainctl can be dropped into Claude Code / MCP hosts with zero glue code.
+- **Framework adapters.** Thin LangChain `Memory` and `Retriever` adapters, and an AutoGen memory provider, so brainctl is a one-liner in popular harnesses.
+- **Seed & fixture data.** A `brainctl seed` command that loads a realistic demo brain for testing and onboarding.
+- **Test coverage.** Integration tests per route (especially the lazy-table and migration paths), plus a retrieval-quality regression suite using `/analytics/retrieval-effectiveness`.
+- **Complete OpenAPI response schemas.** A few routes omit `response:` schema blocks (to dodge a type conflict on 404 unions). Resolve these so `/docs` is fully accurate and the generated SDK is complete.
+
+### Real-Time & Eventing
+
+- **Server-Sent Events / WebSocket subscriptions.** Let a harness subscribe to "new memory stored", "trigger fired", or "affect threshold breached" instead of polling.
+- **Webhook delivery hardening.** Add retries with backoff, a dead-letter log, and HMAC signing to the push subsystem so deliveries are reliable and verifiable.
+- **Reactive triggers.** Today triggers are checked on demand via `/triggers/check`. Allow a trigger to fire a webhook automatically when a matching memory or event is written.
+
+### New Capabilities
+
+- **Temporal queries.** "What did I believe about X *as of* last Tuesday?" — query memory state at a point in time using the epoch/timestamp data already stored.
+- **Memory diffing.** Show how an entity's `compiled_truth` or an agent's belief set changed between two epochs.
+- **Federated brains.** A protocol for two brainctl instances to selectively sync subgraphs, enabling distributed multi-agent teams without a shared database.
+- **Multi-modal memories.** Store and embed images / audio alongside text, using a multi-modal embedding model through LiteLLM.
+- **Knowledge graph visualization.** A read-only endpoint emitting the graph in a standard format (e.g. GraphML / JSON for D3) for inspection in external tools.
+- **Explainable retrieval.** Return *why* each result matched (FTS rank, vector distance, graph proximity, recency boost) so callers can debug and trust retrieval.

--- a/apps/brainctl/README.md
+++ b/apps/brainctl/README.md
@@ -1,0 +1,586 @@
+# brainctl
+
+A TypeScript/Fastify REST service that provides a persistent cognitive memory layer for AI agents. brainctl is a ground-up rewrite of the [original Python brainctl MCP server](https://github.com/TSchonleber/brainctl), surfacing all MCP tools as plain HTTP endpoints instead — no MCP protocol required.
+
+---
+
+## What is brainctl?
+
+AI agents are stateless by default. Each new context window starts cold. brainctl solves this by giving agents a persistent, queryable brain:
+
+- **Memories** stored with confidence scores, temporal decay, and semantic embeddings
+- **Knowledge graph** linking memories, entities, and events with typed, weighted edges
+- **Consolidation engine** that periodically prunes, promotes, and compresses memories — analogous to biological sleep consolidation
+- **Grounded reasoning** endpoints that retrieve supporting evidence before calling an LLM
+- **Multi-agent support** with per-agent isolation, cross-agent memory sharing, and Theory of Mind modeling
+- **Cognitive subsystems** for beliefs, trust, reflections, workspace, tasks, and policies
+
+All state lives in a single SQLite database (via `better-sqlite3`). FTS5 full-text search and optional `sqlite-vec` vector search run in the same process — no external search infra required.
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Fastify (port 3100)                   │
+│         fastify-type-provider-zod · @ee/starter          │
+├──────────────┬──────────────┬──────────────┬────────────┤
+│   Memory &   │  Knowledge   │  Reasoning & │  Agent &   │
+│  Lifecycle   │    Graph     │ Consolidation│ Subsystems │
+├──────────────┴──────────────┴──────────────┴────────────┤
+│                  Service Layer (23 modules)              │
+├─────────────────────────────────────────────────────────┤
+│   better-sqlite3  ·  FTS5  ·  sqlite-vec (optional)     │
+│              WAL mode · 10s busy timeout                 │
+├──────────────────────────┬──────────────────────────────┤
+│  LiteLLM Proxy (chat)    │  LiteLLM Proxy (embeddings)  │
+│  LITELLM_CHAT_MODEL      │  LITELLM_EMBEDDING_MODEL     │
+└──────────────────────────┴──────────────────────────────┘
+```
+
+### Key design decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Single SQLite file | No external dependencies; backup is a single file copy |
+| FTS5 + sqlite-vec via RRF | Hybrid search without a vector DB: keyword precision + semantic recall, merged via Reciprocal Rank Fusion (K=60) |
+| LiteLLM proxy | Swap any self-hosted or cloud model by changing env vars; no code changes |
+| Per-agent `agent_id` | All tables carry `agent_id`; default value is `'default'`; enables true multi-tenancy |
+| Lazy table creation | Subsystem tables are created on first write so a fresh DB starts minimal |
+| Safe migrations | `ALTER TABLE … ADD COLUMN` wrapped in try/catch because SQLite has no `IF NOT EXISTS` column syntax |
+
+---
+
+## Quick Start
+
+### Prerequisites
+
+- **Bun** ≥ 1.0 (monorepo package manager)
+- **Node** ≥ 20 (for esbuild)
+- Optional: LiteLLM proxy for embeddings and LLM reasoning
+
+### Build & run
+
+```bash
+# From the monorepo root
+npx nx serve brainctl
+
+# Or build a production bundle
+npx nx build brainctl
+node dist/apps/brainctl/main.js
+```
+
+### Docker
+
+```bash
+docker build -f apps/brainctl/Dockerfile -t brainctl .
+docker run -p 3100:3100 \
+  -e LITELLM_BASE_URL=http://my-litellm:4000 \
+  -v /data/brainctl:/data \
+  -e BRAIN_DB=/data/brain.db \
+  brainctl
+```
+
+---
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `BRAIN_DB` | `~/brainctl/brain.db` | SQLite database path |
+| `LITELLM_BASE_URL` | _(none)_ | LiteLLM proxy base URL. Embeddings and LLM calls disabled when unset |
+| `LITELLM_API_KEY` | `no-key` | Bearer token for LiteLLM proxy |
+| `LITELLM_EMBEDDING_MODEL` | `text-embedding-3-small` | Model name sent in `/v1/embeddings` requests |
+| `LITELLM_EMBEDDING_DIMENSIONS` | `1536` | Vector dimensions — must match the embedding model's output |
+| `LITELLM_CHAT_MODEL` | `gpt-4o-mini` | Model name for chat/reasoning requests |
+| `BRAIN_CONSOLIDATION_CRON` | _(none)_ | Cron expression for automatic consolidation (e.g. `0 3 * * *` for 3 AM daily) |
+| `PORT` | `3100` | HTTP listen port (overrides app.config default) |
+
+---
+
+## API Reference
+
+All endpoints accept and return JSON. `agent_id` defaults to `"default"` when omitted. Swagger UI is available at `/docs` when `ENABLE_SWAGGER=true`.
+
+---
+
+### Core Memory
+
+The primary storage unit. Each memory has a `confidence` score (0–1), a `memory_type` (`episodic`, `semantic`, `procedural`), and a `temporal_class` (`ephemeral`, `short`, `medium`, `long`) that controls decay half-life.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/memories` | Store a new memory | `add_memory` |
+| `GET` | `/memories/search?q=` | Hybrid FTS5+vec search with RRF | `search_memories` |
+| `GET` | `/memories/:id` | Retrieve memory by ID (bumps recall stats) | `get_memory` |
+| `DELETE` | `/memories/:id` | Soft-retire a memory | `forget_memory` |
+
+**POST /memories body:**
+```json
+{
+  "content": "The deployment pipeline uses GitHub Actions",
+  "category": "devops",
+  "tags": ["ci", "github"],
+  "confidence": 0.9,
+  "memory_type": "semantic",
+  "temporal_class": "long",
+  "scope": "project-x",
+  "agent_id": "claude-3"
+}
+```
+
+---
+
+### Memory Lifecycle
+
+Advanced memory management: abstraction layers, conflict resolution, quarantine, and pattern detection. These have no direct MCP equivalents — they are new capabilities added in this implementation.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/memories/:id/zoom-in` | Granular episodic memories semantically close to a seed |
+| `POST` | `/memories/zoom-out` | Abstract summary of a memory cluster (by IDs or query) |
+| `POST` | `/memories/abstract` | Multi-level hierarchical summary at 1–5 granularity levels |
+| `GET` | `/memories/retirement-candidates` | Low-confidence / low-recall memories ready for retirement |
+| `POST` | `/memories/resolve-conflict` | Detect and resolve contradictions between two memories |
+| `POST` | `/memories/:id/quarantine` | Isolate a memory for review without retiring it |
+| `DELETE` | `/memories/:id/quarantine` | Release a memory from quarantine |
+| `GET` | `/memories/quarantined` | List all quarantined memories |
+| `GET` | `/memories/patterns` | Recurring themes by tag frequency + optional LLM pattern extraction |
+
+---
+
+### Events
+
+Append-only observation log. Events are lighter than memories — they record *what happened* without the full retrieval/confidence infrastructure.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/events` | Log a new event | `log_event` |
+| `GET` | `/events/search?q=` | Hybrid event search | `search_events` |
+| `GET` | `/events/recent` | Most recent N events | `get_recent_events` |
+
+---
+
+### Entities
+
+Named concepts, people, projects, or systems with compiled understanding accumulated over time.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/entities` | Create or get an entity | `create_entity` |
+| `GET` | `/entities/search?q=` | FTS search across entity name, observations, compiled truth | `search_entities` |
+| `GET` | `/entities/:name` | Retrieve entity with full properties | `get_entity` |
+| `GET` | `/entities/:name/relations` | Bidirectional knowledge graph edges for entity | `get_entity_relations` |
+| `POST` | `/entities/relate` | Create a typed relation between two entities | `relate_entities` |
+
+---
+
+### Decisions
+
+Immutable decision records with rationale — useful for audit trails and reasoning about past choices.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/decisions` | Record a decision | `record_decision` |
+| `GET` | `/decisions` | List decisions, filter by project | `list_decisions` |
+
+---
+
+### Session
+
+Session continuity tools: orient at the start of a session, hand off at the end.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `GET` | `/session/orient` | Surface relevant memories + latest handoff to bootstrap context | `orient` |
+| `POST` | `/session/wrap-up` | Log a summary event and create handoff | `wrap_up` |
+| `POST` | `/session/handoff` | Explicit handoff with goal, state, open loops, next step | `create_handoff` |
+| `GET` | `/session/handoff/latest` | Retrieve latest unconsumed handoff | `get_latest_handoff` |
+
+---
+
+### Triggers
+
+Prospective memory: register conditions that fire when future inputs match.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/triggers` | Create a trigger with keywords and action | `create_trigger` |
+| `GET` | `/triggers` | List active triggers | `list_triggers` |
+| `GET` | `/triggers/check?q=` | Test a string against all active triggers | `check_triggers` |
+| `DELETE` | `/triggers/:id` | Remove a trigger | `delete_trigger` |
+
+---
+
+### Procedures
+
+Reusable workflows and conventions with confidence scores and execution feedback.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/procedures` | Create a procedure with goal and steps | `create_procedure` |
+| `GET` | `/procedures/search?q=` | FTS search across goal, title, description | `search_procedures` |
+| `GET` | `/procedures` | List procedures with status/scope filter | `list_procedures` |
+| `GET` | `/procedures/:id` | Retrieve full procedure by ID | `get_procedure` |
+| `POST` | `/procedures/:id/feedback` | Record execution feedback (success, usefulness score) | `record_feedback` |
+
+---
+
+### Search & Reasoning
+
+Cross-table search and LLM-powered reasoning grounded in stored memories.
+
+#### Search
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `GET` | `/search?q=` | Unified FTS across memories + entities + events | `unified_search` |
+| `GET` | `/vsearch?q=` | Vector-only semantic search across all record types | `vsearch` |
+| `GET` | `/think?q=` | Spreading-activation BFS over the knowledge graph | `think` |
+| `POST` | `/embeddings/backfill` | Embed all records missing vectors (run after enabling embeddings) | — |
+
+#### Reasoning (requires `LITELLM_BASE_URL`)
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/reason` | Grounded Q&A: retrieve context → LLM answer with citations | `reason` |
+| `POST` | `/infer` | Structured inference: premise → list of conclusions | `infer` |
+| `POST` | `/infer/pretask` | Pre-task briefing: what does the agent know about this task? | `pretask` |
+| `POST` | `/infer/gapfill` | Knowledge gap analysis: known facts, gaps, suggested questions | `gapfill` |
+| `POST` | `/dream` | Dream synthesis: hypotheses from high-confidence memories | `dream` |
+
+---
+
+### Affect
+
+Valence-Arousal-Dominance (VAD) classifier with threshold-based monitoring.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/affect` | Classify text and optionally store the result | `classify_affect` / `log_affect` |
+| `GET` | `/affect/state` | Rolling VAD average over a time window | _(new)_ |
+| `GET` | `/affect/history` | Recent affect log entries | _(new)_ |
+| `PUT` | `/affect/thresholds/:metric` | Set a threshold alert for `valence`, `arousal`, or `dominance` | _(new)_ |
+| `GET` | `/affect/thresholds` | List all configured thresholds | _(new)_ |
+| `DELETE` | `/affect/thresholds/:id` | Remove a threshold | _(new)_ |
+| `GET` | `/affect/monitor` | Check current affect against all thresholds, return breaches | `affect_monitor` |
+
+---
+
+### Consolidation
+
+Memory consolidation engine. Inspired by biological sleep consolidation: the system periodically reorganises memories to strengthen important ones and discard noise.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/consolidation/run` | Run a full or partial consolidation cycle | `run_consolidation` |
+| `GET` | `/consolidation/status` | Last run summary + history | `consolidation_status` |
+| `POST` | `/consolidation/decay` | Pass 1: exponential confidence decay by temporal class | — |
+| `POST` | `/consolidation/promote` | Pass 2: episodic → semantic for high-replay memories | — |
+| `POST` | `/consolidation/compress` | Pass 3: cluster near-duplicate memories (vec or FTS Jaccard) | — |
+| `POST` | `/consolidation/hebbian` | Pass 4: reinforce co-active edges, prune weak ones | — |
+| `POST` | `/consolidation/gap-scan` | Pass 5: identify orphans, empty entities, broken edges | — |
+| `POST` | `/consolidation/entity-tiers` | Pass 6: assign entity tier 1/2/3 by edge count | — |
+
+**Consolidation passes in order:**
+
+1. **Decay** — exponential confidence reduction by temporal class half-life (ephemeral: 3.5d, short: 10d, medium: 23d, long: 69d). Memories below `retire_threshold` (default 0.1) are soft-retired. Protected if `confidence ≥ 0.8 AND recalled_count ≥ 10`.
+2. **Promote** — episodic memories with `replay_priority ≥ 0.3`, `ripple_tags ≥ 3`, `confidence ≥ 0.7` become semantic.
+3. **Compress** — vec KNN clustering (distance ≤ 0.18) or FTS Jaccard fallback (≥ 0.4 overlap). Clusters of ≥ 3 merged into a single summary memory.
+4. **Hebbian** — edges where both endpoints have `confidence ≥ 0.6` are boosted; others decay. Edges below 0.05 pruned.
+5. **Gap scan** — read-only audit: orphaned FTS rows, empty entities, broken edges, missing vectors.
+6. **Entity tiers** — tier 3 if `edges ≥ 20`, tier 2 if `edges ≥ 5`, tier 1 otherwise.
+
+---
+
+### Scheduler
+
+Automatic consolidation via cron expressions (backed by `node-cron`).
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/scheduler` | Register a cron-scheduled consolidation job | — |
+| `GET` | `/scheduler` | List all schedules | — |
+| `GET` | `/scheduler/:id` | Get a specific schedule | — |
+| `DELETE` | `/scheduler/:id` | Remove a schedule | — |
+| `POST` | `/scheduler/:id/pause` | Pause without deleting | — |
+| `POST` | `/scheduler/:id/resume` | Resume a paused schedule | — |
+
+---
+
+### Knowledge Graph
+
+The `knowledge_edges` table connects any two records (memories, entities, events) with a typed, weighted directed edge. PageRank and graph traversal run directly over this table.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `GET` | `/graph/pagerank` | Weighted PageRank over agent's subgraph | `pagerank` |
+| `GET` | `/graph/whosknows?q=` | Which entities have the most knowledge touching a topic? | `whos_knows` |
+| `GET` | `/graph/traverse` | BFS traversal from a seed node with depth limit | `traverse` |
+| `GET` | `/graph/edges` | List edges with type/id/relation filters | _(new)_ |
+| `POST` | `/graph/edges` | Create an edge manually | _(new)_ |
+| `PATCH` | `/graph/edges/:id/weight` | Update an edge weight | `weights` |
+| `DELETE` | `/graph/edges/:id` | Delete an edge | _(new)_ |
+| `POST` | `/graph/events/:id/link` | Explicitly link an event to memories/entities | `event_link` |
+| `GET` | `/graph/events/:id/links` | Get all edges from an event | _(new)_ |
+| `PUT` | `/graph/epochs/:label` | Create a named temporal epoch | `epoch` |
+| `POST` | `/graph/epochs/:label/close` | Close an epoch (set end timestamp) | _(new)_ |
+| `GET` | `/graph/epochs` | List all epochs | _(new)_ |
+| `GET` | `/graph/epochs/:label/memories` | Memories created during an epoch's time window | _(new)_ |
+
+---
+
+### Admin
+
+Bulk operations, data management, and maintenance. The `confirm=true` guard on the wipe endpoint is a hard requirement.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/admin/memories/bulk` | Import up to 1 000 memories at once | `bulk_import` |
+| `DELETE` | `/admin/memories/retired` | Hard-delete soft-retired memories (optionally older than N days) | — |
+| `GET` | `/admin/export` | Full agent data export as JSON | `export_data` |
+| `DELETE` | `/admin/agent?confirm=true` | Irreversibly wipe all data for an agent | `wipe_agent` |
+| `GET` | `/admin/backup` | Stream a live SQLite backup (`.db` file download) | `backup` |
+| `POST` | `/admin/reindex` | Rebuild all FTS5 indexes | — |
+| `GET` | `/admin/breakdown` | Memory stats by category, type, temporal class; top accessed | `breakdown` |
+
+---
+
+### Multi-Agent
+
+All tables are isolated by `agent_id`. These endpoints manage the relationships between agents.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `GET` | `/agents` | List all known agents with activity counts | `list_agents` |
+| `GET` | `/agents/:id/state` | Key-value state for an agent (all or single key) | `get_agent_state` |
+| `PUT` | `/agents/:id/state` | Set multiple state keys | `set_agent_state` |
+| `DELETE` | `/agents/:id/state/:key` | Delete a state key | — |
+| `POST` | `/agents/:id/share` | Copy memories from this agent to another | `share_memories` |
+| `POST` | `/agents/:id/transfer` | Transfer the latest handoff to another agent | `transfer_handoff` |
+
+---
+
+### Diagnostics
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `GET` | `/health` | FTS5/vec availability, DB size, integrity, embedding status | `health` |
+| `GET` | `/stats` | Count of every record type + optional vec counts | `stats` |
+
+---
+
+### Context
+
+Long-document ingestion with automatic chunking and per-chunk vector search.
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `PUT` | `/context/:document` | Ingest/re-ingest a named document; auto-chunks at `chunk_size` words (default 300) with `overlap` (default 50) |
+| `GET` | `/context` | List all documents for an agent |
+| `GET` | `/context/:document` | Retrieve all chunks in order |
+| `DELETE` | `/context/:document` | Remove all chunks for a document |
+| `POST` | `/context/search` | Hybrid FTS5+vec search across chunks, optionally filtered by document |
+
+---
+
+### Analytics
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `GET` | `/analytics/validate` | Deep DB consistency check: orphaned FTS rows, missing embeddings, broken edges | `validate` / `lint` |
+| `GET` | `/analytics/free-energy` | Homeostatic memory pressure score (0–1) with capacity recommendations | `free_energy_check` |
+| `GET` | `/analytics/allostatic-prime` | Memories near decay threshold ranked by decay risk — surface before consolidation | `allostatic_prime` |
+| `GET` | `/analytics/demand-forecast` | Recency-weighted access prediction for the top N memories | `demand_forecast` |
+| `POST` | `/analytics/retrieval-effectiveness` | Offline precision@k / recall@k for a set of (query, expected_ids) test cases | `retrieval_effectiveness` |
+
+---
+
+### Cognitive Subsystems
+
+Six lightweight in-process "subsystems" that model higher-order cognitive processes. All tables are created lazily on first write.
+
+#### Belief
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/belief` | Upsert a belief with confidence and evidence | `upsert_belief` |
+| `GET` | `/belief` | List beliefs, optionally filtered by minimum confidence | `list_beliefs` |
+
+#### Trust
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/trust/interaction` | Record a positive / negative / neutral outcome with a target | `record_interaction` |
+| `GET` | `/trust` | List all trust records sorted by score | `list_trust` |
+| `GET` | `/trust/:target` | Get trust score for a named target | `get_trust` |
+
+Trust score starts at 0.5 and updates: +0.05 for positive, −0.08 for negative, 0 for neutral. Clamped to [0, 1].
+
+#### Reflexion
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/reflexion` | Reflect on an action/outcome; optionally generate an LLM lesson stored as semantic memory | `reflect` |
+| `GET` | `/reflexion` | List reflections most-recent first | `list_reflections` |
+
+#### Workspace
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `PUT` | `/workspace/:name` | Create or update a named scratchpad | `upsert_workspace` |
+| `GET` | `/workspace` | List workspace items, optionally filter by status | `list_workspace` |
+| `GET` | `/workspace/:name` | Retrieve a specific workspace item | `get_workspace` |
+
+#### Tasks
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/tasks` | Create a task with priority (`critical` / `high` / `medium` / `low`) | `create_task` |
+| `PATCH` | `/tasks/:id/status` | Update task status and optional result | `update_task_status` |
+| `GET` | `/tasks` | List tasks, filter by status and assignee | `list_tasks` |
+
+#### Policies
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `PUT` | `/policy/:name` | Upsert a named policy rule | `upsert_policy` |
+| `POST` | `/policy/:name/evaluate` | Evaluate a policy rule against a context string using LLM | `evaluate_policy` |
+| `GET` | `/policy` | List policies (active only by default) | `list_policies` |
+
+---
+
+### Subsystem Meta-API
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/subsystems` | List all six subsystems with live record counts |
+| `POST` | `/subsystems/:name/emit` | Append a typed event to a subsystem's audit log |
+| `GET` | `/subsystems/:name/events` | Query the subsystem event log |
+| `PUT` | `/subsystems/:name/config` | Set per-agent key-value configuration for a subsystem |
+| `GET` | `/subsystems/:name/config` | Retrieve subsystem configuration |
+
+---
+
+### Theory of Mind
+
+Model what another agent believes or intends based on their memory records.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `POST` | `/tom/model` | Generate a ToM model: observer searches subject's memories → LLM extracts beliefs/intentions | `tom` |
+| `GET` | `/tom/:observer/model/:subject` | Retrieve the latest ToM model for a subject | _(new)_ |
+| `GET` | `/tom/:observer/models` | List all models produced by an observer | _(new)_ |
+
+---
+
+### Budget
+
+Token and call-count budgeting per agent. Useful when embedding brainctl in agentic pipelines with cost controls.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `PUT` | `/budget/:agent_id` | Set or update token/call budget limits | `budget_set` |
+| `GET` | `/budget/:agent_id` | Get current usage vs. limits | `budget_status` |
+| `POST` | `/budget/:agent_id/usage` | Record token and/or call usage | _(new)_ |
+| `POST` | `/budget/:agent_id/reset` | Reset usage counters | _(new)_ |
+
+---
+
+### Push & Webhooks
+
+Deliver memories or structured reports to external services.
+
+| Method | Path | Description | MCP equivalent |
+|--------|------|-------------|----------------|
+| `PUT` | `/webhooks/:name` | Register or update a webhook URL | _(new)_ |
+| `GET` | `/webhooks` | List all active webhooks | _(new)_ |
+| `DELETE` | `/webhooks/:name` | Remove a webhook | _(new)_ |
+| `POST` | `/push` | Push matching memories to a webhook (by query or ID list) | `push` |
+| `POST` | `/push/report` | Deliver a structured report payload to a webhook | `push_report` |
+
+---
+
+## Database Schema
+
+All tables live in a single SQLite file. Key tables:
+
+| Table | Purpose |
+|-------|---------|
+| `memories` | Core memory store with FTS5 (`memories_fts`) and optional `vec_memories` |
+| `entities` | Named concepts with FTS5 (`entities_fts`) and optional `vec_entities` |
+| `events` | Append-only observation log with FTS5 (`events_fts`) |
+| `knowledge_edges` | Typed, weighted directed edges between any records |
+| `decisions` | Immutable decision records |
+| `triggers` | Prospective memory conditions |
+| `handoffs` | Session state transfer packets |
+| `procedures` | Reusable workflows with FTS5 (`procedures_fts`) |
+| `procedure_feedback` | Execution outcomes for procedure confidence updates |
+| `agent_state` | Per-agent key-value store |
+| `affect_log` | VAD scores with safety flag annotations |
+| `consolidation_log` | Audit trail of consolidation cycle runs |
+| `context` | Chunked document storage with FTS5 (`context_fts`) and `vec_context` |
+| `beliefs` | Per-agent graded belief set (lazy) |
+| `trust_records` | Trust scores for named targets (lazy) |
+| `reflections` | Action/outcome reflection log (lazy) |
+| `workspace` | Named scratchpad items (lazy) |
+| `tasks` | Shared task queue (lazy) |
+| `policies` | Named rule definitions (lazy) |
+| `epochs` | Named temporal segments (lazy) |
+| `tom_models` | Theory of Mind model snapshots (lazy) |
+| `agent_budgets` | Token/call budget tracking (lazy) |
+| `webhooks` | Registered push destinations (lazy) |
+| `subsystem_config` | Per-agent subsystem key-value config (lazy) |
+| `subsystem_events` | Subsystem audit log (lazy) |
+| `affect_thresholds` | VAD threshold alert definitions (lazy) |
+
+FTS5 tables use `content=` (external content) with `AFTER INSERT/UPDATE/DELETE` triggers to stay in sync with their base tables.
+
+---
+
+## Search Architecture
+
+When `LITELLM_BASE_URL` is set and `sqlite-vec` is loaded, search uses **Reciprocal Rank Fusion (RRF)**:
+
+```
+score(d) = 1/(K + rank_fts(d)) + 1/(K + rank_vec(d))   K = 60
+```
+
+FTS5 and vector results are ranked independently and merged. The K=60 constant dampens the impact of rank position differences near the top of each list. If either source is unavailable the other is used directly.
+
+---
+
+## LLM Degradation
+
+Every LLM call has a fallback path:
+
+- **Embeddings unavailable** → store/search without vectors; FTS5 only
+- **LLM unavailable** → reasoning endpoints return a degraded response with `[LLM unavailable]` noted
+- **Policy evaluation with no LLM** → defaults to `allowed: true` (fail-open)
+- **Reflexion lesson generation** → skipped; reflection is stored without a lesson
+
+---
+
+## Endpoint Count Summary
+
+| Category | Endpoints |
+|----------|-----------|
+| Core memory | 4 |
+| Memory lifecycle | 9 |
+| Events | 3 |
+| Entities | 5 |
+| Decisions | 2 |
+| Session | 4 |
+| Triggers | 4 |
+| Procedures | 5 |
+| Search & reasoning | 9 |
+| Affect | 7 |
+| Consolidation | 8 |
+| Scheduler | 6 |
+| Knowledge graph | 13 |
+| Admin | 7 |
+| Multi-agent | 6 |
+| Diagnostics | 2 |
+| Context | 5 |
+| Analytics | 5 |
+| Subsystems (6 × 2–3) | 17 |
+| Subsystem meta | 5 |
+| Theory of Mind | 3 |
+| Budget | 4 |
+| Push & webhooks | 5 |
+| **Total** | **153** |

--- a/apps/brainctl/project.json
+++ b/apps/brainctl/project.json
@@ -1,0 +1,70 @@
+{
+  "name": "brainctl",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/brainctl/src",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "dist/apps/brainctl",
+        "format": ["esm"],
+        "bundle": true,
+        "main": "apps/brainctl/src/main.ts",
+        "tsConfig": "apps/brainctl/tsconfig.app.json",
+        "assets": ["apps/brainctl/src/assets"],
+        "generatePackageJson": true,
+        "esbuildOptions": {
+          "sourcemap": true,
+          "outExtension": {
+            ".js": ".js"
+          }
+        }
+      },
+      "configurations": {
+        "development": {},
+        "production": {
+          "thirdParty": false,
+          "esbuildOptions": {
+            "sourcemap": false,
+            "bundle": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "development",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "brainctl:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "brainctl:build:development"
+        },
+        "production": {
+          "buildTarget": "brainctl:build:production"
+        }
+      }
+    },
+    "container": {
+      "dependsOn": ["build"],
+      "executor": "./tools/executors/deploy:container",
+      "options": {
+        "image": "ethanelliottio/brainctl",
+        "dockerfile": "apps/brainctl/Dockerfile",
+        "deployment": "brainctl"
+      }
+    }
+  }
+}

--- a/apps/brainctl/src/app/app.config.ts
+++ b/apps/brainctl/src/app/app.config.ts
@@ -1,0 +1,6 @@
+import { AppConfig } from '@ee/starter';
+
+export const appConfig: AppConfig = {
+  providers: [],
+  port: 3100,
+};

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -20,6 +20,8 @@ import { ContextRoutes } from './routes/context.js';
 import { MemoryLifecycleRoutes } from './routes/memory.lifecycle.js';
 import { AnalyticsRoutes } from './routes/analytics.js';
 import { TomRoutes } from './routes/tom.js';
+import { SubsystemMetaRoutes } from './routes/subsystems.meta.js';
+import { PushRoutes } from './routes/push.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -43,4 +45,6 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryLifecycleRoutes);
   fastify.register(AnalyticsRoutes);
   fastify.register(TomRoutes);
+  fastify.register(SubsystemMetaRoutes);
+  fastify.register(PushRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -19,6 +19,7 @@ import { SubsystemRoutes } from './routes/subsystems.js';
 import { ContextRoutes } from './routes/context.js';
 import { MemoryLifecycleRoutes } from './routes/memory.lifecycle.js';
 import { AnalyticsRoutes } from './routes/analytics.js';
+import { TomRoutes } from './routes/tom.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -41,4 +42,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(ContextRoutes);
   fastify.register(MemoryLifecycleRoutes);
   fastify.register(AnalyticsRoutes);
+  fastify.register(TomRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -10,6 +10,7 @@ import { SearchRoutes } from './routes/search.js';
 import { AffectRoutes } from './routes/affect.js';
 import { DiagnosticsRoutes } from './routes/diagnostics.js';
 import { ConsolidationRoutes } from './routes/consolidation.js';
+import { ReasoningRoutes } from './routes/reasoning.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -23,4 +24,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(AffectRoutes);
   fastify.register(DiagnosticsRoutes);
   fastify.register(ConsolidationRoutes);
+  fastify.register(ReasoningRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -12,6 +12,7 @@ import { DiagnosticsRoutes } from './routes/diagnostics.js';
 import { ConsolidationRoutes } from './routes/consolidation.js';
 import { ReasoningRoutes } from './routes/reasoning.js';
 import { SchedulerRoutes } from './routes/scheduler.js';
+import { GraphRoutes } from './routes/graph.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -27,4 +28,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(ConsolidationRoutes);
   fastify.register(ReasoningRoutes);
   fastify.register(SchedulerRoutes);
+  fastify.register(GraphRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -9,6 +9,7 @@ import { ProcedureRoutes } from './routes/procedures.js';
 import { SearchRoutes } from './routes/search.js';
 import { AffectRoutes } from './routes/affect.js';
 import { DiagnosticsRoutes } from './routes/diagnostics.js';
+import { ConsolidationRoutes } from './routes/consolidation.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -21,4 +22,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(SearchRoutes);
   fastify.register(AffectRoutes);
   fastify.register(DiagnosticsRoutes);
+  fastify.register(ConsolidationRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -13,6 +13,7 @@ import { ConsolidationRoutes } from './routes/consolidation.js';
 import { ReasoningRoutes } from './routes/reasoning.js';
 import { SchedulerRoutes } from './routes/scheduler.js';
 import { GraphRoutes } from './routes/graph.js';
+import { AdminRoutes } from './routes/admin.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -29,4 +30,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(ReasoningRoutes);
   fastify.register(SchedulerRoutes);
   fastify.register(GraphRoutes);
+  fastify.register(AdminRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -17,6 +17,7 @@ import { AdminRoutes } from './routes/admin.js';
 import { AgentRoutes } from './routes/agents.js';
 import { SubsystemRoutes } from './routes/subsystems.js';
 import { ContextRoutes } from './routes/context.js';
+import { MemoryLifecycleRoutes } from './routes/memory.lifecycle.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -37,4 +38,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(AgentRoutes);
   fastify.register(SubsystemRoutes);
   fastify.register(ContextRoutes);
+  fastify.register(MemoryLifecycleRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -11,6 +11,7 @@ import { AffectRoutes } from './routes/affect.js';
 import { DiagnosticsRoutes } from './routes/diagnostics.js';
 import { ConsolidationRoutes } from './routes/consolidation.js';
 import { ReasoningRoutes } from './routes/reasoning.js';
+import { SchedulerRoutes } from './routes/scheduler.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -25,4 +26,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(DiagnosticsRoutes);
   fastify.register(ConsolidationRoutes);
   fastify.register(ReasoningRoutes);
+  fastify.register(SchedulerRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -16,6 +16,7 @@ import { GraphRoutes } from './routes/graph.js';
 import { AdminRoutes } from './routes/admin.js';
 import { AgentRoutes } from './routes/agents.js';
 import { SubsystemRoutes } from './routes/subsystems.js';
+import { ContextRoutes } from './routes/context.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -35,4 +36,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(AdminRoutes);
   fastify.register(AgentRoutes);
   fastify.register(SubsystemRoutes);
+  fastify.register(ContextRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -1,0 +1,24 @@
+import { FastifyInstance } from 'fastify';
+import { MemoryRoutes } from './routes/memory.js';
+import { EventRoutes } from './routes/events.js';
+import { EntityRoutes } from './routes/entities.js';
+import { DecisionRoutes } from './routes/decisions.js';
+import { SessionRoutes } from './routes/session.js';
+import { TriggerRoutes } from './routes/triggers.js';
+import { ProcedureRoutes } from './routes/procedures.js';
+import { SearchRoutes } from './routes/search.js';
+import { AffectRoutes } from './routes/affect.js';
+import { DiagnosticsRoutes } from './routes/diagnostics.js';
+
+export async function Application(fastify: FastifyInstance) {
+  fastify.register(MemoryRoutes);
+  fastify.register(EventRoutes);
+  fastify.register(EntityRoutes);
+  fastify.register(DecisionRoutes);
+  fastify.register(SessionRoutes);
+  fastify.register(TriggerRoutes);
+  fastify.register(ProcedureRoutes);
+  fastify.register(SearchRoutes);
+  fastify.register(AffectRoutes);
+  fastify.register(DiagnosticsRoutes);
+}

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -14,6 +14,7 @@ import { ReasoningRoutes } from './routes/reasoning.js';
 import { SchedulerRoutes } from './routes/scheduler.js';
 import { GraphRoutes } from './routes/graph.js';
 import { AdminRoutes } from './routes/admin.js';
+import { AgentRoutes } from './routes/agents.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -31,4 +32,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(SchedulerRoutes);
   fastify.register(GraphRoutes);
   fastify.register(AdminRoutes);
+  fastify.register(AgentRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -15,6 +15,7 @@ import { SchedulerRoutes } from './routes/scheduler.js';
 import { GraphRoutes } from './routes/graph.js';
 import { AdminRoutes } from './routes/admin.js';
 import { AgentRoutes } from './routes/agents.js';
+import { SubsystemRoutes } from './routes/subsystems.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -33,4 +34,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(GraphRoutes);
   fastify.register(AdminRoutes);
   fastify.register(AgentRoutes);
+  fastify.register(SubsystemRoutes);
 }

--- a/apps/brainctl/src/app/app.ts
+++ b/apps/brainctl/src/app/app.ts
@@ -18,6 +18,7 @@ import { AgentRoutes } from './routes/agents.js';
 import { SubsystemRoutes } from './routes/subsystems.js';
 import { ContextRoutes } from './routes/context.js';
 import { MemoryLifecycleRoutes } from './routes/memory.lifecycle.js';
+import { AnalyticsRoutes } from './routes/analytics.js';
 
 export async function Application(fastify: FastifyInstance) {
   fastify.register(MemoryRoutes);
@@ -39,4 +40,5 @@ export async function Application(fastify: FastifyInstance) {
   fastify.register(SubsystemRoutes);
   fastify.register(ContextRoutes);
   fastify.register(MemoryLifecycleRoutes);
+  fastify.register(AnalyticsRoutes);
 }

--- a/apps/brainctl/src/app/db/database.ts
+++ b/apps/brainctl/src/app/db/database.ts
@@ -2,7 +2,7 @@ import Database from 'better-sqlite3';
 import { readFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { EMBEDDING_DIMENSIONS, isEmbeddingAvailable } from '../services/embeddings.service.js';
+import { EMBEDDING_DIMENSIONS } from '../services/embeddings.service.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
@@ -23,16 +23,33 @@ export function getDb(): Database.Database {
   const schema = readFileSync(join(__dirname, 'schema.sql'), 'utf-8');
   _db.exec(schema);
 
+  runMigrations(_db);
+
   _vecLoaded = tryLoadVec(_db);
-  if (_vecLoaded) {
-    initVecTables(_db);
-  }
+  if (_vecLoaded) initVecTables(_db);
 
   return _db;
 }
 
 export function isVecLoaded(): boolean {
   return _vecLoaded;
+}
+
+// Safe ALTER TABLE for columns added after initial schema deployment.
+// SQLite has no "ADD COLUMN IF NOT EXISTS" — we catch the duplicate-column error.
+function addColumnIfMissing(db: Database.Database, table: string, column: string, definition: string): void {
+  try {
+    db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
+  } catch {
+    // Column already exists — ignore
+  }
+}
+
+function runMigrations(db: Database.Database): void {
+  addColumnIfMissing(db, 'memories', 'recalled_count', 'INTEGER NOT NULL DEFAULT 0');
+  addColumnIfMissing(db, 'memories', 'temporal_class', "TEXT NOT NULL DEFAULT 'medium'");
+  addColumnIfMissing(db, 'memories', 'last_accessed_at', 'TEXT');
+  addColumnIfMissing(db, 'memories', 'compressed_into', 'INTEGER');
 }
 
 function tryLoadVec(db: Database.Database): boolean {
@@ -52,10 +69,8 @@ function initVecTables(db: Database.Database): void {
   db.exec(`
     CREATE VIRTUAL TABLE IF NOT EXISTS vec_memories
       USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
-
     CREATE VIRTUAL TABLE IF NOT EXISTS vec_entities
       USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
-
     CREATE VIRTUAL TABLE IF NOT EXISTS vec_events
       USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
   `);

--- a/apps/brainctl/src/app/db/database.ts
+++ b/apps/brainctl/src/app/db/database.ts
@@ -73,6 +73,8 @@ function initVecTables(db: Database.Database): void {
       USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
     CREATE VIRTUAL TABLE IF NOT EXISTS vec_events
       USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
+    CREATE VIRTUAL TABLE IF NOT EXISTS vec_context
+      USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
   `);
 }
 

--- a/apps/brainctl/src/app/db/database.ts
+++ b/apps/brainctl/src/app/db/database.ts
@@ -50,6 +50,7 @@ function runMigrations(db: Database.Database): void {
   addColumnIfMissing(db, 'memories', 'temporal_class', "TEXT NOT NULL DEFAULT 'medium'");
   addColumnIfMissing(db, 'memories', 'last_accessed_at', 'TEXT');
   addColumnIfMissing(db, 'memories', 'compressed_into', 'INTEGER');
+  addColumnIfMissing(db, 'memories', 'quarantined_at', 'TEXT');
 }
 
 function tryLoadVec(db: Database.Database): boolean {

--- a/apps/brainctl/src/app/db/database.ts
+++ b/apps/brainctl/src/app/db/database.ts
@@ -1,18 +1,18 @@
 import Database from 'better-sqlite3';
-import { readFileSync } from 'fs';
+import { readFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
-import { mkdirSync } from 'fs';
+import { EMBEDDING_DIMENSIONS, isEmbeddingAvailable } from '../services/embeddings.service.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 let _db: Database.Database | null = null;
+let _vecLoaded = false;
 
 export function getDb(): Database.Database {
   if (_db) return _db;
 
   const dbPath = process.env['BRAIN_DB'] ?? join(process.env['HOME'] ?? '/tmp', 'brainctl', 'brain.db');
-
   mkdirSync(dirname(dbPath), { recursive: true });
 
   _db = new Database(dbPath);
@@ -23,12 +23,48 @@ export function getDb(): Database.Database {
   const schema = readFileSync(join(__dirname, 'schema.sql'), 'utf-8');
   _db.exec(schema);
 
+  _vecLoaded = tryLoadVec(_db);
+  if (_vecLoaded) {
+    initVecTables(_db);
+  }
+
   return _db;
+}
+
+export function isVecLoaded(): boolean {
+  return _vecLoaded;
+}
+
+function tryLoadVec(db: Database.Database): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const sqliteVec = require('sqlite-vec');
+    sqliteVec.load(db);
+    return true;
+  } catch {
+    console.warn('[db] sqlite-vec not available — vector search disabled');
+    return false;
+  }
+}
+
+function initVecTables(db: Database.Database): void {
+  const dim = EMBEDDING_DIMENSIONS;
+  db.exec(`
+    CREATE VIRTUAL TABLE IF NOT EXISTS vec_memories
+      USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
+
+    CREATE VIRTUAL TABLE IF NOT EXISTS vec_entities
+      USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
+
+    CREATE VIRTUAL TABLE IF NOT EXISTS vec_events
+      USING vec0(rowid INTEGER PRIMARY KEY, embedding FLOAT[${dim}]);
+  `);
 }
 
 export function closeDb(): void {
   if (_db) {
     _db.close();
     _db = null;
+    _vecLoaded = false;
   }
 }

--- a/apps/brainctl/src/app/db/database.ts
+++ b/apps/brainctl/src/app/db/database.ts
@@ -1,0 +1,34 @@
+import Database from 'better-sqlite3';
+import { readFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { mkdirSync } from 'fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+let _db: Database.Database | null = null;
+
+export function getDb(): Database.Database {
+  if (_db) return _db;
+
+  const dbPath = process.env['BRAIN_DB'] ?? join(process.env['HOME'] ?? '/tmp', 'brainctl', 'brain.db');
+
+  mkdirSync(dirname(dbPath), { recursive: true });
+
+  _db = new Database(dbPath);
+  _db.pragma('journal_mode = WAL');
+  _db.pragma('busy_timeout = 10000');
+  _db.pragma('foreign_keys = ON');
+
+  const schema = readFileSync(join(__dirname, 'schema.sql'), 'utf-8');
+  _db.exec(schema);
+
+  return _db;
+}
+
+export function closeDb(): void {
+  if (_db) {
+    _db.close();
+    _db = null;
+  }
+}

--- a/apps/brainctl/src/app/db/database.ts
+++ b/apps/brainctl/src/app/db/database.ts
@@ -36,7 +36,8 @@ export function isVecLoaded(): boolean {
 }
 
 // Safe ALTER TABLE for columns added after initial schema deployment.
-// SQLite has no "ADD COLUMN IF NOT EXISTS" — we catch the duplicate-column error.
+// SQLite has no "ADD COLUMN IF NOT EXISTS" so we catch the duplicate-column error.
+// This means migrations are idempotent: safe to re-run on every startup.
 function addColumnIfMissing(db: Database.Database, table: string, column: string, definition: string): void {
   try {
     db.exec(`ALTER TABLE ${table} ADD COLUMN ${column} ${definition}`);
@@ -65,6 +66,9 @@ function tryLoadVec(db: Database.Database): boolean {
   }
 }
 
+// Vec tables must be created with the embedding dimension baked in.
+// If LITELLM_EMBEDDING_DIMENSIONS changes, the old vec tables are incompatible
+// and the DB must be re-created or the vec tables dropped and recreated manually.
 function initVecTables(db: Database.Database): void {
   const dim = EMBEDDING_DIMENSIONS;
   db.exec(`

--- a/apps/brainctl/src/app/db/schema.sql
+++ b/apps/brainctl/src/app/db/schema.sql
@@ -10,6 +10,10 @@ CREATE TABLE IF NOT EXISTS memories (
   scope TEXT NOT NULL DEFAULT 'global',
   replay_priority REAL NOT NULL DEFAULT 0.0,
   ripple_tags INTEGER NOT NULL DEFAULT 0,
+  recalled_count INTEGER NOT NULL DEFAULT 0,
+  temporal_class TEXT NOT NULL DEFAULT 'medium',
+  last_accessed_at TEXT,
+  compressed_into INTEGER,
   created_at TEXT NOT NULL DEFAULT (datetime('now')),
   retired_at TEXT
 );
@@ -255,3 +259,16 @@ CREATE TABLE IF NOT EXISTS affect_log (
 );
 
 CREATE INDEX IF NOT EXISTS idx_affect_agent ON affect_log(agent_id);
+
+-- Consolidation run audit log
+CREATE TABLE IF NOT EXISTS consolidation_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  started_at TEXT NOT NULL DEFAULT (datetime('now')),
+  completed_at TEXT,
+  status TEXT NOT NULL DEFAULT 'running',
+  report TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_consolidation_agent ON consolidation_log(agent_id);
+CREATE INDEX IF NOT EXISTS idx_consolidation_status ON consolidation_log(status);

--- a/apps/brainctl/src/app/db/schema.sql
+++ b/apps/brainctl/src/app/db/schema.sql
@@ -1,0 +1,257 @@
+-- Core memory store
+CREATE TABLE IF NOT EXISTS memories (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  content TEXT NOT NULL,
+  category TEXT NOT NULL DEFAULT 'general',
+  tags TEXT,
+  confidence REAL NOT NULL DEFAULT 1.0,
+  memory_type TEXT NOT NULL DEFAULT 'episodic',
+  scope TEXT NOT NULL DEFAULT 'global',
+  replay_priority REAL NOT NULL DEFAULT 0.0,
+  ripple_tags INTEGER NOT NULL DEFAULT 0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  retired_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_memories_agent ON memories(agent_id);
+CREATE INDEX IF NOT EXISTS idx_memories_category ON memories(category);
+CREATE INDEX IF NOT EXISTS idx_memories_type ON memories(memory_type);
+CREATE INDEX IF NOT EXISTS idx_memories_retired ON memories(retired_at);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+  content,
+  category,
+  tags,
+  content='memories',
+  content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories BEGIN
+  INSERT INTO memories_fts(rowid, content, category, tags)
+  VALUES (new.id, new.content, new.category, COALESCE(new.tags, ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories BEGIN
+  INSERT INTO memories_fts(memories_fts, rowid, content, category, tags)
+  VALUES ('delete', old.id, old.content, old.category, COALESCE(old.tags, ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories BEGIN
+  INSERT INTO memories_fts(memories_fts, rowid, content, category, tags)
+  VALUES ('delete', old.id, old.content, old.category, COALESCE(old.tags, ''));
+  INSERT INTO memories_fts(rowid, content, category, tags)
+  VALUES (new.id, new.content, new.category, COALESCE(new.tags, ''));
+END;
+
+-- Named entities with compiled understanding
+CREATE TABLE IF NOT EXISTS entities (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  name TEXT NOT NULL,
+  entity_type TEXT NOT NULL DEFAULT 'concept',
+  properties TEXT,
+  observations TEXT,
+  compiled_truth TEXT,
+  tier INTEGER NOT NULL DEFAULT 1,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_entities_name_agent ON entities(name, agent_id);
+CREATE INDEX IF NOT EXISTS idx_entities_type ON entities(entity_type);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS entities_fts USING fts5(
+  name,
+  entity_type,
+  observations,
+  compiled_truth,
+  content='entities',
+  content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS entities_ai AFTER INSERT ON entities BEGIN
+  INSERT INTO entities_fts(rowid, name, entity_type, observations, compiled_truth)
+  VALUES (new.id, new.name, new.entity_type, COALESCE(new.observations, ''), COALESCE(new.compiled_truth, ''));
+END;
+
+CREATE TRIGGER IF NOT EXISTS entities_au AFTER UPDATE ON entities BEGIN
+  INSERT INTO entities_fts(entities_fts, rowid, name, entity_type, observations, compiled_truth)
+  VALUES ('delete', old.id, old.name, old.entity_type, COALESCE(old.observations, ''), COALESCE(old.compiled_truth, ''));
+  INSERT INTO entities_fts(rowid, name, entity_type, observations, compiled_truth)
+  VALUES (new.id, new.name, new.entity_type, COALESCE(new.observations, ''), COALESCE(new.compiled_truth, ''));
+END;
+
+-- Directed, typed relationships between any records
+CREATE TABLE IF NOT EXISTS knowledge_edges (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  from_type TEXT NOT NULL,
+  from_id INTEGER NOT NULL,
+  relation TEXT NOT NULL,
+  to_type TEXT NOT NULL,
+  to_id INTEGER NOT NULL,
+  weight REAL NOT NULL DEFAULT 1.0,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_edges_from ON knowledge_edges(from_type, from_id);
+CREATE INDEX IF NOT EXISTS idx_edges_to ON knowledge_edges(to_type, to_id);
+CREATE INDEX IF NOT EXISTS idx_edges_relation ON knowledge_edges(relation);
+
+-- Append-only event log
+CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  summary TEXT NOT NULL,
+  event_type TEXT NOT NULL DEFAULT 'observation',
+  project TEXT,
+  importance REAL NOT NULL DEFAULT 0.5,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_agent ON events(agent_id);
+CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
+CREATE INDEX IF NOT EXISTS idx_events_project ON events(project);
+CREATE INDEX IF NOT EXISTS idx_events_created ON events(created_at);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(
+  summary,
+  event_type,
+  project,
+  content='events',
+  content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS events_ai AFTER INSERT ON events BEGIN
+  INSERT INTO events_fts(rowid, summary, event_type, project)
+  VALUES (new.id, new.summary, new.event_type, COALESCE(new.project, ''));
+END;
+
+-- Decisions with rationale
+CREATE TABLE IF NOT EXISTS decisions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  title TEXT NOT NULL,
+  rationale TEXT NOT NULL,
+  project TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_decisions_agent ON decisions(agent_id);
+CREATE INDEX IF NOT EXISTS idx_decisions_project ON decisions(project);
+
+-- Prospective memory triggers
+CREATE TABLE IF NOT EXISTS triggers (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  condition TEXT NOT NULL,
+  keywords TEXT NOT NULL,
+  action TEXT NOT NULL,
+  priority TEXT NOT NULL DEFAULT 'medium',
+  expires TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  fired_at TEXT,
+  active INTEGER NOT NULL DEFAULT 1
+);
+
+CREATE INDEX IF NOT EXISTS idx_triggers_agent ON triggers(agent_id);
+CREATE INDEX IF NOT EXISTS idx_triggers_active ON triggers(active);
+
+-- Session handoff packets
+CREATE TABLE IF NOT EXISTS handoffs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  goal TEXT NOT NULL,
+  current_state TEXT NOT NULL,
+  open_loops TEXT NOT NULL,
+  next_step TEXT NOT NULL,
+  project TEXT,
+  title TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  consumed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_handoffs_agent ON handoffs(agent_id);
+CREATE INDEX IF NOT EXISTS idx_handoffs_project ON handoffs(project);
+CREATE INDEX IF NOT EXISTS idx_handoffs_consumed ON handoffs(consumed_at);
+
+-- Structured procedures / workflows
+CREATE TABLE IF NOT EXISTS procedures (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  goal TEXT NOT NULL,
+  title TEXT,
+  description TEXT NOT NULL DEFAULT '',
+  steps TEXT,
+  procedure_kind TEXT NOT NULL DEFAULT 'workflow',
+  scope TEXT NOT NULL DEFAULT 'global',
+  category TEXT NOT NULL DEFAULT 'convention',
+  confidence REAL NOT NULL DEFAULT 0.9,
+  status TEXT NOT NULL DEFAULT 'active',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_procedures_agent ON procedures(agent_id);
+CREATE INDEX IF NOT EXISTS idx_procedures_status ON procedures(status);
+CREATE INDEX IF NOT EXISTS idx_procedures_scope ON procedures(scope);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS procedures_fts USING fts5(
+  goal,
+  title,
+  description,
+  content='procedures',
+  content_rowid='id'
+);
+
+CREATE TRIGGER IF NOT EXISTS procedures_ai AFTER INSERT ON procedures BEGIN
+  INSERT INTO procedures_fts(rowid, goal, title, description)
+  VALUES (new.id, new.goal, COALESCE(new.title, ''), new.description);
+END;
+
+CREATE TRIGGER IF NOT EXISTS procedures_au AFTER UPDATE ON procedures BEGIN
+  INSERT INTO procedures_fts(procedures_fts, rowid, goal, title, description)
+  VALUES ('delete', old.id, old.goal, COALESCE(old.title, ''), old.description);
+  INSERT INTO procedures_fts(rowid, goal, title, description)
+  VALUES (new.id, new.goal, COALESCE(new.title, ''), new.description);
+END;
+
+-- Procedure execution feedback
+CREATE TABLE IF NOT EXISTS procedure_feedback (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  procedure_id INTEGER NOT NULL REFERENCES procedures(id),
+  success INTEGER NOT NULL DEFAULT 0,
+  usefulness_score REAL,
+  outcome_summary TEXT,
+  errors_seen TEXT,
+  validated INTEGER NOT NULL DEFAULT 0,
+  task_signature TEXT,
+  input_summary TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_procedure ON procedure_feedback(procedure_id);
+
+-- Per-agent key-value state
+CREATE TABLE IF NOT EXISTS agent_state (
+  agent_id TEXT NOT NULL,
+  key TEXT NOT NULL,
+  value TEXT NOT NULL,
+  updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+  PRIMARY KEY (agent_id, key)
+);
+
+-- Affect / emotional valence log
+CREATE TABLE IF NOT EXISTS affect_log (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id TEXT NOT NULL DEFAULT 'default',
+  text TEXT NOT NULL,
+  source TEXT NOT NULL DEFAULT 'observation',
+  valence REAL NOT NULL DEFAULT 0.0,
+  arousal REAL NOT NULL DEFAULT 0.0,
+  dominance REAL NOT NULL DEFAULT 0.0,
+  safety_flags TEXT,
+  created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_affect_agent ON affect_log(agent_id);

--- a/apps/brainctl/src/app/routes/admin.ts
+++ b/apps/brainctl/src/app/routes/admin.ts
@@ -3,6 +3,7 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { getDb } from '../db/database.js';
 import { addMemory } from '../services/memory.service.js';
+import { join } from 'path';
 
 export async function AdminRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -118,6 +119,22 @@ export async function AdminRoutes(fastify: FastifyInstance) {
     })();
 
     return reply.send({ wiped: agentId });
+  });
+
+  // Streaming SQLite backup
+  f.get('/admin/backup', async (_req, reply) => {
+    const srcPath = process.env['BRAIN_DB'] ?? join(process.env['HOME'] ?? '/tmp', 'brainctl', 'brain.db');
+    const tmpPath = `${srcPath}.backup-${Date.now()}.db`;
+    const src = getDb();
+
+    await src.backup(tmpPath);
+
+    const buf = await import('fs/promises').then((fs) => fs.readFile(tmpPath));
+    await import('fs/promises').then((fs) => fs.unlink(tmpPath)).catch(() => {});
+
+    reply.header('Content-Type', 'application/octet-stream');
+    reply.header('Content-Disposition', `attachment; filename="brain-backup-${Date.now()}.db"`);
+    return reply.send(buf);
   });
 
   // Rebuild FTS indexes (useful after bulk imports or corruption)

--- a/apps/brainctl/src/app/routes/admin.ts
+++ b/apps/brainctl/src/app/routes/admin.ts
@@ -1,0 +1,168 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { getDb } from '../db/database.js';
+import { addMemory } from '../services/memory.service.js';
+
+export async function AdminRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // Bulk import memories
+  f.post('/admin/memories/bulk', {
+    schema: {
+      body: z.object({
+        memories: z.array(z.object({
+          content: z.string().min(1),
+          category: z.string().optional(),
+          tags: z.union([z.string(), z.array(z.string())]).optional(),
+          confidence: z.number().min(0).max(1).optional(),
+          memory_type: z.enum(['episodic', 'semantic', 'procedural']).optional(),
+          scope: z.string().optional(),
+        })).min(1).max(1000),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const agentId = req.body.agent_id ?? 'default';
+    const ids: number[] = [];
+    for (const m of req.body.memories) {
+      ids.push(await addMemory({ ...m, agent_id: agentId }));
+    }
+    return reply.status(201).send({ inserted: ids.length, ids });
+  });
+
+  // Purge all retired memories (hard delete)
+  f.delete('/admin/memories/retired', {
+    schema: {
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        older_than_days: z.coerce.number().int().min(1).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const db = getDb();
+    const agentId = req.query.agent_id ?? 'default';
+    let sql = 'DELETE FROM memories WHERE agent_id = @agent_id AND retired_at IS NOT NULL';
+    const params: Record<string, unknown> = { agent_id: agentId };
+
+    if (req.query.older_than_days) {
+      sql += ' AND julianday(\'now\') - julianday(retired_at) > @days';
+      params['days'] = req.query.older_than_days;
+    }
+
+    const result = db.prepare(sql).run(params);
+    return reply.send({ deleted: result.changes });
+  });
+
+  // Export all agent data as JSON
+  f.get('/admin/export', {
+    schema: {
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const db = getDb();
+    const agentId = req.query.agent_id ?? 'default';
+
+    const data = {
+      exported_at: new Date().toISOString(),
+      agent_id: agentId,
+      memories: db.prepare('SELECT * FROM memories WHERE agent_id = ?').all(agentId),
+      events: db.prepare('SELECT * FROM events WHERE agent_id = ?').all(agentId),
+      entities: db.prepare('SELECT * FROM entities WHERE agent_id = ?').all(agentId),
+      decisions: db.prepare('SELECT * FROM decisions WHERE agent_id = ?').all(agentId),
+      procedures: db.prepare('SELECT * FROM procedures WHERE agent_id = ?').all(agentId),
+      triggers: db.prepare('SELECT * FROM triggers WHERE agent_id = ?').all(agentId),
+      handoffs: db.prepare('SELECT * FROM handoffs WHERE agent_id = ?').all(agentId),
+      knowledge_edges: db.prepare(`
+        SELECT ke.* FROM knowledge_edges ke
+        WHERE EXISTS (
+          SELECT 1 FROM memories m WHERE m.id = ke.from_id AND m.agent_id = ?
+          UNION SELECT 1 FROM memories m WHERE m.id = ke.to_id AND m.agent_id = ?
+          UNION SELECT 1 FROM entities e WHERE e.id = ke.from_id AND e.agent_id = ?
+          UNION SELECT 1 FROM entities e WHERE e.id = ke.to_id AND e.agent_id = ?
+        )
+      `).all(agentId, agentId, agentId, agentId),
+    };
+
+    reply.header('Content-Disposition', `attachment; filename="brain-${agentId}-${Date.now()}.json"`);
+    return reply.send(data);
+  });
+
+  // Wipe all data for an agent (irreversible — requires confirm=true)
+  f.delete('/admin/agent', {
+    schema: {
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        confirm: z.literal('true'),
+      }),
+    },
+  }, async (req, reply) => {
+    const db = getDb();
+    const agentId = req.query.agent_id ?? 'default';
+
+    const tables = ['memories', 'events', 'entities', 'decisions', 'procedures',
+      'procedure_feedback', 'triggers', 'handoffs', 'agent_state', 'affect_log', 'consolidation_log'];
+
+    db.transaction(() => {
+      for (const table of tables) {
+        db.prepare(`DELETE FROM ${table} WHERE agent_id = ?`).run(agentId);
+      }
+      // Remove edges where both endpoints belonged to this agent (best effort)
+      db.prepare(`
+        DELETE FROM knowledge_edges WHERE from_id IN (
+          SELECT id FROM memories WHERE agent_id = ?
+        ) OR to_id IN (
+          SELECT id FROM memories WHERE agent_id = ?
+        )
+      `).run(agentId, agentId);
+    })();
+
+    return reply.send({ wiped: agentId });
+  });
+
+  // Rebuild FTS indexes (useful after bulk imports or corruption)
+  f.post('/admin/reindex', {
+    schema: {
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (_req, reply) => {
+    const db = getDb();
+    db.exec(`
+      INSERT INTO memories_fts(memories_fts) VALUES('rebuild');
+      INSERT INTO entities_fts(entities_fts) VALUES('rebuild');
+      INSERT INTO events_fts(events_fts) VALUES('rebuild');
+      INSERT INTO procedures_fts(procedures_fts) VALUES('rebuild');
+    `);
+    return reply.send({ reindexed: true });
+  });
+
+  // Memory stats broken down by category and type
+  f.get('/admin/breakdown', {
+    schema: {
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const db = getDb();
+    const agentId = req.query.agent_id ?? 'default';
+
+    const byCategory = db.prepare(`
+      SELECT category, memory_type, COUNT(*) AS count, AVG(confidence) AS avg_confidence
+      FROM memories WHERE agent_id = ? AND retired_at IS NULL
+      GROUP BY category, memory_type ORDER BY count DESC
+    `).all(agentId);
+
+    const byTemporalClass = db.prepare(`
+      SELECT temporal_class, COUNT(*) AS count, AVG(confidence) AS avg_confidence
+      FROM memories WHERE agent_id = ? AND retired_at IS NULL
+      GROUP BY temporal_class
+    `).all(agentId);
+
+    const topAccessed = db.prepare(`
+      SELECT id, content, recalled_count, last_accessed_at, confidence
+      FROM memories WHERE agent_id = ? AND retired_at IS NULL
+      ORDER BY recalled_count DESC LIMIT 20
+    `).all(agentId);
+
+    return reply.send({ by_category: byCategory, by_temporal_class: byTemporalClass, top_accessed: topAccessed });
+  });
+}

--- a/apps/brainctl/src/app/routes/affect.ts
+++ b/apps/brainctl/src/app/routes/affect.ts
@@ -1,0 +1,28 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { classifyAffect, logAffect } from '../services/affect.service.js';
+
+export async function AffectRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.post('/affect', {
+    schema: {
+      body: z.object({
+        text: z.string().min(1),
+        source: z.string().optional(),
+        agent_id: z.string().optional(),
+        store: z.boolean().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const result = classifyAffect(req.body.text);
+
+    if (req.body.store) {
+      const id = logAffect(req.body.text, req.body.source ?? 'observation', req.body.agent_id);
+      return reply.send({ ...result, stored_id: id });
+    }
+
+    return reply.send(result);
+  });
+}

--- a/apps/brainctl/src/app/routes/affect.ts
+++ b/apps/brainctl/src/app/routes/affect.ts
@@ -1,7 +1,11 @@
 import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { classifyAffect, logAffect } from '../services/affect.service.js';
+import {
+  classifyAffect, logAffect,
+  getAffectState, getAffectHistory,
+  setThreshold, listThresholds, deleteThreshold, checkThresholds,
+} from '../services/affect.service.js';
 
 export async function AffectRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -24,5 +28,77 @@ export async function AffectRoutes(fastify: FastifyInstance) {
     }
 
     return reply.send(result);
+  });
+
+  // Current rolling affect state for an agent
+  f.get('/affect/state', {
+    schema: {
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        window_minutes: z.coerce.number().int().min(1).max(10080).optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.send(getAffectState(req.query.agent_id ?? 'default', req.query.window_minutes ?? 60)));
+
+  // Recent affect log entries
+  f.get('/affect/history', {
+    schema: {
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(500).optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.send(getAffectHistory(req.query.agent_id ?? 'default', req.query.limit ?? 50)));
+
+  // Upsert a threshold for a metric (valence, arousal, or dominance)
+  f.put('/affect/thresholds/:metric', {
+    schema: {
+      params: z.object({ metric: z.enum(['valence', 'arousal', 'dominance']) }),
+      body: z.object({
+        operator: z.enum(['>', '<', '>=', '<=', '==', '=']),
+        value: z.number().min(-1).max(1),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const id = setThreshold(
+      req.body.agent_id ?? 'default',
+      req.params.metric,
+      req.body.operator,
+      req.body.value,
+    );
+    return reply.send({ id });
+  });
+
+  // List thresholds
+  f.get('/affect/thresholds', {
+    schema: { querystring: z.object({ agent_id: z.string().optional() }) },
+  }, async (req, reply) => reply.send(listThresholds(req.query.agent_id ?? 'default')));
+
+  // Delete a threshold
+  f.delete('/affect/thresholds/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const deleted = deleteThreshold(req.query.agent_id ?? 'default', req.params.id);
+    return reply.send({ deleted });
+  });
+
+  // Check current affect state against all configured thresholds
+  f.get('/affect/monitor', {
+    schema: {
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        window_minutes: z.coerce.number().int().min(1).max(10080).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const breaches = checkThresholds(req.query.agent_id ?? 'default', req.query.window_minutes ?? 60);
+    const any_breach = breaches.some((b) => b.breached);
+    return reply.send({ any_breach, breaches });
   });
 }

--- a/apps/brainctl/src/app/routes/agents.ts
+++ b/apps/brainctl/src/app/routes/agents.ts
@@ -1,0 +1,169 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { getDb } from '../db/database.js';
+import { addMemory } from '../services/memory.service.js';
+
+export async function AgentRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // List all known agents (discovered from data across all tables)
+  f.get('/agents', async (_req, reply) => {
+    const db = getDb();
+    const agents = db.prepare(`
+      SELECT agent_id,
+        (SELECT COUNT(*) FROM memories WHERE agent_id = a.agent_id AND retired_at IS NULL) AS memories,
+        (SELECT COUNT(*) FROM events WHERE agent_id = a.agent_id) AS events,
+        (SELECT COUNT(*) FROM entities WHERE agent_id = a.agent_id) AS entities,
+        (SELECT MAX(created_at) FROM memories WHERE agent_id = a.agent_id) AS last_memory_at,
+        (SELECT MAX(created_at) FROM events WHERE agent_id = a.agent_id) AS last_event_at
+      FROM (
+        SELECT DISTINCT agent_id FROM memories
+        UNION SELECT DISTINCT agent_id FROM events
+        UNION SELECT DISTINCT agent_id FROM entities
+        UNION SELECT DISTINCT agent_id FROM handoffs
+      ) a
+      ORDER BY last_memory_at DESC NULLS LAST
+    `).all();
+    return reply.send(agents);
+  });
+
+  // Get/set per-agent key-value state
+  f.get('/agents/:id/state', {
+    schema: {
+      params: z.object({ id: z.string() }),
+      querystring: z.object({ key: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const db = getDb();
+    if (req.query.key) {
+      const row = db.prepare('SELECT value FROM agent_state WHERE agent_id = ? AND key = ?')
+        .get(req.params.id, req.query.key) as { value: string } | undefined;
+      return reply.send(row ? { key: req.query.key, value: JSON.parse(row.value) } : null);
+    }
+    const rows = db.prepare('SELECT key, value FROM agent_state WHERE agent_id = ?')
+      .all(req.params.id) as Array<{ key: string; value: string }>;
+    return reply.send(Object.fromEntries(rows.map((r) => [r.key, JSON.parse(r.value)])));
+  });
+
+  f.put('/agents/:id/state', {
+    schema: {
+      params: z.object({ id: z.string() }),
+      body: z.record(z.unknown()),
+    },
+  }, async (req, reply) => {
+    const db = getDb();
+    const agentId = req.params.id;
+    const upsert = db.prepare(`
+      INSERT INTO agent_state (agent_id, key, value, updated_at)
+      VALUES (?, ?, ?, datetime('now'))
+      ON CONFLICT (agent_id, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at
+    `);
+    db.transaction(() => {
+      for (const [key, val] of Object.entries(req.body)) {
+        upsert.run(agentId, key, JSON.stringify(val));
+      }
+    })();
+    return reply.send({ updated: Object.keys(req.body).length });
+  });
+
+  f.delete('/agents/:id/state/:key', {
+    schema: { params: z.object({ id: z.string(), key: z.string() }) },
+  }, async (req, reply) => {
+    const db = getDb();
+    const result = db.prepare('DELETE FROM agent_state WHERE agent_id = ? AND key = ?')
+      .run(req.params.id, req.params.key);
+    return reply.send({ deleted: result.changes > 0 });
+  });
+
+  // Cross-agent memory sharing: copy memories from one agent to another
+  f.post('/agents/:id/share', {
+    schema: {
+      params: z.object({ id: z.string() }),
+      body: z.object({
+        to_agent: z.string().min(1),
+        memory_ids: z.array(z.number().int()).min(1).max(500).optional(),
+        category: z.string().optional(),
+        scope: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const db = getDb();
+    const fromAgent = req.params.id;
+    const toAgent = req.body.to_agent;
+
+    let sql = 'SELECT * FROM memories WHERE agent_id = @from AND retired_at IS NULL';
+    const params: Record<string, unknown> = { from: fromAgent };
+
+    if (req.body.memory_ids?.length) {
+      sql += ` AND id IN (${req.body.memory_ids.map(() => '?').join(',')})`;
+    }
+    if (req.body.category) { sql += ' AND category = @cat'; params['cat'] = req.body.category; }
+    if (req.body.scope) { sql += ' AND scope = @scope'; params['scope'] = req.body.scope; }
+
+    const stmt = req.body.memory_ids?.length
+      ? db.prepare(sql.replace('?', req.body.memory_ids.map(() => '?').join(',')))
+      : db.prepare(sql);
+
+    const memories = req.body.memory_ids?.length
+      ? stmt.all(...Object.values(params), ...req.body.memory_ids)
+      : stmt.all(params);
+
+    const ids: number[] = [];
+    for (const m of memories as any[]) {
+      ids.push(await addMemory({
+        content: m.content,
+        category: m.category,
+        tags: m.tags,
+        confidence: m.confidence,
+        memory_type: m.memory_type,
+        scope: m.scope,
+        agent_id: toAgent,
+      }));
+    }
+
+    return reply.status(201).send({ shared: ids.length, ids });
+  });
+
+  // Agent-to-agent handoff: get the sender's latest handoff and surface it for the recipient
+  f.post('/agents/:id/transfer', {
+    schema: {
+      params: z.object({ id: z.string() }),
+      body: z.object({
+        to_agent: z.string().min(1),
+        project: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const db = getDb();
+    const fromAgent = req.params.id;
+    const toAgent = req.body.to_agent;
+
+    const handoff = db.prepare(`
+      SELECT * FROM handoffs
+      WHERE agent_id = @agent_id AND consumed_at IS NULL
+      ${req.body.project ? 'AND project = @project' : ''}
+      ORDER BY created_at DESC LIMIT 1
+    `).get({ agent_id: fromAgent, ...(req.body.project ? { project: req.body.project } : {}) }) as any;
+
+    if (!handoff) return reply.status(404).send({ error: 'No pending handoff for source agent' });
+
+    const result = db.prepare(`
+      INSERT INTO handoffs (agent_id, goal, current_state, open_loops, next_step, project, title)
+      VALUES (@agent_id, @goal, @current_state, @open_loops, @next_step, @project, @title)
+    `).run({
+      agent_id: toAgent,
+      goal: handoff.goal,
+      current_state: handoff.current_state,
+      open_loops: handoff.open_loops,
+      next_step: handoff.next_step,
+      project: handoff.project,
+      title: `[transferred from ${fromAgent}] ${handoff.title ?? ''}`.trim(),
+    });
+
+    // Mark original consumed
+    db.prepare('UPDATE handoffs SET consumed_at = datetime(\'now\') WHERE id = ?').run(handoff.id);
+
+    return reply.status(201).send({ handoff_id: result.lastInsertRowid, to_agent: toAgent });
+  });
+}

--- a/apps/brainctl/src/app/routes/analytics.ts
+++ b/apps/brainctl/src/app/routes/analytics.ts
@@ -1,0 +1,61 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  validateDatabase, freeEnergyCheck, allostaticPrime,
+  demandForecast, retrievalEffectiveness,
+} from '../services/analytics.service.js';
+
+const AgentQ = z.object({ agent_id: z.string().optional() });
+
+export async function AnalyticsRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // validate / lint — deep DB consistency check
+  f.get('/analytics/validate', {
+    schema: { querystring: AgentQ },
+  }, async (req, reply) => {
+    const result = validateDatabase(req.query.agent_id ?? 'default');
+    return reply.status(result.valid ? 200 : 207).send(result);
+  });
+
+  // free_energy_check — homeostatic memory pressure metric
+  f.get('/analytics/free-energy', {
+    schema: {
+      querystring: AgentQ.extend({
+        capacity_target: z.coerce.number().int().min(100).optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.send(freeEnergyCheck(req.query.agent_id ?? 'default', req.query.capacity_target)));
+
+  // allostatic_prime — memories near decay threshold
+  f.get('/analytics/allostatic-prime', {
+    schema: {
+      querystring: AgentQ.extend({ limit: z.coerce.number().int().min(1).max(100).optional() }),
+    },
+  }, async (req, reply) =>
+    reply.send(allostaticPrime(req.query.agent_id ?? 'default', req.query.limit)));
+
+  // demand_forecast — predicted high-access memories
+  f.get('/analytics/demand-forecast', {
+    schema: {
+      querystring: AgentQ.extend({ limit: z.coerce.number().int().min(1).max(100).optional() }),
+    },
+  }, async (req, reply) =>
+    reply.send(demandForecast(req.query.agent_id ?? 'default', req.query.limit)));
+
+  // retrieval_effectiveness — offline precision/recall testing
+  f.post('/analytics/retrieval-effectiveness', {
+    schema: {
+      body: z.object({
+        test_cases: z.array(z.object({
+          query: z.string().min(1),
+          expected_ids: z.array(z.number().int()).min(1),
+        })).min(1).max(50),
+        k: z.number().int().min(1).max(50).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send(await retrievalEffectiveness(req.body)));
+}

--- a/apps/brainctl/src/app/routes/consolidation.ts
+++ b/apps/brainctl/src/app/routes/consolidation.ts
@@ -1,0 +1,109 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  runConsolidationCycle,
+  runDecayPass,
+  runPromotionPass,
+  runCompressionPass,
+  runHebbianPass,
+  runGapScanPass,
+  runEntityTierPass,
+  getLastConsolidation,
+  getConsolidationHistory,
+} from '../services/consolidation.service.js';
+
+const PassEnum = z.enum(['decay', 'promote', 'compress', 'hebbian', 'gap_scan', 'entity_tiers']);
+
+const ConsolidationOptionsSchema = z.object({
+  agent_id: z.string().optional(),
+  dry_run: z.boolean().optional(),
+  batch_limit: z.coerce.number().int().min(1).max(5000).optional(),
+  decay_rate: z.number().min(0).max(1).optional(),
+  protect_confidence: z.number().min(0).max(1).optional(),
+  protect_recall_min: z.coerce.number().int().optional(),
+  retire_threshold: z.number().min(0).max(1).optional(),
+  promote_min_priority: z.number().min(0).max(1).optional(),
+  promote_min_ripple_tags: z.coerce.number().int().optional(),
+  promote_min_confidence: z.number().min(0).max(1).optional(),
+  compression_min_cluster: z.coerce.number().int().min(2).optional(),
+  vec_similarity_threshold: z.number().min(0).max(2).optional(),
+  fts_overlap_threshold: z.number().min(0).max(1).optional(),
+  hebbian_boost: z.number().min(0).max(1).optional(),
+  hebbian_decay: z.number().min(0).max(1).optional(),
+  prune_threshold: z.number().min(0).max(1).optional(),
+  passes: z.array(PassEnum).optional(),
+});
+
+export async function ConsolidationRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // Run a full consolidation cycle (all or selected passes)
+  f.post('/consolidation/run', {
+    schema: {
+      body: ConsolidationOptionsSchema,
+    },
+  }, async (req, reply) => {
+    const { agent_id, ...opts } = req.body;
+    const report = await runConsolidationCycle(agent_id ?? 'default', opts);
+    return reply.send(report);
+  });
+
+  // Status: last run + history
+  f.get('/consolidation/status', {
+    schema: {
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        history: z.coerce.number().int().min(1).max(50).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const agentId = req.query.agent_id ?? 'default';
+    const last = getLastConsolidation(agentId);
+    const history = getConsolidationHistory(agentId, req.query.history ?? 10);
+    return reply.send({ last, history });
+  });
+
+  // Individual pass endpoints — useful for targeted runs or debugging
+  f.post('/consolidation/decay', {
+    schema: { body: ConsolidationOptionsSchema },
+  }, async (req, reply) => {
+    const { agent_id, ...opts } = req.body;
+    return reply.send(runDecayPass(agent_id ?? 'default', opts));
+  });
+
+  f.post('/consolidation/promote', {
+    schema: { body: ConsolidationOptionsSchema },
+  }, async (req, reply) => {
+    const { agent_id, ...opts } = req.body;
+    return reply.send(runPromotionPass(agent_id ?? 'default', opts));
+  });
+
+  f.post('/consolidation/compress', {
+    schema: { body: ConsolidationOptionsSchema },
+  }, async (req, reply) => {
+    const { agent_id, ...opts } = req.body;
+    return reply.send(await runCompressionPass(agent_id ?? 'default', opts));
+  });
+
+  f.post('/consolidation/hebbian', {
+    schema: { body: ConsolidationOptionsSchema },
+  }, async (req, reply) => {
+    const { agent_id, ...opts } = req.body;
+    return reply.send(runHebbianPass(agent_id ?? 'default', opts));
+  });
+
+  f.post('/consolidation/gap-scan', {
+    schema: { body: ConsolidationOptionsSchema },
+  }, async (req, reply) => {
+    const { agent_id, ...opts } = req.body;
+    return reply.send(runGapScanPass(agent_id ?? 'default', opts));
+  });
+
+  f.post('/consolidation/entity-tiers', {
+    schema: { body: ConsolidationOptionsSchema },
+  }, async (req, reply) => {
+    const { agent_id, ...opts } = req.body;
+    return reply.send(runEntityTierPass(agent_id ?? 'default', opts));
+  });
+}

--- a/apps/brainctl/src/app/routes/context.ts
+++ b/apps/brainctl/src/app/routes/context.ts
@@ -2,7 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import {
-  ingestDocument, getDocument, listDocuments, deleteDocument, searchContext,
+  ingestDocument, getDocument, listDocuments, deleteDocument, searchContext, getChunk,
 } from '../services/context.service.js';
 
 const AgentQ = z.object({ agent_id: z.string().optional() });
@@ -42,6 +42,21 @@ export async function ContextRoutes(fastify: FastifyInstance) {
     const chunks = getDocument(req.params.document, req.query.agent_id ?? 'default');
     if (!chunks.length) return reply.status(404).send({ error: 'Document not found' });
     return reply.send(chunks);
+  });
+
+  // Retrieve a specific chunk by index
+  f.get('/context/:document/:chunk_index', {
+    schema: {
+      params: z.object({
+        document: z.string().min(1),
+        chunk_index: z.coerce.number().int().min(0),
+      }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const chunk = getChunk(req.params.document, req.params.chunk_index, req.query.agent_id ?? 'default');
+    if (!chunk) return reply.status(404).send({ error: 'Chunk not found' });
+    return reply.send(chunk);
   });
 
   // Delete a document and all its chunks

--- a/apps/brainctl/src/app/routes/context.ts
+++ b/apps/brainctl/src/app/routes/context.ts
@@ -1,0 +1,69 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  ingestDocument, getDocument, listDocuments, deleteDocument, searchContext,
+} from '../services/context.service.js';
+
+const AgentQ = z.object({ agent_id: z.string().optional() });
+
+export async function ContextRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // Ingest (or re-ingest) a named document — auto-chunks by word count
+  f.put('/context/:document', {
+    schema: {
+      params: z.object({ document: z.string().min(1) }),
+      body: z.object({
+        content: z.string().min(1),
+        chunk_size: z.number().int().min(50).max(2000).optional(),
+        overlap: z.number().int().min(0).max(500).optional(),
+        metadata: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const result = await ingestDocument({ document: req.params.document, ...req.body });
+    return reply.status(201).send(result);
+  });
+
+  // List all documents for an agent
+  f.get('/context', {
+    schema: { querystring: AgentQ },
+  }, async (req, reply) => reply.send(listDocuments(req.query.agent_id ?? 'default')));
+
+  // Retrieve all chunks for a document
+  f.get('/context/:document', {
+    schema: {
+      params: z.object({ document: z.string().min(1) }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const chunks = getDocument(req.params.document, req.query.agent_id ?? 'default');
+    if (!chunks.length) return reply.status(404).send({ error: 'Document not found' });
+    return reply.send(chunks);
+  });
+
+  // Delete a document and all its chunks
+  f.delete('/context/:document', {
+    schema: {
+      params: z.object({ document: z.string().min(1) }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const deleted = deleteDocument(req.params.document, req.query.agent_id ?? 'default');
+    return reply.send({ deleted });
+  });
+
+  // Hybrid semantic search over context chunks
+  f.post('/context/search', {
+    schema: {
+      body: z.object({
+        query: z.string().min(1),
+        document: z.string().optional(),
+        limit: z.number().int().min(1).max(50).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send(await searchContext(req.body)));
+}

--- a/apps/brainctl/src/app/routes/decisions.ts
+++ b/apps/brainctl/src/app/routes/decisions.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { createDecision, listDecisions } from '../services/decision.service.js';
+import { createDecision, listDecisions, getDecision, deleteDecision } from '../services/decision.service.js';
 
 export async function DecisionRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -21,6 +21,28 @@ export async function DecisionRoutes(fastify: FastifyInstance) {
   }, async (req, reply) => {
     const id = createDecision(req.body);
     return reply.status(201).send({ id });
+  });
+
+  f.get('/decisions/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const decision = getDecision(req.params.id, req.query.agent_id ?? 'default');
+    if (!decision) return reply.status(404).send({ error: 'Decision not found' });
+    return reply.send(decision);
+  });
+
+  f.delete('/decisions/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const deleted = deleteDecision(req.params.id, req.query.agent_id ?? 'default');
+    if (!deleted) return reply.status(404).send({ error: 'Decision not found' });
+    return reply.send({ deleted });
   });
 
   f.get('/decisions', {

--- a/apps/brainctl/src/app/routes/decisions.ts
+++ b/apps/brainctl/src/app/routes/decisions.ts
@@ -1,0 +1,38 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { createDecision, listDecisions } from '../services/decision.service.js';
+
+export async function DecisionRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.post('/decisions', {
+    schema: {
+      body: z.object({
+        title: z.string().min(1),
+        rationale: z.string().min(1),
+        project: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        201: z.object({ id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const id = createDecision(req.body);
+    return reply.status(201).send({ id });
+  });
+
+  f.get('/decisions', {
+    schema: {
+      querystring: z.object({
+        project: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = listDecisions(req.query.agent_id, req.query.project, req.query.limit);
+    return reply.send(results);
+  });
+}

--- a/apps/brainctl/src/app/routes/diagnostics.ts
+++ b/apps/brainctl/src/app/routes/diagnostics.ts
@@ -1,0 +1,27 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { getStats, checkHealth } from '../services/diagnostics.service.js';
+
+export async function DiagnosticsRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.get('/health', {
+    schema: {
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const health = checkHealth(req.query.agent_id);
+    const status = health.healthy ? 200 : 503;
+    return reply.status(status).send(health);
+  });
+
+  f.get('/stats', {
+    schema: {
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const stats = getStats(req.query.agent_id);
+    return reply.send(stats);
+  });
+}

--- a/apps/brainctl/src/app/routes/diagnostics.ts
+++ b/apps/brainctl/src/app/routes/diagnostics.ts
@@ -3,12 +3,31 @@ import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { getStats, checkHealth } from '../services/diagnostics.service.js';
 
+const HealthSchema = z.object({
+  ok: z.boolean(),
+  healthy: z.boolean(),
+  issues: z.array(z.string()),
+  fts5_available: z.boolean(),
+  vec_available: z.boolean(),
+  embedding_available: z.boolean(),
+  embedding_dimensions: z.number(),
+  embedding_model: z.string(),
+  db_size_mb: z.number(),
+  db_path: z.string(),
+}).passthrough();
+
+const StatsSchema = z.record(z.unknown());
+
 export async function DiagnosticsRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
 
   f.get('/health', {
     schema: {
       querystring: z.object({ agent_id: z.string().optional() }),
+      response: {
+        200: HealthSchema,
+        503: HealthSchema,
+      },
     },
   }, async (req, reply) => {
     const health = checkHealth(req.query.agent_id);
@@ -19,6 +38,9 @@ export async function DiagnosticsRoutes(fastify: FastifyInstance) {
   f.get('/stats', {
     schema: {
       querystring: z.object({ agent_id: z.string().optional() }),
+      response: {
+        200: StatsSchema,
+      },
     },
   }, async (req, reply) => {
     const stats = getStats(req.query.agent_id);

--- a/apps/brainctl/src/app/routes/entities.ts
+++ b/apps/brainctl/src/app/routes/entities.ts
@@ -1,0 +1,89 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  createOrGetEntity,
+  getEntity,
+  searchEntities,
+  relateEntities,
+  getEntityRelations,
+} from '../services/entity.service.js';
+
+export async function EntityRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.post('/entities', {
+    schema: {
+      body: z.object({
+        name: z.string().min(1),
+        entity_type: z.string().optional(),
+        properties: z.record(z.unknown()).optional(),
+        observations: z.array(z.string()).optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        201: z.object({ id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const id = createOrGetEntity(req.body);
+    return reply.status(201).send({ id });
+  });
+
+  f.get('/entities/search', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        entity_type: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = searchEntities({
+      query: req.query.q,
+      limit: req.query.limit,
+      entity_type: req.query.entity_type,
+      agent_id: req.query.agent_id,
+    });
+    return reply.send(results);
+  });
+
+  f.get('/entities/:name', {
+    schema: {
+      params: z.object({ name: z.string() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const entity = getEntity(req.params.name, req.query.agent_id);
+    if (!entity) return reply.status(404).send({ error: 'Entity not found' });
+    return reply.send(entity);
+  });
+
+  f.get('/entities/:name/relations', {
+    schema: {
+      params: z.object({ name: z.string() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const relations = getEntityRelations(req.params.name, req.query.agent_id);
+    return reply.send(relations);
+  });
+
+  f.post('/entities/relate', {
+    schema: {
+      body: z.object({
+        from: z.string().min(1),
+        relation: z.string().min(1),
+        to: z.string().min(1),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        200: z.object({ ok: z.boolean() }),
+      },
+    },
+  }, async (req, reply) => {
+    relateEntities(req.body.from, req.body.relation, req.body.to, req.body.agent_id);
+    return reply.send({ ok: true });
+  });
+}

--- a/apps/brainctl/src/app/routes/entities.ts
+++ b/apps/brainctl/src/app/routes/entities.ts
@@ -8,6 +8,7 @@ import {
   relateEntities,
   getEntityRelations,
 } from '../services/entity.service.js';
+import { EntitySchema, ErrorSchema } from '../schemas.js';
 
 export async function EntityRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -38,6 +39,9 @@ export async function EntityRoutes(fastify: FastifyInstance) {
         entity_type: z.string().optional(),
         agent_id: z.string().optional(),
       }),
+      response: {
+        200: z.array(EntitySchema),
+      },
     },
   }, async (req, reply) => {
     const results = searchEntities({
@@ -53,6 +57,10 @@ export async function EntityRoutes(fastify: FastifyInstance) {
     schema: {
       params: z.object({ name: z.string() }),
       querystring: z.object({ agent_id: z.string().optional() }),
+      response: {
+        200: EntitySchema,
+        404: ErrorSchema,
+      },
     },
   }, async (req, reply) => {
     const entity = getEntity(req.params.name, req.query.agent_id);

--- a/apps/brainctl/src/app/routes/entities.ts
+++ b/apps/brainctl/src/app/routes/entities.ts
@@ -7,6 +7,8 @@ import {
   searchEntities,
   relateEntities,
   getEntityRelations,
+  updateEntity,
+  deleteEntity,
 } from '../services/entity.service.js';
 import { EntitySchema, ErrorSchema } from '../schemas.js';
 
@@ -76,6 +78,36 @@ export async function EntityRoutes(fastify: FastifyInstance) {
   }, async (req, reply) => {
     const relations = getEntityRelations(req.params.name, req.query.agent_id);
     return reply.send(relations);
+  });
+
+  f.patch('/entities/:name', {
+    schema: {
+      params: z.object({ name: z.string() }),
+      body: z.object({
+        entity_type: z.string().optional(),
+        properties: z.record(z.unknown()).optional(),
+        observations: z.array(z.string()).optional(),
+        compiled_truth: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: { 200: z.object({ updated: z.boolean() }), 404: ErrorSchema },
+    },
+  }, async (req, reply) => {
+    const updated = await updateEntity(req.params.name, req.body);
+    if (!updated) return reply.status(404).send({ error: 'Entity not found' });
+    return reply.send({ updated });
+  });
+
+  f.delete('/entities/:name', {
+    schema: {
+      params: z.object({ name: z.string() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+      response: { 200: z.object({ deleted: z.boolean() }), 404: ErrorSchema },
+    },
+  }, async (req, reply) => {
+    const deleted = deleteEntity(req.params.name, req.query.agent_id ?? 'default');
+    if (!deleted) return reply.status(404).send({ error: 'Entity not found' });
+    return reply.send({ deleted });
   });
 
   f.post('/entities/relate', {

--- a/apps/brainctl/src/app/routes/entities.ts
+++ b/apps/brainctl/src/app/routes/entities.ts
@@ -26,7 +26,7 @@ export async function EntityRoutes(fastify: FastifyInstance) {
       },
     },
   }, async (req, reply) => {
-    const id = createOrGetEntity(req.body);
+    const id = await createOrGetEntity(req.body);
     return reply.status(201).send({ id });
   });
 

--- a/apps/brainctl/src/app/routes/events.ts
+++ b/apps/brainctl/src/app/routes/events.ts
@@ -20,7 +20,7 @@ export async function EventRoutes(fastify: FastifyInstance) {
       },
     },
   }, async (req, reply) => {
-    const id = logEvent(req.body);
+    const id = await logEvent(req.body);
     return reply.status(201).send({ id });
   });
 
@@ -35,7 +35,7 @@ export async function EventRoutes(fastify: FastifyInstance) {
       }),
     },
   }, async (req, reply) => {
-    const results = searchEvents({
+    const results = await searchEvents({
       query: req.query.q,
       limit: req.query.limit,
       event_type: req.query.event_type,

--- a/apps/brainctl/src/app/routes/events.ts
+++ b/apps/brainctl/src/app/routes/events.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { logEvent, searchEvents, getRecentEvents } from '../services/event.service.js';
+import { EventSchema } from '../schemas.js';
 
 export async function EventRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -33,6 +34,9 @@ export async function EventRoutes(fastify: FastifyInstance) {
         project: z.string().optional(),
         agent_id: z.string().optional(),
       }),
+      response: {
+        200: z.array(EventSchema),
+      },
     },
   }, async (req, reply) => {
     const results = await searchEvents({
@@ -51,6 +55,9 @@ export async function EventRoutes(fastify: FastifyInstance) {
         limit: z.coerce.number().int().min(1).max(100).optional(),
         agent_id: z.string().optional(),
       }),
+      response: {
+        200: z.array(EventSchema),
+      },
     },
   }, async (req, reply) => {
     const results = getRecentEvents(req.query.agent_id, req.query.limit);

--- a/apps/brainctl/src/app/routes/events.ts
+++ b/apps/brainctl/src/app/routes/events.ts
@@ -1,11 +1,46 @@
 import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { logEvent, searchEvents, getRecentEvents } from '../services/event.service.js';
+import { logEvent, searchEvents, getRecentEvents, getEvent, deleteEvent, listEvents } from '../services/event.service.js';
 import { EventSchema } from '../schemas.js';
 
 export async function EventRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.get('/events', {
+    schema: {
+      querystring: z.object({
+        event_type: z.string().optional(),
+        project: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(500).optional(),
+        offset: z.coerce.number().int().min(0).optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: { 200: z.array(EventSchema) },
+    },
+  }, async (req, reply) => reply.send(listEvents(req.query)));
+
+  f.get('/events/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const event = getEvent(req.params.id, req.query.agent_id ?? 'default');
+    if (!event) return reply.status(404).send({ error: 'Event not found' });
+    return reply.send(event);
+  });
+
+  f.delete('/events/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const deleted = deleteEvent(req.params.id, req.query.agent_id ?? 'default');
+    if (!deleted) return reply.status(404).send({ error: 'Event not found' });
+    return reply.send({ deleted });
+  });
 
   f.post('/events', {
     schema: {

--- a/apps/brainctl/src/app/routes/events.ts
+++ b/apps/brainctl/src/app/routes/events.ts
@@ -1,0 +1,59 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { logEvent, searchEvents, getRecentEvents } from '../services/event.service.js';
+
+export async function EventRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.post('/events', {
+    schema: {
+      body: z.object({
+        summary: z.string().min(1),
+        event_type: z.string().optional(),
+        project: z.string().optional(),
+        importance: z.number().min(0).max(1).optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        201: z.object({ id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const id = logEvent(req.body);
+    return reply.status(201).send({ id });
+  });
+
+  f.get('/events/search', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        event_type: z.string().optional(),
+        project: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = searchEvents({
+      query: req.query.q,
+      limit: req.query.limit,
+      event_type: req.query.event_type,
+      project: req.query.project,
+      agent_id: req.query.agent_id,
+    });
+    return reply.send(results);
+  });
+
+  f.get('/events/recent', {
+    schema: {
+      querystring: z.object({
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = getRecentEvents(req.query.agent_id, req.query.limit);
+    return reply.send(results);
+  });
+}

--- a/apps/brainctl/src/app/routes/graph.ts
+++ b/apps/brainctl/src/app/routes/graph.ts
@@ -1,0 +1,64 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { computePageRank, whosKnows, traverse } from '../services/graph.service.js';
+
+export async function GraphRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // PageRank over the knowledge graph for this agent
+  f.get('/graph/pagerank', {
+    schema: {
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        iterations: z.coerce.number().int().min(1).max(100).optional(),
+        damping: z.coerce.number().min(0).max(1).optional(),
+        top_k: z.coerce.number().int().min(1).max(200).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const nodes = computePageRank(
+      req.query.agent_id ?? 'default',
+      req.query.iterations,
+      req.query.damping,
+      req.query.top_k,
+    );
+    return reply.send(nodes);
+  });
+
+  // Which entities have the most knowledge touching a topic?
+  f.get('/graph/whosknows', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        agent_id: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = await whosKnows(req.query.q, req.query.agent_id ?? 'default', req.query.limit);
+    return reply.send(results);
+  });
+
+  // Multi-hop traversal from a starting node
+  f.get('/graph/traverse', {
+    schema: {
+      querystring: z.object({
+        type: z.enum(['memory', 'entity']),
+        id: z.coerce.number().int(),
+        agent_id: z.string().optional(),
+        depth: z.coerce.number().int().min(1).max(6).optional(),
+        max_nodes: z.coerce.number().int().min(1).max(200).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const nodes = traverse(
+      req.query.type,
+      req.query.id,
+      req.query.agent_id ?? 'default',
+      req.query.depth,
+      req.query.max_nodes,
+    );
+    return reply.send(nodes);
+  });
+}

--- a/apps/brainctl/src/app/routes/graph.ts
+++ b/apps/brainctl/src/app/routes/graph.ts
@@ -2,6 +2,11 @@ import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { computePageRank, whosKnows, traverse } from '../services/graph.service.js';
+import {
+  listEdges, setEdgeWeight, createEdge, deleteEdge,
+  linkEvent, getEventLinks,
+  createEpoch, closeEpoch, listEpochs, getEpochMemories,
+} from '../services/graph.edges.service.js';
 
 export async function GraphRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -60,5 +65,113 @@ export async function GraphRoutes(fastify: FastifyInstance) {
       req.query.max_nodes,
     );
     return reply.send(nodes);
+  });
+
+  // ---- edge weights ----
+
+  f.get('/graph/edges', {
+    schema: {
+      querystring: z.object({
+        from_type: z.string().optional(),
+        from_id: z.coerce.number().int().optional(),
+        to_type: z.string().optional(),
+        to_id: z.coerce.number().int().optional(),
+        relation: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(500).optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send(listEdges(req.query)));
+
+  f.post('/graph/edges', {
+    schema: {
+      body: z.object({
+        from_type: z.string().min(1),
+        from_id: z.number().int(),
+        relation: z.string().min(1),
+        to_type: z.string().min(1),
+        to_id: z.number().int(),
+        weight: z.number().min(0).max(10).optional(),
+      }),
+    },
+  }, async (req, reply) => reply.status(201).send({ id: createEdge(req.body) }));
+
+  f.patch('/graph/edges/:id/weight', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      body: z.object({ weight: z.number().min(0).max(10) }),
+    },
+  }, async (req, reply) => {
+    const updated = setEdgeWeight(req.params.id, req.body.weight);
+    return reply.send({ updated });
+  });
+
+  f.delete('/graph/edges/:id', {
+    schema: { params: z.object({ id: z.coerce.number().int() }) },
+  }, async (req, reply) => reply.send({ deleted: deleteEdge(req.params.id) }));
+
+  // ---- event_link ----
+
+  f.post('/graph/events/:id/link', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      body: z.object({
+        targets: z.array(z.object({
+          type: z.enum(['memory', 'entity']),
+          id: z.number().int(),
+          relation: z.string().optional(),
+        })).min(1).max(100),
+        weight: z.number().min(0).max(10).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const ids = linkEvent({ event_id: req.params.id, ...req.body });
+    return reply.status(201).send({ edge_ids: ids });
+  });
+
+  f.get('/graph/events/:id/links', {
+    schema: { params: z.object({ id: z.coerce.number().int() }) },
+  }, async (req, reply) => reply.send(getEventLinks(req.params.id)));
+
+  // ---- epochs ----
+
+  f.put('/graph/epochs/:label', {
+    schema: {
+      params: z.object({ label: z.string().min(1) }),
+      body: z.object({
+        starts_at: z.string().min(1),
+        ends_at: z.string().optional(),
+        description: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.status(201).send({ id: createEpoch({ label: req.params.label, ...req.body }) }));
+
+  f.post('/graph/epochs/:label/close', {
+    schema: {
+      params: z.object({ label: z.string().min(1) }),
+      body: z.object({ ends_at: z.string().optional(), agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const closed = closeEpoch(req.params.label, req.body.agent_id ?? 'default', req.body.ends_at);
+    return reply.send({ closed });
+  });
+
+  f.get('/graph/epochs', {
+    schema: { querystring: z.object({ agent_id: z.string().optional() }) },
+  }, async (req, reply) => reply.send(listEpochs(req.query.agent_id ?? 'default')));
+
+  f.get('/graph/epochs/:label/memories', {
+    schema: {
+      params: z.object({ label: z.string().min(1) }),
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(500).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const result = getEpochMemories(req.params.label, req.query.agent_id ?? 'default', req.query.limit);
+    if (!result.epoch) return reply.status(404).send({ error: 'Epoch not found' });
+    return reply.send(result);
   });
 }

--- a/apps/brainctl/src/app/routes/memory.lifecycle.ts
+++ b/apps/brainctl/src/app/routes/memory.lifecycle.ts
@@ -1,0 +1,126 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  zoomIn, zoomOut, abstractSummarize,
+  retirementAnalysis, resolveConflict,
+  quarantineMemory, unquarantineMemory, listQuarantined,
+  searchPatterns,
+} from '../services/memory.lifecycle.service.js';
+
+const AgentQ = z.object({ agent_id: z.string().optional() });
+
+export async function MemoryLifecycleRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // zoom_in — granular memories related to a seed
+  f.get('/memories/:id/zoom-in', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: AgentQ.extend({ limit: z.coerce.number().int().min(1).max(50).optional() }),
+    },
+  }, async (req, reply) =>
+    reply.send(await zoomIn({ id: req.params.id, agent_id: req.query.agent_id, limit: req.query.limit })));
+
+  // zoom_out — abstract summary of a cluster of memories
+  f.post('/memories/zoom-out', {
+    schema: {
+      body: z.object({
+        ids: z.array(z.number().int()).min(1).max(100).optional(),
+        query: z.string().optional(),
+        store: z.boolean().optional(),
+        model: z.string().optional(),
+        agent_id: z.string().optional(),
+      }).refine((b) => b.ids?.length || b.query, { message: 'Provide ids or query' }),
+    },
+  }, async (req, reply) => reply.send(await zoomOut(req.body)));
+
+  // abstract_summarize — multi-level summary
+  f.post('/memories/abstract', {
+    schema: {
+      body: z.object({
+        query: z.string().min(1),
+        levels: z.number().int().min(1).max(5).optional(),
+        model: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send(await abstractSummarize(req.body)));
+
+  // retirement_analysis — candidates for soft-deletion
+  f.get('/memories/retirement-candidates', {
+    schema: {
+      querystring: AgentQ.extend({
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        explain: z.coerce.boolean().optional(),
+        model: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.send(await retirementAnalysis({
+      agent_id: req.query.agent_id,
+      limit: req.query.limit,
+      explain: req.query.explain,
+      model: req.query.model,
+    })));
+
+  // resolve_conflict — detect and resolve contradictions between two memories
+  f.post('/memories/resolve-conflict', {
+    schema: {
+      body: z.object({
+        id_a: z.number().int(),
+        id_b: z.number().int(),
+        store: z.boolean().optional(),
+        model: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send(await resolveConflict(req.body)));
+
+  // quarantine — isolate a memory pending review
+  f.post('/memories/:id/quarantine', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const quarantined = quarantineMemory(req.params.id, req.query.agent_id ?? 'default');
+    return reply.send({ quarantined });
+  });
+
+  // unquarantine — release from quarantine
+  f.delete('/memories/:id/quarantine', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const released = unquarantineMemory(req.params.id, req.query.agent_id ?? 'default');
+    return reply.send({ released });
+  });
+
+  // list quarantined memories
+  f.get('/memories/quarantined', {
+    schema: {
+      querystring: AgentQ.extend({ limit: z.coerce.number().int().min(1).max(200).optional() }),
+    },
+  }, async (req, reply) =>
+    reply.send(listQuarantined(req.query.agent_id ?? 'default', req.query.limit)));
+
+  // search_patterns — recurring themes across the memory store
+  f.get('/memories/patterns', {
+    schema: {
+      querystring: AgentQ.extend({
+        limit: z.coerce.number().int().min(1).max(50).optional(),
+        min_count: z.coerce.number().int().min(1).optional(),
+        model: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.send(await searchPatterns({
+      agent_id: req.query.agent_id,
+      limit: req.query.limit,
+      min_count: req.query.min_count,
+      model: req.query.model,
+    })));
+}

--- a/apps/brainctl/src/app/routes/memory.ts
+++ b/apps/brainctl/src/app/routes/memory.ts
@@ -22,7 +22,7 @@ export async function MemoryRoutes(fastify: FastifyInstance) {
       },
     },
   }, async (req, reply) => {
-    const id = addMemory(req.body);
+    const id = await addMemory(req.body);
     return reply.status(201).send({ id });
   });
 
@@ -36,7 +36,7 @@ export async function MemoryRoutes(fastify: FastifyInstance) {
       }),
     },
   }, async (req, reply) => {
-    const results = searchMemories({
+    const results = await searchMemories({
       query: req.query.q,
       limit: req.query.limit,
       memory_type: req.query.memory_type,

--- a/apps/brainctl/src/app/routes/memory.ts
+++ b/apps/brainctl/src/app/routes/memory.ts
@@ -2,6 +2,7 @@ import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { addMemory, searchMemories, forgetMemory, getMemory } from '../services/memory.service.js';
+import { MemorySchema, ErrorSchema, DeletedSchema } from '../schemas.js';
 
 export async function MemoryRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -34,6 +35,9 @@ export async function MemoryRoutes(fastify: FastifyInstance) {
         memory_type: z.string().optional(),
         agent_id: z.string().optional(),
       }),
+      response: {
+        200: z.array(MemorySchema),
+      },
     },
   }, async (req, reply) => {
     const results = await searchMemories({
@@ -49,6 +53,10 @@ export async function MemoryRoutes(fastify: FastifyInstance) {
     schema: {
       params: z.object({ id: z.coerce.number().int() }),
       querystring: z.object({ agent_id: z.string().optional() }),
+      response: {
+        200: MemorySchema,
+        404: ErrorSchema,
+      },
     },
   }, async (req, reply) => {
     const memory = getMemory(req.params.id, req.query.agent_id);
@@ -61,7 +69,7 @@ export async function MemoryRoutes(fastify: FastifyInstance) {
       params: z.object({ id: z.coerce.number().int() }),
       querystring: z.object({ agent_id: z.string().optional() }),
       response: {
-        200: z.object({ deleted: z.boolean() }),
+        200: DeletedSchema,
       },
     },
   }, async (req, reply) => {

--- a/apps/brainctl/src/app/routes/memory.ts
+++ b/apps/brainctl/src/app/routes/memory.ts
@@ -1,11 +1,27 @@
 import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { addMemory, searchMemories, forgetMemory, getMemory } from '../services/memory.service.js';
+import { addMemory, searchMemories, forgetMemory, getMemory, updateMemory, listMemories } from '../services/memory.service.js';
 import { MemorySchema, ErrorSchema, DeletedSchema } from '../schemas.js';
 
 export async function MemoryRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // List memories with optional filters and pagination
+  f.get('/memories', {
+    schema: {
+      querystring: z.object({
+        category: z.string().optional(),
+        memory_type: z.string().optional(),
+        scope: z.string().optional(),
+        include_retired: z.coerce.boolean().optional(),
+        limit: z.coerce.number().int().min(1).max(500).optional(),
+        offset: z.coerce.number().int().min(0).optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: { 200: z.array(MemorySchema) },
+    },
+  }, async (req, reply) => reply.send(listMemories(req.query)));
 
   f.post('/memories', {
     schema: {
@@ -62,6 +78,26 @@ export async function MemoryRoutes(fastify: FastifyInstance) {
     const memory = getMemory(req.params.id, req.query.agent_id);
     if (!memory) return reply.status(404).send({ error: 'Memory not found' });
     return reply.send(memory);
+  });
+
+  f.patch('/memories/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      body: z.object({
+        content: z.string().optional(),
+        category: z.string().optional(),
+        tags: z.union([z.string(), z.array(z.string())]).optional(),
+        confidence: z.number().min(0).max(1).optional(),
+        memory_type: z.enum(['episodic', 'semantic', 'procedural']).optional(),
+        temporal_class: z.enum(['ephemeral', 'short', 'medium', 'long']).optional(),
+        scope: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const updated = updateMemory(req.params.id, req.body);
+    if (!updated) return reply.status(404).send({ error: 'Memory not found' });
+    return reply.send({ updated });
   });
 
   f.delete('/memories/:id', {

--- a/apps/brainctl/src/app/routes/memory.ts
+++ b/apps/brainctl/src/app/routes/memory.ts
@@ -1,0 +1,71 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { addMemory, searchMemories, forgetMemory, getMemory } from '../services/memory.service.js';
+
+export async function MemoryRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.post('/memories', {
+    schema: {
+      body: z.object({
+        content: z.string().min(1),
+        category: z.string().optional(),
+        tags: z.union([z.string(), z.array(z.string())]).optional(),
+        confidence: z.number().min(0).max(1).optional(),
+        memory_type: z.enum(['episodic', 'semantic', 'procedural']).optional(),
+        scope: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        201: z.object({ id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const id = addMemory(req.body);
+    return reply.status(201).send({ id });
+  });
+
+  f.get('/memories/search', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        memory_type: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = searchMemories({
+      query: req.query.q,
+      limit: req.query.limit,
+      memory_type: req.query.memory_type,
+      agent_id: req.query.agent_id,
+    });
+    return reply.send(results);
+  });
+
+  f.get('/memories/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const memory = getMemory(req.params.id, req.query.agent_id);
+    if (!memory) return reply.status(404).send({ error: 'Memory not found' });
+    return reply.send(memory);
+  });
+
+  f.delete('/memories/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+      response: {
+        200: z.object({ deleted: z.boolean() }),
+      },
+    },
+  }, async (req, reply) => {
+    const deleted = forgetMemory(req.params.id, req.query.agent_id);
+    return reply.send({ deleted });
+  });
+}

--- a/apps/brainctl/src/app/routes/procedures.ts
+++ b/apps/brainctl/src/app/routes/procedures.ts
@@ -1,0 +1,109 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  createProcedure,
+  getProcedure,
+  listProcedures,
+  searchProcedures,
+  recordFeedback,
+} from '../services/procedure.service.js';
+
+const StepSchema = z.object({
+  step: z.number().int(),
+  action: z.string(),
+  notes: z.string().optional(),
+});
+
+export async function ProcedureRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.post('/procedures', {
+    schema: {
+      body: z.object({
+        goal: z.string().min(1),
+        title: z.string().optional(),
+        description: z.string().optional(),
+        steps: z.array(StepSchema).optional(),
+        procedure_kind: z.string().optional(),
+        scope: z.string().optional(),
+        category: z.string().optional(),
+        confidence: z.number().min(0).max(1).optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        201: z.object({ id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const id = createProcedure(req.body);
+    return reply.status(201).send({ id });
+  });
+
+  f.get('/procedures/search', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        scope: z.string().optional(),
+        status: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = searchProcedures({
+      query: req.query.q,
+      limit: req.query.limit,
+      scope: req.query.scope,
+      status: req.query.status,
+      agent_id: req.query.agent_id,
+    });
+    return reply.send(results);
+  });
+
+  f.get('/procedures', {
+    schema: {
+      querystring: z.object({
+        status: z.string().optional(),
+        scope: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = listProcedures(req.query);
+    return reply.send(results);
+  });
+
+  f.get('/procedures/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const proc = getProcedure(req.params.id, req.query.agent_id);
+    if (!proc) return reply.status(404).send({ error: 'Procedure not found' });
+    return reply.send(proc);
+  });
+
+  f.post('/procedures/:id/feedback', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      body: z.object({
+        success: z.boolean(),
+        usefulness_score: z.number().min(0).max(1).optional(),
+        outcome_summary: z.string().optional(),
+        errors_seen: z.string().optional(),
+        validated: z.boolean().optional(),
+        task_signature: z.string().optional(),
+        input_summary: z.string().optional(),
+      }),
+      response: {
+        201: z.object({ id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const id = recordFeedback({ procedure_id: req.params.id, ...req.body });
+    return reply.status(201).send({ id });
+  });
+}

--- a/apps/brainctl/src/app/routes/procedures.ts
+++ b/apps/brainctl/src/app/routes/procedures.ts
@@ -7,6 +7,8 @@ import {
   listProcedures,
   searchProcedures,
   recordFeedback,
+  updateProcedure,
+  deleteProcedure,
 } from '../services/procedure.service.js';
 
 const StepSchema = z.object({
@@ -84,6 +86,39 @@ export async function ProcedureRoutes(fastify: FastifyInstance) {
     const proc = getProcedure(req.params.id, req.query.agent_id);
     if (!proc) return reply.status(404).send({ error: 'Procedure not found' });
     return reply.send(proc);
+  });
+
+  f.patch('/procedures/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      body: z.object({
+        goal: z.string().optional(),
+        title: z.string().optional(),
+        description: z.string().optional(),
+        steps: z.array(StepSchema).optional(),
+        procedure_kind: z.string().optional(),
+        scope: z.string().optional(),
+        category: z.string().optional(),
+        confidence: z.number().min(0).max(1).optional(),
+        status: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const updated = updateProcedure(req.params.id, req.body);
+    if (!updated) return reply.status(404).send({ error: 'Procedure not found' });
+    return reply.send({ updated });
+  });
+
+  f.delete('/procedures/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const deleted = deleteProcedure(req.params.id, req.query.agent_id ?? 'default');
+    if (!deleted) return reply.status(404).send({ error: 'Procedure not found' });
+    return reply.send({ deleted });
   });
 
   f.post('/procedures/:id/feedback', {

--- a/apps/brainctl/src/app/routes/push.ts
+++ b/apps/brainctl/src/app/routes/push.ts
@@ -1,0 +1,70 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  upsertWebhook, listWebhooks, deleteWebhook,
+  pushMemories, pushReport,
+} from '../services/push.service.js';
+
+export async function PushRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // ---- Webhooks ----
+
+  f.put('/webhooks/:name', {
+    schema: {
+      params: z.object({ name: z.string().min(1) }),
+      body: z.object({
+        url: z.string().url(),
+        secret: z.string().optional(),
+        events: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.status(201).send({ id: upsertWebhook({ name: req.params.name, ...req.body }) }));
+
+  f.get('/webhooks', async (_req, reply) => reply.send(listWebhooks()));
+
+  f.delete('/webhooks/:name', {
+    schema: { params: z.object({ name: z.string().min(1) }) },
+  }, async (req, reply) => reply.send({ deleted: deleteWebhook(req.params.name) }));
+
+  // ---- Push ----
+
+  // Push memories to a webhook (by query or explicit IDs)
+  f.post('/push', {
+    schema: {
+      body: z.object({
+        webhook: z.string().min(1),
+        query: z.string().optional(),
+        memory_ids: z.array(z.number().int()).max(500).optional(),
+        event_type: z.string().optional(),
+        agent_id: z.string().optional(),
+      }).refine((b) => b.query || b.memory_ids?.length, { message: 'Provide query or memory_ids' }),
+    },
+  }, async (req, reply) => {
+    try {
+      return reply.send(await pushMemories(req.body));
+    } catch (err) {
+      return reply.status(404).send({ error: (err as Error).message });
+    }
+  });
+
+  // Push a structured report to a webhook
+  f.post('/push/report', {
+    schema: {
+      body: z.object({
+        webhook: z.string().min(1),
+        title: z.string().min(1),
+        body: z.record(z.unknown()),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    try {
+      return reply.send(await pushReport(req.body));
+    } catch (err) {
+      return reply.status(404).send({ error: (err as Error).message });
+    }
+  });
+}

--- a/apps/brainctl/src/app/routes/reasoning.ts
+++ b/apps/brainctl/src/app/routes/reasoning.ts
@@ -1,0 +1,90 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { reason, infer, dream, inferPretask, inferGapfill } from '../services/reasoning.service.js';
+import { isLlmAvailable } from '../services/llm.service.js';
+
+const BaseReasonSchema = z.object({
+  agent_id: z.string().optional(),
+  model: z.string().optional(),
+  temperature: z.number().min(0).max(2).optional(),
+  max_tokens: z.number().int().min(1).max(8192).optional(),
+  context_limit: z.number().int().min(1).max(50).optional(),
+});
+
+function requireLlm(reply: any): boolean {
+  if (!isLlmAvailable()) {
+    reply.status(503).send({ error: 'LLM unavailable — set LITELLM_BASE_URL to enable reasoning endpoints' });
+    return false;
+  }
+  return true;
+}
+
+export async function ReasoningRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // Grounded Q&A: retrieve relevant memories, answer using LLM
+  f.post('/reason', {
+    schema: {
+      body: BaseReasonSchema.extend({
+        query: z.string().min(1),
+        memory_types: z.array(z.string()).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    if (!requireLlm(reply)) return;
+    return reply.send(await reason(req.body));
+  });
+
+  // Draw inferences from a premise + supporting memories
+  f.post('/infer', {
+    schema: {
+      body: BaseReasonSchema.extend({
+        premise: z.string().min(1),
+        context: z.array(z.string()).optional(),
+        depth: z.enum(['shallow', 'deep']).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    if (!requireLlm(reply)) return;
+    return reply.send(await infer(req.body));
+  });
+
+  // Pre-task briefing: what does the agent know about this task?
+  f.post('/infer/pretask', {
+    schema: {
+      body: BaseReasonSchema.extend({
+        query: z.string().min(1),
+      }),
+    },
+  }, async (req, reply) => {
+    if (!requireLlm(reply)) return;
+    return reply.send(await inferPretask(req.body));
+  });
+
+  // Knowledge gap analysis: what's missing on this topic?
+  f.post('/infer/gapfill', {
+    schema: {
+      body: BaseReasonSchema.extend({
+        query: z.string().min(1),
+      }),
+    },
+  }, async (req, reply) => {
+    if (!requireLlm(reply)) return;
+    return reply.send(await inferGapfill(req.body));
+  });
+
+  // Dream cycle: synthesise hypotheses from recent high-confidence memories
+  f.post('/dream', {
+    schema: {
+      body: BaseReasonSchema.extend({
+        topic: z.string().optional(),
+        memory_limit: z.number().int().min(1).max(100).optional(),
+        min_confidence: z.number().min(0).max(1).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    if (!requireLlm(reply)) return;
+    return reply.send(await dream(req.body));
+  });
+}

--- a/apps/brainctl/src/app/routes/scheduler.ts
+++ b/apps/brainctl/src/app/routes/scheduler.ts
@@ -1,0 +1,81 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  addSchedule,
+  removeSchedule,
+  listSchedules,
+  getSchedule,
+  pauseSchedule,
+  resumeSchedule,
+} from '../services/scheduler.service.js';
+
+const PassEnum = z.enum(['decay', 'promote', 'compress', 'hebbian', 'gap_scan', 'entity_tiers']);
+
+const ScheduleBodySchema = z.object({
+  cron: z.string().min(1),
+  agent_id: z.string().optional(),
+  enabled: z.boolean().optional(),
+  options: z.object({
+    dry_run: z.boolean().optional(),
+    batch_limit: z.coerce.number().int().optional(),
+    decay_rate: z.number().optional(),
+    promote_min_priority: z.number().optional(),
+    promote_min_ripple_tags: z.number().int().optional(),
+    promote_min_confidence: z.number().optional(),
+    compression_min_cluster: z.number().int().optional(),
+    hebbian_boost: z.number().optional(),
+    prune_threshold: z.number().optional(),
+    passes: z.array(PassEnum).optional(),
+  }).optional(),
+});
+
+export async function SchedulerRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.get('/scheduler', async (_req, reply) => {
+    return reply.send(listSchedules());
+  });
+
+  f.post('/scheduler', {
+    schema: { body: ScheduleBodySchema },
+  }, async (req, reply) => {
+    try {
+      const entry = addSchedule(req.body);
+      return reply.status(201).send(entry);
+    } catch (err) {
+      return reply.status(400).send({ error: (err as Error).message });
+    }
+  });
+
+  f.get('/scheduler/:id', {
+    schema: { params: z.object({ id: z.string() }) },
+  }, async (req, reply) => {
+    const entry = getSchedule(req.params.id);
+    if (!entry) return reply.status(404).send({ error: 'Schedule not found' });
+    return reply.send(entry);
+  });
+
+  f.delete('/scheduler/:id', {
+    schema: { params: z.object({ id: z.string() }) },
+  }, async (req, reply) => {
+    const removed = removeSchedule(req.params.id);
+    return reply.send({ removed });
+  });
+
+  f.post('/scheduler/:id/pause', {
+    schema: { params: z.object({ id: z.string() }) },
+  }, async (req, reply) => {
+    const ok = pauseSchedule(req.params.id);
+    if (!ok) return reply.status(404).send({ error: 'Schedule not found' });
+    return reply.send({ paused: true });
+  });
+
+  f.post('/scheduler/:id/resume', {
+    schema: { params: z.object({ id: z.string() }) },
+  }, async (req, reply) => {
+    const ok = resumeSchedule(req.params.id);
+    if (!ok) return reply.status(404).send({ error: 'Schedule not found' });
+    return reply.send({ resumed: true });
+  });
+}

--- a/apps/brainctl/src/app/routes/search.ts
+++ b/apps/brainctl/src/app/routes/search.ts
@@ -1,0 +1,44 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { unifiedSearch, think } from '../services/search.service.js';
+
+export async function SearchRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.get('/search', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const results = unifiedSearch(req.query.q, req.query.limit, req.query.agent_id);
+    return reply.send(results);
+  });
+
+  f.get('/think', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        seed_limit: z.coerce.number().int().min(1).max(20).optional(),
+        hops: z.coerce.number().int().min(1).max(5).optional(),
+        decay: z.coerce.number().min(0).max(1).optional(),
+        top_k: z.coerce.number().int().min(1).max(100).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const result = think(
+      req.query.q,
+      req.query.agent_id,
+      req.query.seed_limit,
+      req.query.hops,
+      req.query.decay,
+      req.query.top_k,
+    );
+    return reply.send(result);
+  });
+}

--- a/apps/brainctl/src/app/routes/search.ts
+++ b/apps/brainctl/src/app/routes/search.ts
@@ -1,7 +1,12 @@
 import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { unifiedSearch, think } from '../services/search.service.js';
+import { unifiedSearch, vsearch, think } from '../services/search.service.js';
+import { isVecLoaded, getDb } from '../db/database.js';
+import { getMemoriesWithoutEmbeddings } from '../services/memory.service.js';
+import { getEntitiesWithoutEmbeddings } from '../services/entity.service.js';
+import { getEventsWithoutEmbeddings } from '../services/event.service.js';
+import { serializeVec, isEmbeddingAvailable, embedBatch } from '../services/embeddings.service.js';
 
 export async function SearchRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -15,7 +20,23 @@ export async function SearchRoutes(fastify: FastifyInstance) {
       }),
     },
   }, async (req, reply) => {
-    const results = unifiedSearch(req.query.q, req.query.limit, req.query.agent_id);
+    const results = await unifiedSearch(req.query.q, req.query.limit, req.query.agent_id);
+    return reply.send(results);
+  });
+
+  f.get('/vsearch', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        limit: z.coerce.number().int().min(1).max(100).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    if (!isVecLoaded() || !isEmbeddingAvailable()) {
+      return reply.status(503).send({ error: 'Vector search unavailable — configure LITELLM_BASE_URL' });
+    }
+    const results = await vsearch(req.query.q, req.query.limit, req.query.agent_id);
     return reply.send(results);
   });
 
@@ -31,7 +52,7 @@ export async function SearchRoutes(fastify: FastifyInstance) {
       }),
     },
   }, async (req, reply) => {
-    const result = think(
+    const result = await think(
       req.query.q,
       req.query.agent_id,
       req.query.seed_limit,
@@ -40,5 +61,104 @@ export async function SearchRoutes(fastify: FastifyInstance) {
       req.query.top_k,
     );
     return reply.send(result);
+  });
+
+  // Backfill embeddings for existing records that don't have vectors yet.
+  // Processes up to `batch_size` records per call; repeat until exhausted.
+  f.post('/embeddings/backfill', {
+    schema: {
+      body: z.object({
+        agent_id: z.string().optional(),
+        batch_size: z.number().int().min(1).max(500).optional(),
+        table: z.enum(['memories', 'entities', 'events', 'all']).optional(),
+      }),
+      response: {
+        200: z.object({
+          memories_processed: z.number(),
+          entities_processed: z.number(),
+          events_processed: z.number(),
+          vec_available: z.boolean(),
+          embedding_available: z.boolean(),
+        }),
+      },
+    },
+  }, async (req, reply) => {
+    const vecAvailable = isVecLoaded();
+    const embAvailable = isEmbeddingAvailable();
+
+    if (!vecAvailable || !embAvailable) {
+      return reply.send({
+        memories_processed: 0,
+        entities_processed: 0,
+        events_processed: 0,
+        vec_available: vecAvailable,
+        embedding_available: embAvailable,
+      });
+    }
+
+    const db = getDb();
+    const agentId = req.body.agent_id ?? 'default';
+    const batchSize = req.body.batch_size ?? 100;
+    const table = req.body.table ?? 'all';
+
+    let memoriesProcessed = 0;
+    let entitiesProcessed = 0;
+    let eventsProcessed = 0;
+
+    if (table === 'memories' || table === 'all') {
+      const rows = getMemoriesWithoutEmbeddings(agentId, batchSize);
+      if (rows.length) {
+        const vecs = await embedBatch(rows.map((r) => r.content));
+        const insert = db.prepare('INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?, ?)');
+        const tx = db.transaction(() => {
+          for (let i = 0; i < rows.length; i++) {
+            const vec = vecs[i];
+            if (vec) { insert.run(rows[i].id, serializeVec(vec)); memoriesProcessed++; }
+          }
+        });
+        tx();
+      }
+    }
+
+    if (table === 'entities' || table === 'all') {
+      const rows = getEntitiesWithoutEmbeddings(agentId, batchSize);
+      if (rows.length) {
+        const texts = rows.map((r) =>
+          [r.name, r.entity_type, r.observations ? JSON.parse(r.observations).join(' ') : ''].join(' ')
+        );
+        const vecs = await embedBatch(texts);
+        const insert = db.prepare('INSERT OR REPLACE INTO vec_entities(rowid, embedding) VALUES (?, ?)');
+        const tx = db.transaction(() => {
+          for (let i = 0; i < rows.length; i++) {
+            const vec = vecs[i];
+            if (vec) { insert.run(rows[i].id, serializeVec(vec)); entitiesProcessed++; }
+          }
+        });
+        tx();
+      }
+    }
+
+    if (table === 'events' || table === 'all') {
+      const rows = getEventsWithoutEmbeddings(agentId, batchSize);
+      if (rows.length) {
+        const vecs = await embedBatch(rows.map((r) => r.summary));
+        const insert = db.prepare('INSERT OR REPLACE INTO vec_events(rowid, embedding) VALUES (?, ?)');
+        const tx = db.transaction(() => {
+          for (let i = 0; i < rows.length; i++) {
+            const vec = vecs[i];
+            if (vec) { insert.run(rows[i].id, serializeVec(vec)); eventsProcessed++; }
+          }
+        });
+        tx();
+      }
+    }
+
+    return reply.send({
+      memories_processed: memoriesProcessed,
+      entities_processed: entitiesProcessed,
+      events_processed: eventsProcessed,
+      vec_available: vecAvailable,
+      embedding_available: embAvailable,
+    });
   });
 }

--- a/apps/brainctl/src/app/routes/session.ts
+++ b/apps/brainctl/src/app/routes/session.ts
@@ -1,0 +1,77 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { createHandoff, getLatestHandoff, orient, wrapUp } from '../services/session.service.js';
+
+export async function SessionRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.get('/session/orient', {
+    schema: {
+      querystring: z.object({
+        project: z.string().optional(),
+        q: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const result = orient({
+      project: req.query.project,
+      query: req.query.q,
+      agent_id: req.query.agent_id,
+    });
+    return reply.send(result);
+  });
+
+  f.post('/session/wrap-up', {
+    schema: {
+      body: z.object({
+        summary: z.string().min(1),
+        goal: z.string().optional(),
+        open_loops: z.string().optional(),
+        next_step: z.string().optional(),
+        project: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        200: z.object({ event_id: z.number(), handoff_id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const result = wrapUp(req.body);
+    return reply.send(result);
+  });
+
+  f.post('/session/handoff', {
+    schema: {
+      body: z.object({
+        goal: z.string().min(1),
+        current_state: z.string().min(1),
+        open_loops: z.string().min(1),
+        next_step: z.string().min(1),
+        project: z.string().optional(),
+        title: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        201: z.object({ id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const id = createHandoff(req.body);
+    return reply.status(201).send({ id });
+  });
+
+  f.get('/session/handoff/latest', {
+    schema: {
+      querystring: z.object({
+        project: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const handoff = getLatestHandoff(req.query.agent_id, req.query.project);
+    if (!handoff) return reply.status(404).send({ error: 'No pending handoff' });
+    return reply.send(handoff);
+  });
+}

--- a/apps/brainctl/src/app/routes/session.ts
+++ b/apps/brainctl/src/app/routes/session.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { createHandoff, getLatestHandoff, orient, wrapUp } from '../services/session.service.js';
+import { createHandoff, getLatestHandoff, listHandoffs, consumeHandoff, orient, wrapUp } from '../services/session.service.js';
 
 export async function SessionRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -60,6 +60,32 @@ export async function SessionRoutes(fastify: FastifyInstance) {
   }, async (req, reply) => {
     const id = createHandoff(req.body);
     return reply.status(201).send({ id });
+  });
+
+  f.get('/session/handoffs', {
+    schema: {
+      querystring: z.object({
+        project: z.string().optional(),
+        include_consumed: z.coerce.boolean().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const handoffs = listHandoffs(
+      req.query.agent_id,
+      req.query.project,
+      req.query.include_consumed,
+    );
+    return reply.send(handoffs);
+  });
+
+  f.post('/session/handoff/:id/consume', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+    },
+  }, async (req, reply) => {
+    consumeHandoff(req.params.id);
+    return reply.send({ consumed: true });
   });
 
   f.get('/session/handoff/latest', {

--- a/apps/brainctl/src/app/routes/session.ts
+++ b/apps/brainctl/src/app/routes/session.ts
@@ -15,7 +15,7 @@ export async function SessionRoutes(fastify: FastifyInstance) {
       }),
     },
   }, async (req, reply) => {
-    const result = orient({
+    const result = await orient({
       project: req.query.project,
       query: req.query.q,
       agent_id: req.query.agent_id,
@@ -38,7 +38,7 @@ export async function SessionRoutes(fastify: FastifyInstance) {
       },
     },
   }, async (req, reply) => {
-    const result = wrapUp(req.body);
+    const result = await wrapUp(req.body);
     return reply.send(result);
   });
 

--- a/apps/brainctl/src/app/routes/subsystems.meta.ts
+++ b/apps/brainctl/src/app/routes/subsystems.meta.ts
@@ -1,0 +1,162 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { getDb } from '../db/database.js';
+
+// The canonical list of built-in subsystems and their backing tables
+const SUBSYSTEM_REGISTRY: Array<{
+  name: string;
+  table: string;
+  description: string;
+  operations: string[];
+}> = [
+  { name: 'belief', table: 'beliefs', description: 'Graded beliefs with confidence tracking', operations: ['upsert', 'list'] },
+  { name: 'trust', table: 'trust_records', description: 'Trust scores for named sources', operations: ['record_interaction', 'get', 'list'] },
+  { name: 'reflexion', table: 'reflections', description: 'Action/outcome reflection with lesson extraction', operations: ['reflect', 'list'] },
+  { name: 'workspace', table: 'workspace', description: 'Scoped scratchpad for in-progress work', operations: ['upsert', 'get', 'list'] },
+  { name: 'task', table: 'tasks', description: 'Shared task queue with status tracking', operations: ['create', 'update_status', 'list'] },
+  { name: 'policy', table: 'policies', description: 'Named rules with LLM evaluation', operations: ['upsert', 'evaluate', 'list'] },
+];
+
+function ensureSubsystemConfigTable(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS subsystem_config (
+      agent_id TEXT NOT NULL,
+      subsystem TEXT NOT NULL,
+      key TEXT NOT NULL,
+      value TEXT NOT NULL,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (agent_id, subsystem, key)
+    );
+  `);
+}
+
+function ensureSubsystemEventLog(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS subsystem_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      subsystem TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      payload TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_ssevents_agent ON subsystem_events(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_ssevents_subsystem ON subsystem_events(subsystem);
+  `);
+}
+
+export async function SubsystemMetaRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // List all registered subsystems with live table-row counts
+  f.get('/subsystems', {
+    schema: { querystring: z.object({ agent_id: z.string().optional() }) },
+  }, async (req, reply) => {
+    const db = getDb();
+    const agentId = req.query.agent_id ?? 'default';
+
+    const subsystems = SUBSYSTEM_REGISTRY.map((s) => {
+      let count = 0;
+      try {
+        const row = db.prepare(`SELECT COUNT(*) AS c FROM ${s.table} WHERE agent_id = ?`)
+          .get(agentId) as { c: number } | undefined;
+        count = row?.c ?? 0;
+      } catch { /* table not yet created */ }
+      return { ...s, record_count: count };
+    });
+
+    return reply.send(subsystems);
+  });
+
+  // Emit a generic event to a subsystem (appended to audit log)
+  f.post('/subsystems/:name/emit', {
+    schema: {
+      params: z.object({ name: z.string().min(1) }),
+      body: z.object({
+        event_type: z.string().min(1),
+        payload: z.record(z.unknown()).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const known = SUBSYSTEM_REGISTRY.find((s) => s.name === req.params.name);
+    if (!known) return reply.status(404).send({ error: `Unknown subsystem: ${req.params.name}` });
+
+    ensureSubsystemEventLog();
+    const result = getDb().prepare(`
+      INSERT INTO subsystem_events (agent_id, subsystem, event_type, payload)
+      VALUES (?, ?, ?, ?)
+    `).run(
+      req.body.agent_id ?? 'default',
+      req.params.name,
+      req.body.event_type,
+      JSON.stringify(req.body.payload ?? {}),
+    );
+
+    return reply.status(201).send({ id: result.lastInsertRowid });
+  });
+
+  // Get subsystem event log
+  f.get('/subsystems/:name/events', {
+    schema: {
+      params: z.object({ name: z.string().min(1) }),
+      querystring: z.object({
+        agent_id: z.string().optional(),
+        limit: z.coerce.number().int().min(1).max(200).optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    ensureSubsystemEventLog();
+    const rows = getDb().prepare(`
+      SELECT * FROM subsystem_events
+      WHERE subsystem = ? AND agent_id = ?
+      ORDER BY created_at DESC LIMIT ?
+    `).all(req.params.name, req.query.agent_id ?? 'default', req.query.limit ?? 50);
+    return reply.send(rows);
+  });
+
+  // Configure a subsystem (key-value settings per agent)
+  f.put('/subsystems/:name/config', {
+    schema: {
+      params: z.object({ name: z.string().min(1) }),
+      body: z.object({
+        config: z.record(z.unknown()),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const known = SUBSYSTEM_REGISTRY.find((s) => s.name === req.params.name);
+    if (!known) return reply.status(404).send({ error: `Unknown subsystem: ${req.params.name}` });
+
+    ensureSubsystemConfigTable();
+    const db = getDb();
+    const agentId = req.body.agent_id ?? 'default';
+    const upsert = db.prepare(`
+      INSERT INTO subsystem_config (agent_id, subsystem, key, value)
+      VALUES (?, ?, ?, ?)
+      ON CONFLICT (agent_id, subsystem, key) DO UPDATE SET value = excluded.value, updated_at = datetime('now')
+    `);
+    db.transaction(() => {
+      for (const [k, v] of Object.entries(req.body.config)) {
+        upsert.run(agentId, req.params.name, k, JSON.stringify(v));
+      }
+    })();
+    return reply.send({ configured: Object.keys(req.body.config).length });
+  });
+
+  // Get subsystem config for an agent
+  f.get('/subsystems/:name/config', {
+    schema: {
+      params: z.object({ name: z.string().min(1) }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    ensureSubsystemConfigTable();
+    const rows = getDb().prepare(`
+      SELECT key, value FROM subsystem_config
+      WHERE subsystem = ? AND agent_id = ?
+    `).all(req.params.name, req.query.agent_id ?? 'default') as Array<{ key: string; value: string }>;
+    return reply.send(Object.fromEntries(rows.map((r) => [r.key, JSON.parse(r.value)])));
+  });
+}

--- a/apps/brainctl/src/app/routes/subsystems.ts
+++ b/apps/brainctl/src/app/routes/subsystems.ts
@@ -1,0 +1,158 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  upsertBelief, listBeliefs,
+  recordInteraction, getTrust, listTrust,
+  reflect, listReflections,
+  upsertWorkspace, getWorkspace, listWorkspace,
+  createTask, updateTaskStatus, listTasks,
+  upsertPolicy, evaluatePolicy, listPolicies,
+} from '../services/subsystems.service.js';
+
+const AgentQ = z.object({ agent_id: z.string().optional() });
+
+export async function SubsystemRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // ---- belief ----
+  f.post('/belief', {
+    schema: {
+      body: z.object({
+        claim: z.string().min(1),
+        confidence: z.number().min(0).max(1).optional(),
+        evidence_for: z.string().optional(),
+        evidence_against: z.string().optional(),
+        source: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.status(201).send({ id: upsertBelief(req.body) }));
+
+  f.get('/belief', {
+    schema: { querystring: AgentQ.extend({ min_confidence: z.coerce.number().optional() }) },
+  }, async (req, reply) => reply.send(listBeliefs(req.query.agent_id ?? 'default', req.query.min_confidence)));
+
+  // ---- trust ----
+  f.post('/trust/interaction', {
+    schema: {
+      body: z.object({
+        target: z.string().min(1),
+        outcome: z.enum(['positive', 'negative', 'neutral']),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send(recordInteraction(req.body)));
+
+  f.get('/trust', {
+    schema: { querystring: AgentQ },
+  }, async (req, reply) => reply.send(listTrust(req.query.agent_id ?? 'default')));
+
+  f.get('/trust/:target', {
+    schema: { params: z.object({ target: z.string() }), querystring: AgentQ },
+  }, async (req, reply) => {
+    const record = getTrust(req.params.target, req.query.agent_id ?? 'default');
+    if (!record) return reply.status(404).send({ error: 'Trust record not found' });
+    return reply.send(record);
+  });
+
+  // ---- reflexion ----
+  f.post('/reflexion', {
+    schema: {
+      body: z.object({
+        action: z.string().min(1),
+        outcome: z.string().min(1),
+        generate_lesson: z.boolean().optional(),
+        model: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.status(201).send(await reflect(req.body)));
+
+  f.get('/reflexion', {
+    schema: { querystring: AgentQ.extend({ limit: z.coerce.number().int().optional() }) },
+  }, async (req, reply) => reply.send(listReflections(req.query.agent_id ?? 'default', req.query.limit)));
+
+  // ---- workspace ----
+  f.put('/workspace/:name', {
+    schema: {
+      params: z.object({ name: z.string() }),
+      body: z.object({
+        content: z.string(),
+        workspace_type: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send({ id: upsertWorkspace({ name: req.params.name, ...req.body }) }));
+
+  f.get('/workspace', {
+    schema: { querystring: AgentQ.extend({ status: z.string().optional() }) },
+  }, async (req, reply) => reply.send(listWorkspace(req.query.agent_id ?? 'default', req.query.status)));
+
+  f.get('/workspace/:name', {
+    schema: { params: z.object({ name: z.string() }), querystring: AgentQ },
+  }, async (req, reply) => {
+    const item = getWorkspace(req.params.name, req.query.agent_id ?? 'default');
+    if (!item) return reply.status(404).send({ error: 'Workspace item not found' });
+    return reply.send(item);
+  });
+
+  // ---- task ----
+  f.post('/tasks', {
+    schema: {
+      body: z.object({
+        title: z.string().min(1),
+        description: z.string().optional(),
+        priority: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+        assignee: z.string().optional(),
+        due_at: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.status(201).send({ id: createTask(req.body) }));
+
+  f.patch('/tasks/:id/status', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      body: z.object({
+        status: z.string().min(1),
+        result: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const ok = updateTaskStatus(req.params.id, req.body.status, req.body.result, req.body.agent_id);
+    return reply.send({ updated: ok });
+  });
+
+  f.get('/tasks', {
+    schema: { querystring: AgentQ.extend({ status: z.string().optional(), assignee: z.string().optional() }) },
+  }, async (req, reply) => reply.send(listTasks(req.query.agent_id ?? 'default', req.query.status, req.query.assignee)));
+
+  // ---- policy ----
+  f.put('/policy/:name', {
+    schema: {
+      params: z.object({ name: z.string() }),
+      body: z.object({
+        rule: z.string().min(1),
+        scope: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send({ id: upsertPolicy({ name: req.params.name, ...req.body }) }));
+
+  f.post('/policy/:name/evaluate', {
+    schema: {
+      params: z.object({ name: z.string() }),
+      body: z.object({
+        context: z.string().min(1),
+        model: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send(await evaluatePolicy({ name: req.params.name, ...req.body })));
+
+  f.get('/policy', {
+    schema: { querystring: AgentQ.extend({ active_only: z.coerce.boolean().optional() }) },
+  }, async (req, reply) => reply.send(listPolicies(req.query.agent_id ?? 'default', req.query.active_only !== false)));
+}

--- a/apps/brainctl/src/app/routes/subsystems.ts
+++ b/apps/brainctl/src/app/routes/subsystems.ts
@@ -2,11 +2,11 @@ import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import {
-  upsertBelief, listBeliefs,
+  upsertBelief, listBeliefs, deleteBelief,
   recordInteraction, getTrust, listTrust,
   reflect, listReflections,
-  upsertWorkspace, getWorkspace, listWorkspace,
-  createTask, updateTaskStatus, listTasks,
+  upsertWorkspace, getWorkspace, listWorkspace, deleteWorkspace,
+  createTask, updateTaskStatus, listTasks, getTask, deleteTask,
   upsertPolicy, evaluatePolicy, listPolicies,
 } from '../services/subsystems.service.js';
 
@@ -28,6 +28,17 @@ export async function SubsystemRoutes(fastify: FastifyInstance) {
       }),
     },
   }, async (req, reply) => reply.status(201).send({ id: upsertBelief(req.body) }));
+
+  f.delete('/belief/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const deleted = deleteBelief(req.params.id, req.query.agent_id ?? 'default');
+    if (!deleted) return reply.status(404).send({ error: 'Belief not found' });
+    return reply.send({ deleted });
+  });
 
   f.get('/belief', {
     schema: { querystring: AgentQ.extend({ min_confidence: z.coerce.number().optional() }) },
@@ -85,6 +96,17 @@ export async function SubsystemRoutes(fastify: FastifyInstance) {
     },
   }, async (req, reply) => reply.send({ id: upsertWorkspace({ name: req.params.name, ...req.body }) }));
 
+  f.delete('/workspace/:name', {
+    schema: {
+      params: z.object({ name: z.string() }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const deleted = deleteWorkspace(req.params.name, req.query.agent_id ?? 'default');
+    if (!deleted) return reply.status(404).send({ error: 'Workspace item not found' });
+    return reply.send({ deleted });
+  });
+
   f.get('/workspace', {
     schema: { querystring: AgentQ.extend({ status: z.string().optional() }) },
   }, async (req, reply) => reply.send(listWorkspace(req.query.agent_id ?? 'default', req.query.status)));
@@ -110,6 +132,28 @@ export async function SubsystemRoutes(fastify: FastifyInstance) {
       }),
     },
   }, async (req, reply) => reply.status(201).send({ id: createTask(req.body) }));
+
+  f.get('/tasks/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const task = getTask(req.params.id, req.query.agent_id ?? 'default');
+    if (!task) return reply.status(404).send({ error: 'Task not found' });
+    return reply.send(task);
+  });
+
+  f.delete('/tasks/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: AgentQ,
+    },
+  }, async (req, reply) => {
+    const deleted = deleteTask(req.params.id, req.query.agent_id ?? 'default');
+    if (!deleted) return reply.status(404).send({ error: 'Task not found' });
+    return reply.send({ deleted });
+  });
 
   f.patch('/tasks/:id/status', {
     schema: {

--- a/apps/brainctl/src/app/routes/tom.ts
+++ b/apps/brainctl/src/app/routes/tom.ts
@@ -1,0 +1,78 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import {
+  modelAgent, getLatestTomModel, listTomModels,
+  setBudget, recordBudgetUsage, resetBudget, getBudgetStatus,
+} from '../services/tom.service.js';
+
+export async function TomRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // ---- Theory of Mind ----
+
+  // Model another agent's beliefs/intentions from their memory records
+  f.post('/tom/model', {
+    schema: {
+      body: z.object({
+        observer_agent: z.string().min(1),
+        subject_agent: z.string().min(1),
+        topic: z.string().optional(),
+        model: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => reply.send(await modelAgent(req.body)));
+
+  // Retrieve the latest ToM model for a subject
+  f.get('/tom/:observer/model/:subject', {
+    schema: {
+      params: z.object({ observer: z.string(), subject: z.string() }),
+    },
+  }, async (req, reply) => {
+    const model = getLatestTomModel(req.params.observer, req.params.subject);
+    if (!model) return reply.status(404).send({ error: 'No ToM model found' });
+    return reply.send(model);
+  });
+
+  // List all ToM models produced by an observer agent
+  f.get('/tom/:observer/models', {
+    schema: { params: z.object({ observer: z.string() }) },
+  }, async (req, reply) => reply.send(listTomModels(req.params.observer)));
+
+  // ---- Budget ----
+
+  // Set or update token/call budget for an agent
+  f.put('/budget/:agent_id', {
+    schema: {
+      params: z.object({ agent_id: z.string() }),
+      body: z.object({
+        token_budget: z.number().int().min(0).optional(),
+        call_budget: z.number().int().min(0).optional(),
+        reset_at: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.send(setBudget({ agent_id: req.params.agent_id, ...req.body })));
+
+  // Get current budget status
+  f.get('/budget/:agent_id', {
+    schema: { params: z.object({ agent_id: z.string() }) },
+  }, async (req, reply) => reply.send(getBudgetStatus(req.params.agent_id)));
+
+  // Record token/call usage against budget
+  f.post('/budget/:agent_id/usage', {
+    schema: {
+      params: z.object({ agent_id: z.string() }),
+      body: z.object({
+        tokens_used: z.number().int().min(0),
+        calls: z.number().int().min(1).optional(),
+      }),
+    },
+  }, async (req, reply) =>
+    reply.send(recordBudgetUsage(req.params.agent_id, req.body.tokens_used, req.body.calls)));
+
+  // Reset usage counters
+  f.post('/budget/:agent_id/reset', {
+    schema: { params: z.object({ agent_id: z.string() }) },
+  }, async (req, reply) => reply.send(resetBudget(req.params.agent_id)));
+}

--- a/apps/brainctl/src/app/routes/triggers.ts
+++ b/apps/brainctl/src/app/routes/triggers.ts
@@ -1,0 +1,61 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { createTrigger, checkTriggers, getActiveTriggers, deleteTrigger } from '../services/trigger.service.js';
+
+export async function TriggerRoutes(fastify: FastifyInstance) {
+  const f = fastify.withTypeProvider<ZodTypeProvider>();
+
+  f.post('/triggers', {
+    schema: {
+      body: z.object({
+        condition: z.string().min(1),
+        keywords: z.string().min(1),
+        action: z.string().min(1),
+        priority: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+        expires: z.string().optional(),
+        agent_id: z.string().optional(),
+      }),
+      response: {
+        201: z.object({ id: z.number() }),
+      },
+    },
+  }, async (req, reply) => {
+    const id = createTrigger(req.body);
+    return reply.status(201).send({ id });
+  });
+
+  f.get('/triggers', {
+    schema: {
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const triggers = getActiveTriggers(req.query.agent_id);
+    return reply.send(triggers);
+  });
+
+  f.get('/triggers/check', {
+    schema: {
+      querystring: z.object({
+        q: z.string().min(1),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const matches = checkTriggers(req.query.q, req.query.agent_id);
+    return reply.send(matches);
+  });
+
+  f.delete('/triggers/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+      response: {
+        200: z.object({ deleted: z.boolean() }),
+      },
+    },
+  }, async (req, reply) => {
+    const deleted = deleteTrigger(req.params.id, req.query.agent_id);
+    return reply.send({ deleted });
+  });
+}

--- a/apps/brainctl/src/app/routes/triggers.ts
+++ b/apps/brainctl/src/app/routes/triggers.ts
@@ -1,7 +1,7 @@
 import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
-import { createTrigger, checkTriggers, getActiveTriggers, deleteTrigger } from '../services/trigger.service.js';
+import { createTrigger, checkTriggers, getActiveTriggers, deleteTrigger, getTrigger, updateTrigger, fireTrigger } from '../services/trigger.service.js';
 
 export async function TriggerRoutes(fastify: FastifyInstance) {
   const f = fastify.withTypeProvider<ZodTypeProvider>();
@@ -44,6 +44,44 @@ export async function TriggerRoutes(fastify: FastifyInstance) {
   }, async (req, reply) => {
     const matches = checkTriggers(req.query.q, req.query.agent_id);
     return reply.send(matches);
+  });
+
+  f.get('/triggers/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const trigger = getTrigger(req.params.id, req.query.agent_id ?? 'default');
+    if (!trigger) return reply.status(404).send({ error: 'Trigger not found' });
+    return reply.send(trigger);
+  });
+
+  f.patch('/triggers/:id', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      body: z.object({
+        active: z.boolean().optional(),
+        expires: z.string().nullable().optional(),
+        priority: z.enum(['critical', 'high', 'medium', 'low']).optional(),
+        agent_id: z.string().optional(),
+      }),
+    },
+  }, async (req, reply) => {
+    const updated = updateTrigger(req.params.id, req.body);
+    if (!updated) return reply.status(404).send({ error: 'Trigger not found' });
+    return reply.send({ updated });
+  });
+
+  f.post('/triggers/:id/fire', {
+    schema: {
+      params: z.object({ id: z.coerce.number().int() }),
+      querystring: z.object({ agent_id: z.string().optional() }),
+    },
+  }, async (req, reply) => {
+    const trigger = fireTrigger(req.params.id, req.query.agent_id ?? 'default');
+    if (!trigger) return reply.status(404).send({ error: 'Trigger not found' });
+    return reply.send(trigger);
   });
 
   f.delete('/triggers/:id', {

--- a/apps/brainctl/src/app/schemas.ts
+++ b/apps/brainctl/src/app/schemas.ts
@@ -1,0 +1,48 @@
+import { z } from 'zod';
+
+export const MemorySchema = z.object({
+  id: z.number(),
+  agent_id: z.string(),
+  content: z.string(),
+  category: z.string(),
+  tags: z.string().nullable(),
+  confidence: z.number(),
+  memory_type: z.string(),
+  scope: z.string(),
+  replay_priority: z.number(),
+  ripple_tags: z.number(),
+  recalled_count: z.number(),
+  temporal_class: z.string(),
+  last_accessed_at: z.string().nullable(),
+  compressed_into: z.number().nullable(),
+  quarantined_at: z.string().nullable().optional(),
+  created_at: z.string(),
+  retired_at: z.string().nullable(),
+});
+
+export const EventSchema = z.object({
+  id: z.number(),
+  agent_id: z.string(),
+  summary: z.string(),
+  event_type: z.string(),
+  project: z.string().nullable(),
+  importance: z.number(),
+  created_at: z.string(),
+});
+
+export const EntitySchema = z.object({
+  id: z.number(),
+  agent_id: z.string(),
+  name: z.string(),
+  entity_type: z.string(),
+  properties: z.string().nullable(),
+  observations: z.string().nullable(),
+  compiled_truth: z.string().nullable(),
+  tier: z.number(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export const ErrorSchema = z.object({ error: z.string() });
+export const DeletedSchema = z.object({ deleted: z.boolean() });
+export const IdSchema = z.object({ id: z.number() });

--- a/apps/brainctl/src/app/services/affect.service.ts
+++ b/apps/brainctl/src/app/services/affect.service.ts
@@ -1,0 +1,81 @@
+import { getDb } from '../db/database.js';
+
+export interface AffectResult {
+  valence: number;
+  arousal: number;
+  dominance: number;
+  label: string;
+  safety_flags: string[];
+}
+
+const POSITIVE_WORDS = new Set([
+  'good', 'great', 'excellent', 'happy', 'joy', 'love', 'wonderful', 'amazing',
+  'fantastic', 'perfect', 'success', 'win', 'positive', 'benefit', 'helpful',
+  'exciting', 'pleased', 'satisfied', 'confident', 'proud', 'calm', 'safe',
+]);
+
+const NEGATIVE_WORDS = new Set([
+  'bad', 'terrible', 'awful', 'sad', 'hate', 'fear', 'angry', 'worst',
+  'horrible', 'failure', 'lose', 'negative', 'harmful', 'useless', 'broken',
+  'wrong', 'error', 'problem', 'issue', 'danger', 'risk', 'threat', 'urgent',
+]);
+
+const AROUSAL_HIGH = new Set([
+  'urgent', 'emergency', 'critical', 'exciting', 'panic', 'alarm', 'rush',
+  'important', 'immediately', 'now', 'fast', 'quick', 'alert',
+]);
+
+const SAFETY_PATTERNS = [
+  { pattern: /\b(kill|harm|hurt|destroy|attack)\b/i, flag: 'potential_harm' },
+  { pattern: /\b(die|death|suicide)\b/i, flag: 'distress' },
+  { pattern: /\b(urgent|emergency|crisis)\b/i, flag: 'urgency' },
+];
+
+export function classifyAffect(text: string): AffectResult {
+  const words = text.toLowerCase().split(/\W+/).filter(Boolean);
+
+  let valence = 0;
+  let arousalScore = 0;
+
+  for (const word of words) {
+    if (POSITIVE_WORDS.has(word)) valence += 1;
+    if (NEGATIVE_WORDS.has(word)) valence -= 1;
+    if (AROUSAL_HIGH.has(word)) arousalScore += 1;
+  }
+
+  const scale = Math.max(words.length, 1);
+  valence = Math.max(-1, Math.min(1, valence / (scale * 0.3)));
+  const arousal = Math.max(0, Math.min(1, arousalScore / (scale * 0.2)));
+  const dominance = valence > 0 ? 0.6 : valence < 0 ? 0.3 : 0.5;
+
+  const label =
+    valence > 0.3 ? (arousal > 0.5 ? 'excited' : 'positive') :
+    valence < -0.3 ? (arousal > 0.5 ? 'distressed' : 'negative') :
+    'neutral';
+
+  const safety_flags = SAFETY_PATTERNS
+    .filter(({ pattern }) => pattern.test(text))
+    .map(({ flag }) => flag);
+
+  return { valence, arousal, dominance, label, safety_flags };
+}
+
+export function logAffect(text: string, source: string, agentId = 'default'): number {
+  const db = getDb();
+  const result = classifyAffect(text);
+
+  const row = db.prepare(`
+    INSERT INTO affect_log (agent_id, text, source, valence, arousal, dominance, safety_flags)
+    VALUES (@agent_id, @text, @source, @valence, @arousal, @dominance, @safety_flags)
+  `).run({
+    agent_id: agentId,
+    text,
+    source,
+    valence: result.valence,
+    arousal: result.arousal,
+    dominance: result.dominance,
+    safety_flags: result.safety_flags.length ? JSON.stringify(result.safety_flags) : null,
+  });
+
+  return row.lastInsertRowid as number;
+}

--- a/apps/brainctl/src/app/services/affect.service.ts
+++ b/apps/brainctl/src/app/services/affect.service.ts
@@ -60,6 +60,135 @@ export function classifyAffect(text: string): AffectResult {
   return { valence, arousal, dominance, label, safety_flags };
 }
 
+export interface AffectState {
+  valence: number;
+  arousal: number;
+  dominance: number;
+  label: string;
+  sample_count: number;
+  window_minutes: number;
+  safety_flag_counts: Record<string, number>;
+}
+
+export interface AffectThreshold {
+  id: number;
+  agent_id: string;
+  metric: string;
+  operator: string;
+  value: number;
+  created_at: string;
+}
+
+export interface ThresholdBreach {
+  threshold: AffectThreshold;
+  current_value: number;
+  breached: boolean;
+}
+
+function ensureThresholdsTable(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS affect_thresholds (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      metric TEXT NOT NULL,
+      operator TEXT NOT NULL,
+      value REAL NOT NULL,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_affect_thresh_metric_agent
+      ON affect_thresholds(metric, agent_id);
+  `);
+}
+
+export function getAffectState(agentId: string, windowMinutes = 60): AffectState {
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT valence, arousal, dominance, safety_flags
+    FROM affect_log
+    WHERE agent_id = ? AND created_at >= datetime('now', ? || ' minutes')
+    ORDER BY created_at DESC
+  `).all(agentId, `-${windowMinutes}`) as Array<{
+    valence: number; arousal: number; dominance: number; safety_flags: string | null;
+  }>;
+
+  if (!rows.length) {
+    return { valence: 0, arousal: 0, dominance: 0.5, label: 'neutral', sample_count: 0, window_minutes: windowMinutes, safety_flag_counts: {} };
+  }
+
+  const avg = (key: 'valence' | 'arousal' | 'dominance') =>
+    rows.reduce((s, r) => s + r[key], 0) / rows.length;
+
+  const valence = avg('valence');
+  const arousal = avg('arousal');
+  const dominance = avg('dominance');
+
+  const label =
+    valence > 0.3 ? (arousal > 0.5 ? 'excited' : 'positive') :
+    valence < -0.3 ? (arousal > 0.5 ? 'distressed' : 'negative') :
+    'neutral';
+
+  const safety_flag_counts: Record<string, number> = {};
+  for (const row of rows) {
+    if (row.safety_flags) {
+      try {
+        const flags = JSON.parse(row.safety_flags) as string[];
+        for (const f of flags) safety_flag_counts[f] = (safety_flag_counts[f] ?? 0) + 1;
+      } catch { /* malformed */ }
+    }
+  }
+
+  return { valence, arousal, dominance, label, sample_count: rows.length, window_minutes: windowMinutes, safety_flag_counts };
+}
+
+export function getAffectHistory(agentId: string, limit = 50) {
+  return getDb().prepare(
+    'SELECT * FROM affect_log WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?',
+  ).all(agentId, limit);
+}
+
+export function setThreshold(agentId: string, metric: string, operator: string, value: number): number {
+  ensureThresholdsTable();
+  const result = getDb().prepare(`
+    INSERT INTO affect_thresholds (agent_id, metric, operator, value)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT (metric, agent_id) DO UPDATE SET operator = excluded.operator, value = excluded.value
+  `).run(agentId, metric, operator, value);
+  return result.lastInsertRowid as number;
+}
+
+export function listThresholds(agentId: string): AffectThreshold[] {
+  ensureThresholdsTable();
+  return getDb().prepare('SELECT * FROM affect_thresholds WHERE agent_id = ? ORDER BY metric')
+    .all(agentId) as AffectThreshold[];
+}
+
+export function deleteThreshold(agentId: string, id: number): boolean {
+  ensureThresholdsTable();
+  return getDb().prepare('DELETE FROM affect_thresholds WHERE id = ? AND agent_id = ?')
+    .run(id, agentId).changes > 0;
+}
+
+export function checkThresholds(agentId: string, windowMinutes = 60): ThresholdBreach[] {
+  const state = getAffectState(agentId, windowMinutes);
+  const thresholds = listThresholds(agentId);
+  const metricValues: Record<string, number> = {
+    valence: state.valence,
+    arousal: state.arousal,
+    dominance: state.dominance,
+  };
+
+  return thresholds.map((t) => {
+    const current = metricValues[t.metric] ?? 0;
+    let breached = false;
+    if (t.operator === '>') breached = current > t.value;
+    else if (t.operator === '<') breached = current < t.value;
+    else if (t.operator === '>=') breached = current >= t.value;
+    else if (t.operator === '<=') breached = current <= t.value;
+    else if (t.operator === '==' || t.operator === '=') breached = Math.abs(current - t.value) < 0.01;
+    return { threshold: t, current_value: current, breached };
+  });
+}
+
 export function logAffect(text: string, source: string, agentId = 'default'): number {
   const db = getDb();
   const result = classifyAffect(text);

--- a/apps/brainctl/src/app/services/affect.service.ts
+++ b/apps/brainctl/src/app/services/affect.service.ts
@@ -25,6 +25,8 @@ const AROUSAL_HIGH = new Set([
   'important', 'immediately', 'now', 'fast', 'quick', 'alert',
 ]);
 
+// Safety flags are appended regardless of valence so that distress signals
+// are visible even in neutrally-toned text (e.g. clinical reporting).
 const SAFETY_PATTERNS = [
   { pattern: /\b(kill|harm|hurt|destroy|attack)\b/i, flag: 'potential_harm' },
   { pattern: /\b(die|death|suicide)\b/i, flag: 'distress' },

--- a/apps/brainctl/src/app/services/analytics.service.ts
+++ b/apps/brainctl/src/app/services/analytics.service.ts
@@ -93,6 +93,10 @@ export function validateDatabase(agentId: string): {
 
 // ---------------------------------------------------------------------------
 // free_energy_check — homeostatic memory pressure
+// Pressure = active_memories / capacity_target, clamped to [0, 1].
+// A score above 0.9 signals the consolidation engine should run immediately.
+// Named after the free-energy principle (Friston): high pressure = high
+// prediction error in the generative model of the memory store.
 // ---------------------------------------------------------------------------
 
 export function freeEnergyCheck(agentId: string, capacityTarget = 10000): {
@@ -135,6 +139,8 @@ export function freeEnergyCheck(agentId: string, capacityTarget = 10000): {
 
 // ---------------------------------------------------------------------------
 // allostatic_prime — surface memories near decay threshold before consolidation
+// decay_risk ≈ 1 / remaining_half_lives: a memory needing 0.1 more half-lives
+// to hit the retire threshold has risk ≈ 1, while one needing 10 has risk ≈ 0.1.
 // ---------------------------------------------------------------------------
 
 export function allostaticPrime(agentId: string, limit = 20): Array<{

--- a/apps/brainctl/src/app/services/analytics.service.ts
+++ b/apps/brainctl/src/app/services/analytics.service.ts
@@ -1,0 +1,241 @@
+import { getDb, isVecLoaded } from '../db/database.js';
+import { searchMemories } from './memory.service.js';
+
+// ---------------------------------------------------------------------------
+// validate / lint — deep DB consistency checks
+// ---------------------------------------------------------------------------
+
+export interface ValidationIssue {
+  severity: 'critical' | 'warning' | 'info';
+  code: string;
+  message: string;
+  count?: number;
+}
+
+export function validateDatabase(agentId: string): {
+  valid: boolean; issues: ValidationIssue[];
+} {
+  const db = getDb();
+  const issues: ValidationIssue[] = [];
+
+  // Orphaned FTS rows (FTS entry exists but base row is gone)
+  try {
+    const orphanedFts = db.prepare(`
+      SELECT COUNT(*) AS c FROM memories_fts
+      WHERE rowid NOT IN (SELECT id FROM memories)
+    `).get() as { c: number };
+    if (orphanedFts.c > 0) {
+      issues.push({ severity: 'warning', code: 'FTS_ORPHAN_MEMORIES', message: 'FTS5 entries with no matching memory row', count: orphanedFts.c });
+    }
+  } catch { /* FTS not yet populated */ }
+
+  // Missing embeddings
+  if (isVecLoaded()) {
+    try {
+      const missingVec = db.prepare(`
+        SELECT COUNT(*) AS c FROM memories m
+        LEFT JOIN vec_memories v ON v.rowid = m.id
+        WHERE m.agent_id = ? AND m.retired_at IS NULL AND v.rowid IS NULL
+      `).get(agentId) as { c: number };
+      if (missingVec.c > 0) {
+        issues.push({ severity: 'info', code: 'MISSING_EMBEDDINGS', message: 'Active memories without vector embeddings', count: missingVec.c });
+      }
+    } catch { /* vec_memories not loaded */ }
+  }
+
+  // Broken knowledge edges (from_id or to_id points to retired/missing records)
+  try {
+    const brokenEdges = db.prepare(`
+      SELECT COUNT(*) AS c FROM knowledge_edges ke
+      WHERE (ke.from_type = 'memory' AND ke.from_id NOT IN (SELECT id FROM memories WHERE retired_at IS NULL))
+         OR (ke.to_type   = 'memory' AND ke.to_id   NOT IN (SELECT id FROM memories WHERE retired_at IS NULL))
+    `).get() as { c: number };
+    if (brokenEdges.c > 0) {
+      issues.push({ severity: 'warning', code: 'BROKEN_EDGES', message: 'Knowledge edges pointing to retired/missing records', count: brokenEdges.c });
+    }
+  } catch { /* skip */ }
+
+  // Quarantined memories
+  try {
+    const quarantined = db.prepare(
+      "SELECT COUNT(*) AS c FROM memories WHERE agent_id = ? AND quarantined_at IS NOT NULL AND retired_at IS NULL",
+    ).get(agentId) as { c: number };
+    if (quarantined.c > 0) {
+      issues.push({ severity: 'info', code: 'QUARANTINED', message: 'Memories in quarantine pending review', count: quarantined.c });
+    }
+  } catch { /* quarantined_at column may not exist */ }
+
+  // Zero-content entities
+  try {
+    const emptyEntities = db.prepare(`
+      SELECT COUNT(*) AS c FROM entities
+      WHERE agent_id = ? AND (observations IS NULL OR observations = '')
+        AND (compiled_truth IS NULL OR compiled_truth = '')
+    `).get(agentId) as { c: number };
+    if (emptyEntities.c > 0) {
+      issues.push({ severity: 'info', code: 'EMPTY_ENTITIES', message: 'Entities with no observations or compiled truth', count: emptyEntities.c });
+    }
+  } catch { /* skip */ }
+
+  // SQLite integrity
+  try {
+    const check = db.prepare('PRAGMA integrity_check').get() as { integrity_check: string };
+    if (check.integrity_check !== 'ok') {
+      issues.push({ severity: 'critical', code: 'INTEGRITY_FAIL', message: check.integrity_check });
+    }
+  } catch {
+    issues.push({ severity: 'critical', code: 'INTEGRITY_ERROR', message: 'Failed to run integrity check' });
+  }
+
+  const valid = !issues.some((i) => i.severity === 'critical');
+  return { valid, issues };
+}
+
+// ---------------------------------------------------------------------------
+// free_energy_check — homeostatic memory pressure
+// ---------------------------------------------------------------------------
+
+export function freeEnergyCheck(agentId: string, capacityTarget = 10000): {
+  pressure: number;
+  active_memories: number;
+  capacity_target: number;
+  retired_ratio: number;
+  quarantine_ratio: number;
+  low_confidence_ratio: number;
+  recommendations: string[];
+} {
+  const db = getDb();
+
+  const counts = db.prepare(`
+    SELECT
+      SUM(CASE WHEN retired_at IS NULL AND quarantined_at IS NULL THEN 1 ELSE 0 END) AS active,
+      SUM(CASE WHEN retired_at IS NOT NULL THEN 1 ELSE 0 END) AS retired,
+      SUM(CASE WHEN quarantined_at IS NOT NULL AND retired_at IS NULL THEN 1 ELSE 0 END) AS quarantined,
+      SUM(CASE WHEN confidence < 0.4 AND retired_at IS NULL THEN 1 ELSE 0 END) AS low_conf,
+      COUNT(*) AS total
+    FROM memories WHERE agent_id = ?
+  `).get(agentId) as { active: number; retired: number; quarantined: number; low_conf: number; total: number };
+
+  const active = counts.active ?? 0;
+  const total = counts.total ?? 1;
+  const pressure = Math.min(1, active / capacityTarget);
+  const retired_ratio = (counts.retired ?? 0) / Math.max(total, 1);
+  const quarantine_ratio = (counts.quarantined ?? 0) / Math.max(active, 1);
+  const low_confidence_ratio = (counts.low_conf ?? 0) / Math.max(active, 1);
+
+  const recommendations: string[] = [];
+  if (pressure > 0.9) recommendations.push('Run consolidation cycle immediately — memory store near capacity');
+  if (pressure > 0.7) recommendations.push('Consider retiring low-confidence memories');
+  if (low_confidence_ratio > 0.3) recommendations.push('High proportion of low-confidence memories — run retirement analysis');
+  if (quarantine_ratio > 0.1) recommendations.push('Many quarantined memories — review and retire or release');
+  if (retired_ratio > 0.5) recommendations.push('Large retired backlog — run admin/memories/retired purge');
+
+  return { pressure, active_memories: active, capacity_target: capacityTarget, retired_ratio, quarantine_ratio, low_confidence_ratio, recommendations };
+}
+
+// ---------------------------------------------------------------------------
+// allostatic_prime — surface memories near decay threshold before consolidation
+// ---------------------------------------------------------------------------
+
+export function allostaticPrime(agentId: string, limit = 20): Array<{
+  id: number; content: string; confidence: number; temporal_class: string;
+  days_old: number; decay_risk: number;
+}> {
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT id, content, confidence, temporal_class, created_at
+    FROM memories
+    WHERE agent_id = ? AND retired_at IS NULL AND quarantined_at IS NULL
+      AND confidence BETWEEN 0.15 AND 0.45
+    ORDER BY confidence ASC, created_at ASC
+    LIMIT ?
+  `).all(agentId, limit) as Array<{
+    id: number; content: string; confidence: number;
+    temporal_class: string; created_at: string;
+  }>;
+
+  const halfLifeDays: Record<string, number> = {
+    ephemeral: 3.5, short: 10, medium: 23, long: 69,
+  };
+
+  return rows.map((r) => {
+    const days = (Date.now() - new Date(r.created_at).getTime()) / 86400000;
+    const hl = halfLifeDays[r.temporal_class] ?? 23;
+    // Remaining half-lives before hitting 0.1 threshold
+    const remainingDecayFraction = Math.log2(r.confidence / 0.1) * (hl / days || 1);
+    const decay_risk = Math.min(1, 1 / Math.max(0.1, remainingDecayFraction));
+    return {
+      id: r.id, content: r.content, confidence: r.confidence,
+      temporal_class: r.temporal_class, days_old: Math.round(days), decay_risk,
+    };
+  }).sort((a, b) => b.decay_risk - a.decay_risk);
+}
+
+// ---------------------------------------------------------------------------
+// demand_forecast — predict future high-access memories from recall trends
+// ---------------------------------------------------------------------------
+
+export function demandForecast(agentId: string, limit = 20): Array<{
+  id: number; content: string; recalled_count: number;
+  recency_score: number; predicted_demand: number;
+}> {
+  const db = getDb();
+  const rows = db.prepare(`
+    SELECT id, content, recalled_count, last_accessed_at, created_at
+    FROM memories
+    WHERE agent_id = ? AND retired_at IS NULL AND recalled_count > 0
+    ORDER BY recalled_count DESC
+    LIMIT ?
+  `).all(agentId, limit * 2) as Array<{
+    id: number; content: string; recalled_count: number;
+    last_accessed_at: string | null; created_at: string;
+  }>;
+
+  const now = Date.now();
+  return rows.map((r) => {
+    const daysSinceAccess = r.last_accessed_at
+      ? (now - new Date(r.last_accessed_at).getTime()) / 86400000
+      : (now - new Date(r.created_at).getTime()) / 86400000;
+    // Recency-weighted score: recent access + high recall = high demand
+    const recency_score = Math.exp(-daysSinceAccess / 7);
+    const predicted_demand = (r.recalled_count * recency_score) / Math.max(1, daysSinceAccess);
+    return { id: r.id, content: r.content, recalled_count: r.recalled_count, recency_score, predicted_demand };
+  })
+    .sort((a, b) => b.predicted_demand - a.predicted_demand)
+    .slice(0, limit);
+}
+
+// ---------------------------------------------------------------------------
+// retrieval_effectiveness — offline precision/recall for search
+// ---------------------------------------------------------------------------
+
+export async function retrievalEffectiveness(input: {
+  test_cases: Array<{ query: string; expected_ids: number[] }>;
+  agent_id?: string; k?: number;
+}): Promise<{
+  precision_at_k: number;
+  recall_at_k: number;
+  cases: Array<{ query: string; retrieved_ids: number[]; precision: number; recall: number }>;
+}> {
+  const agentId = input.agent_id ?? 'default';
+  const k = input.k ?? 5;
+
+  const cases = await Promise.all(input.test_cases.map(async (tc) => {
+    const results = await searchMemories({ query: tc.query, limit: k, agent_id: agentId });
+    const retrieved = new Set(results.map((r) => r.id));
+    const expected = new Set(tc.expected_ids);
+    const hits = [...retrieved].filter((id) => expected.has(id)).length;
+
+    return {
+      query: tc.query,
+      retrieved_ids: [...retrieved],
+      precision: retrieved.size > 0 ? hits / retrieved.size : 0,
+      recall: expected.size > 0 ? hits / expected.size : 0,
+    };
+  }));
+
+  const avg = (key: 'precision' | 'recall') =>
+    cases.length > 0 ? cases.reduce((s, c) => s + c[key], 0) / cases.length : 0;
+
+  return { precision_at_k: avg('precision'), recall_at_k: avg('recall'), cases };
+}

--- a/apps/brainctl/src/app/services/consolidation.service.ts
+++ b/apps/brainctl/src/app/services/consolidation.service.ts
@@ -64,7 +64,10 @@ const DEFAULTS = {
   batch_limit: 500,
 };
 
-// Half-life in days per temporal class (from brainctl original)
+// Half-life in days per temporal class.
+// Exponential decay formula: confidence(t) = confidence(0) × e^(-λt), λ = ln2/half_life
+// A memory at 0.5 confidence with 'short' class drops below the 0.1 retire threshold
+// after ~33 days without reinforcement.
 const HALF_LIVES: Record<string, number> = {
   ephemeral: 3.5,
   short: 10,
@@ -289,7 +292,9 @@ async function buildVecClusters(
   threshold: number,
   minSize: number
 ): Promise<MemoryRow[][]> {
-  // Union-find clustering via vector KNN
+  // Union-find with path compression: amortised O(α(n)) per lookup.
+  // For each memory we query its K=10 nearest neighbours; any pair within
+  // vec_similarity_threshold distance is merged into the same cluster root.
   const parent = new Map<number, number>();
   const find = (id: number): number => {
     if (parent.get(id) === id) return id;
@@ -338,7 +343,9 @@ function buildFtsClusters(
 
   for (const m of memories) parent.set(m.id, m.id);
 
-  // Group by category first to reduce pairwise comparisons
+  // Group by (category, scope) before pairwise Jaccard — reduces O(n²) to
+  // O(k²) per group where k << n. Each group is further capped at 80 to
+  // prevent runaway comparisons in categories with many similar memories.
   const byCategory = new Map<string, MemoryRow[]>();
   for (const m of memories) {
     const key = `${m.category}::${m.scope}`;

--- a/apps/brainctl/src/app/services/consolidation.service.ts
+++ b/apps/brainctl/src/app/services/consolidation.service.ts
@@ -1,0 +1,687 @@
+import Database from 'better-sqlite3';
+import { getDb, isVecLoaded } from '../db/database.js';
+import { embed, serializeVec, embedBatch } from './embeddings.service.js';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ConsolidationPassResult {
+  pass: string;
+  processed: number;
+  promoted?: number;
+  retired?: number;
+  edges_created?: number;
+  edges_pruned?: number;
+  clusters?: number;
+  issues?: string[];
+  duration_ms: number;
+  dry_run: boolean;
+}
+
+export interface ConsolidationReport {
+  agent_id: string;
+  started_at: string;
+  completed_at: string;
+  passes: ConsolidationPassResult[];
+  total_duration_ms: number;
+  dry_run: boolean;
+}
+
+export interface ConsolidationOptions {
+  decay_rate?: number;
+  protect_confidence?: number;
+  protect_recall_min?: number;
+  retire_threshold?: number;
+  promote_min_priority?: number;
+  promote_min_ripple_tags?: number;
+  promote_min_confidence?: number;
+  compression_min_cluster?: number;
+  vec_similarity_threshold?: number;
+  fts_overlap_threshold?: number;
+  hebbian_boost?: number;
+  hebbian_decay?: number;
+  prune_threshold?: number;
+  passes?: Array<'decay' | 'promote' | 'compress' | 'hebbian' | 'gap_scan' | 'entity_tiers'>;
+  dry_run?: boolean;
+  batch_limit?: number;
+}
+
+const DEFAULTS = {
+  decay_rate: 0.05,
+  protect_confidence: 0.8,
+  protect_recall_min: 10,
+  retire_threshold: 0.1,
+  promote_min_priority: 0.3,
+  promote_min_ripple_tags: 3,
+  promote_min_confidence: 0.7,
+  compression_min_cluster: 3,
+  vec_similarity_threshold: 0.18,
+  fts_overlap_threshold: 0.4,
+  hebbian_boost: 0.1,
+  hebbian_decay: 0.02,
+  prune_threshold: 0.05,
+  batch_limit: 500,
+};
+
+// Half-life in days per temporal class (from brainctl original)
+const HALF_LIVES: Record<string, number> = {
+  ephemeral: 3.5,
+  short: 10,
+  medium: 23,
+  long: 69,
+};
+
+// ---------------------------------------------------------------------------
+// Pass 1 — Decay
+// ---------------------------------------------------------------------------
+
+export function runDecayPass(agentId: string, opts: ConsolidationOptions): ConsolidationPassResult {
+  const t0 = Date.now();
+  const db = getDb();
+  const dryRun = opts.dry_run ?? false;
+  const protectConf = opts.protect_confidence ?? DEFAULTS.protect_confidence;
+  const protectRecall = opts.protect_recall_min ?? DEFAULTS.protect_recall_min;
+  const retireThreshold = opts.retire_threshold ?? DEFAULTS.retire_threshold;
+  const limit = opts.batch_limit ?? DEFAULTS.batch_limit;
+
+  const memories = db.prepare(`
+    SELECT id, confidence, recalled_count, temporal_class, created_at
+    FROM memories
+    WHERE agent_id = @agent_id AND retired_at IS NULL
+    LIMIT @limit
+  `).all({ agent_id: agentId, limit }) as Array<{
+    id: number; confidence: number; recalled_count: number;
+    temporal_class: string; created_at: string;
+  }>;
+
+  let processed = 0;
+  let retired = 0;
+  const now = Date.now();
+
+  const updates: Array<{ id: number; confidence: number; temporal_class: string; retire: boolean }> = [];
+
+  for (const m of memories) {
+    // Protected memories skip decay
+    if (m.confidence >= protectConf && m.recalled_count >= protectRecall) continue;
+
+    const ageDays = (now - new Date(m.created_at).getTime()) / 86_400_000;
+    const temporalClass = classifyTemporalClass(ageDays, m.temporal_class);
+    const halfLife = HALF_LIVES[temporalClass] ?? HALF_LIVES.medium;
+    const lambda = Math.LN2 / halfLife;
+    const decayed = m.confidence * Math.exp(-lambda * ageDays);
+    const newConf = Math.max(0, Math.min(1, decayed));
+
+    processed++;
+    updates.push({
+      id: m.id,
+      confidence: newConf,
+      temporal_class: temporalClass,
+      retire: newConf < retireThreshold,
+    });
+    if (newConf < retireThreshold) retired++;
+  }
+
+  if (!dryRun && updates.length) {
+    const updateStmt = db.prepare(`
+      UPDATE memories SET confidence = @conf, temporal_class = @tc
+      WHERE id = @id
+    `);
+    const retireStmt = db.prepare(`
+      UPDATE memories SET retired_at = datetime('now'), confidence = @conf, temporal_class = @tc
+      WHERE id = @id
+    `);
+    const tx = db.transaction(() => {
+      for (const u of updates) {
+        if (u.retire) retireStmt.run({ conf: u.confidence, tc: u.temporal_class, id: u.id });
+        else updateStmt.run({ conf: u.confidence, tc: u.temporal_class, id: u.id });
+      }
+    });
+    tx();
+  }
+
+  return { pass: 'decay', processed, retired, duration_ms: Date.now() - t0, dry_run: dryRun };
+}
+
+function classifyTemporalClass(ageDays: number, current: string): string {
+  if (ageDays < 7) return 'ephemeral';
+  if (ageDays < 30) return 'short';
+  if (ageDays < 90) return 'medium';
+  return 'long';
+}
+
+// ---------------------------------------------------------------------------
+// Pass 2 — Promotion (episodic → semantic)
+// ---------------------------------------------------------------------------
+
+export function runPromotionPass(agentId: string, opts: ConsolidationOptions): ConsolidationPassResult {
+  const t0 = Date.now();
+  const db = getDb();
+  const dryRun = opts.dry_run ?? false;
+  const minPriority = opts.promote_min_priority ?? DEFAULTS.promote_min_priority;
+  const minRipple = opts.promote_min_ripple_tags ?? DEFAULTS.promote_min_ripple_tags;
+  const minConf = opts.promote_min_confidence ?? DEFAULTS.promote_min_confidence;
+  const limit = opts.batch_limit ?? DEFAULTS.batch_limit;
+
+  const candidates = db.prepare(`
+    SELECT id FROM memories
+    WHERE agent_id = @agent_id
+      AND memory_type = 'episodic'
+      AND retired_at IS NULL
+      AND replay_priority >= @min_priority
+      AND ripple_tags >= @min_ripple
+      AND confidence >= @min_conf
+    ORDER BY replay_priority DESC
+    LIMIT @limit
+  `).all({ agent_id: agentId, min_priority: minPriority, min_ripple: minRipple, min_conf: minConf, limit }) as Array<{ id: number }>;
+
+  if (!dryRun && candidates.length) {
+    const stmt = db.prepare(`
+      UPDATE memories
+      SET memory_type = 'semantic', replay_priority = 0, ripple_tags = 0
+      WHERE id = @id
+    `);
+    const tx = db.transaction(() => { for (const c of candidates) stmt.run({ id: c.id }); });
+    tx();
+  }
+
+  return { pass: 'promote', processed: candidates.length, promoted: candidates.length, duration_ms: Date.now() - t0, dry_run: dryRun };
+}
+
+// ---------------------------------------------------------------------------
+// Pass 3 — Compression (cluster similar memories, merge each cluster)
+// ---------------------------------------------------------------------------
+
+interface MemoryRow {
+  id: number; content: string; category: string; scope: string;
+  confidence: number; tags: string | null; agent_id: string;
+}
+
+export async function runCompressionPass(agentId: string, opts: ConsolidationOptions): Promise<ConsolidationPassResult> {
+  const t0 = Date.now();
+  const db = getDb();
+  const dryRun = opts.dry_run ?? false;
+  const minCluster = opts.compression_min_cluster ?? DEFAULTS.compression_min_cluster;
+  const vecThreshold = opts.vec_similarity_threshold ?? DEFAULTS.vec_similarity_threshold;
+  const ftsThreshold = opts.fts_overlap_threshold ?? DEFAULTS.fts_overlap_threshold;
+  const limit = opts.batch_limit ?? DEFAULTS.batch_limit;
+
+  const memories = db.prepare(`
+    SELECT id, content, category, scope, confidence, tags, agent_id
+    FROM memories
+    WHERE agent_id = @agent_id AND retired_at IS NULL AND compressed_into IS NULL
+    ORDER BY confidence ASC
+    LIMIT @limit
+  `).all({ agent_id: agentId, limit }) as MemoryRow[];
+
+  if (memories.length < minCluster) {
+    return { pass: 'compress', processed: 0, clusters: 0, retired: 0, duration_ms: Date.now() - t0, dry_run: dryRun };
+  }
+
+  const clusters = isVecLoaded()
+    ? await buildVecClusters(db, memories, vecThreshold, minCluster)
+    : buildFtsClusters(db, memories, ftsThreshold, minCluster);
+
+  let retired = 0;
+  let clustersCreated = 0;
+
+  if (!dryRun) {
+    for (const cluster of clusters) {
+      const merged = mergeCluster(cluster);
+      const insertResult = db.prepare(`
+        INSERT INTO memories (agent_id, content, category, tags, confidence, memory_type, scope, ripple_tags)
+        VALUES (@agent_id, @content, @category, @tags, @confidence, 'semantic', @scope, @ripple_tags)
+      `).run({
+        agent_id: agentId,
+        content: merged.content,
+        category: merged.category,
+        scope: merged.scope,
+        tags: merged.tags,
+        confidence: merged.confidence,
+        ripple_tags: cluster.length,
+      });
+
+      const newId = insertResult.lastInsertRowid as number;
+
+      const retireStmt = db.prepare(`
+        UPDATE memories SET retired_at = datetime('now'), compressed_into = @into
+        WHERE id = @id
+      `);
+      const tx = db.transaction(() => {
+        for (const m of cluster) retireStmt.run({ into: newId, id: m.id });
+      });
+      tx();
+
+      // Migrate edges from retired memories to the new merged memory
+      db.prepare(`
+        UPDATE knowledge_edges SET from_id = @new WHERE from_type = 'memory' AND from_id IN (${cluster.map(() => '?').join(',')})
+      `).run(newId, ...cluster.map((m) => m.id));
+      db.prepare(`
+        UPDATE knowledge_edges SET to_id = @new WHERE to_type = 'memory' AND to_id IN (${cluster.map(() => '?').join(',')})
+      `).run(newId, ...cluster.map((m) => m.id));
+
+      // Embed the merged memory if vec is available
+      if (isVecLoaded()) {
+        const vec = await embed(merged.content);
+        if (vec) {
+          db.prepare('INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?, ?)').run(newId, serializeVec(vec));
+        }
+      }
+
+      retired += cluster.length;
+      clustersCreated++;
+    }
+  }
+
+  return {
+    pass: 'compress',
+    processed: memories.length,
+    clusters: dryRun ? clusters.length : clustersCreated,
+    retired,
+    duration_ms: Date.now() - t0,
+    dry_run: dryRun,
+  };
+}
+
+async function buildVecClusters(
+  db: Database.Database,
+  memories: MemoryRow[],
+  threshold: number,
+  minSize: number
+): Promise<MemoryRow[][]> {
+  // Union-find clustering via vector KNN
+  const parent = new Map<number, number>();
+  const find = (id: number): number => {
+    if (parent.get(id) === id) return id;
+    const root = find(parent.get(id)!);
+    parent.set(id, root);
+    return root;
+  };
+  const union = (a: number, b: number) => { parent.set(find(a), find(b)); };
+
+  for (const m of memories) parent.set(m.id, m.id);
+
+  for (const m of memories) {
+    try {
+      const neighbors = db.prepare(`
+        SELECT v.rowid, v.distance FROM vec_memories v
+        WHERE v.embedding MATCH (SELECT embedding FROM vec_memories WHERE rowid = ?) AND k = 10
+        AND v.distance <= ? AND v.rowid != ?
+        ORDER BY v.distance
+      `).all(m.id, threshold, m.id) as Array<{ rowid: number; distance: number }>;
+
+      for (const n of neighbors) {
+        if (parent.has(n.rowid)) union(m.id, n.rowid);
+      }
+    } catch {
+      // vec_memories entry may not exist for this memory
+    }
+  }
+
+  return collectClusters(memories, find, minSize);
+}
+
+function buildFtsClusters(
+  db: Database.Database,
+  memories: MemoryRow[],
+  threshold: number,
+  minSize: number
+): MemoryRow[][] {
+  const parent = new Map<number, number>();
+  const find = (id: number): number => {
+    if (parent.get(id) === id) return id;
+    const root = find(parent.get(id)!);
+    parent.set(id, root);
+    return root;
+  };
+  const union = (a: number, b: number) => { parent.set(find(a), find(b)); };
+
+  for (const m of memories) parent.set(m.id, m.id);
+
+  // Group by category first to reduce pairwise comparisons
+  const byCategory = new Map<string, MemoryRow[]>();
+  for (const m of memories) {
+    const key = `${m.category}::${m.scope}`;
+    if (!byCategory.has(key)) byCategory.set(key, []);
+    byCategory.get(key)!.push(m);
+  }
+
+  for (const group of byCategory.values()) {
+    if (group.length < 2) continue;
+    // Cap group size to avoid O(n²) blowup
+    const sample = group.slice(0, 80);
+    for (let i = 0; i < sample.length; i++) {
+      for (let j = i + 1; j < sample.length; j++) {
+        if (jaccardSimilarity(sample[i].content, sample[j].content) >= threshold) {
+          union(sample[i].id, sample[j].id);
+        }
+      }
+    }
+  }
+
+  return collectClusters(memories, find, minSize);
+}
+
+function collectClusters(memories: MemoryRow[], find: (id: number) => number, minSize: number): MemoryRow[][] {
+  const groups = new Map<number, MemoryRow[]>();
+  for (const m of memories) {
+    const root = find(m.id);
+    if (!groups.has(root)) groups.set(root, []);
+    groups.get(root)!.push(m);
+  }
+  return Array.from(groups.values()).filter((g) => g.length >= minSize);
+}
+
+function jaccardSimilarity(a: string, b: string): number {
+  const tokA = new Set(tokenize(a));
+  const tokB = new Set(tokenize(b));
+  const intersection = new Set([...tokA].filter((t) => tokB.has(t)));
+  const union = new Set([...tokA, ...tokB]);
+  return union.size === 0 ? 0 : intersection.size / union.size;
+}
+
+function tokenize(text: string): string[] {
+  return text.toLowerCase().replace(/[^\w\s]/g, ' ').split(/\s+/).filter((t) => t.length > 2);
+}
+
+function mergeCluster(cluster: MemoryRow[]): { content: string; category: string; scope: string; tags: string | null; confidence: number } {
+  // Sort by confidence descending; primary content comes from most confident member
+  const sorted = [...cluster].sort((a, b) => b.confidence - a.confidence);
+  const primary = sorted[0];
+
+  const uniqueSentences = dedupeSentences(cluster.map((m) => m.content));
+  const content = uniqueSentences.slice(0, 6).join(' ');
+
+  const allTags = cluster.flatMap((m) => (m.tags ? m.tags.split(',') : []));
+  const tags = [...new Set(allTags)].join(',') || null;
+
+  const avgConf = cluster.reduce((s, m) => s + m.confidence, 0) / cluster.length;
+
+  return {
+    content,
+    category: primary.category,
+    scope: primary.scope,
+    tags,
+    confidence: Math.min(1, avgConf * 1.1),
+  };
+}
+
+function dedupeSentences(texts: string[]): string[] {
+  const sentences = texts.flatMap((t) => t.split(/[.!?]+/).map((s) => s.trim()).filter(Boolean));
+  const seen = new Set<string>();
+  return sentences.filter((s) => {
+    const key = s.toLowerCase().replace(/\s+/g, ' ');
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pass 4 — Hebbian (strengthen edges between high-confidence co-activations)
+// ---------------------------------------------------------------------------
+
+export function runHebbianPass(agentId: string, opts: ConsolidationOptions): ConsolidationPassResult {
+  const t0 = Date.now();
+  const db = getDb();
+  const dryRun = opts.dry_run ?? false;
+  const boost = opts.hebbian_boost ?? DEFAULTS.hebbian_boost;
+  const decay = opts.hebbian_decay ?? DEFAULTS.hebbian_decay;
+  const pruneAt = opts.prune_threshold ?? DEFAULTS.prune_threshold;
+
+  // Get all edges touching this agent's memories
+  const edges = db.prepare(`
+    SELECT ke.id, ke.weight, ke.from_id, ke.to_id,
+           mf.confidence AS from_conf, mf.retired_at AS from_retired,
+           mt.confidence AS to_conf, mt.retired_at AS to_retired
+    FROM knowledge_edges ke
+    JOIN memories mf ON mf.id = ke.from_id
+    JOIN memories mt ON mt.id = ke.to_id
+    WHERE ke.from_type = 'memory' AND ke.to_type = 'memory'
+      AND mf.agent_id = @agent_id
+  `).all({ agent_id: agentId }) as Array<{
+    id: number; weight: number; from_id: number; to_id: number;
+    from_conf: number; from_retired: string | null;
+    to_conf: number; to_retired: string | null;
+  }>;
+
+  const toUpdate: Array<{ id: number; weight: number }> = [];
+  const toPrune: number[] = [];
+
+  for (const e of edges) {
+    const eitherRetired = e.from_retired || e.to_retired;
+    if (eitherRetired) {
+      toPrune.push(e.id);
+      continue;
+    }
+
+    const bothStrong = e.from_conf >= 0.6 && e.to_conf >= 0.6;
+    const newWeight = bothStrong
+      ? Math.min(2.0, e.weight + boost)
+      : Math.max(0, e.weight - decay);
+
+    if (newWeight < pruneAt) toPrune.push(e.id);
+    else toUpdate.push({ id: e.id, weight: newWeight });
+  }
+
+  if (!dryRun) {
+    const updateStmt = db.prepare('UPDATE knowledge_edges SET weight = @w WHERE id = @id');
+    const pruneStmt = db.prepare('DELETE FROM knowledge_edges WHERE id = @id');
+    const tx = db.transaction(() => {
+      for (const u of toUpdate) updateStmt.run({ w: u.weight, id: u.id });
+      for (const id of toPrune) pruneStmt.run({ id });
+    });
+    tx();
+  }
+
+  return {
+    pass: 'hebbian',
+    processed: edges.length,
+    edges_created: toUpdate.length,
+    edges_pruned: toPrune.length,
+    duration_ms: Date.now() - t0,
+    dry_run: dryRun,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pass 5 — Gap scan
+// ---------------------------------------------------------------------------
+
+export function runGapScanPass(agentId: string, opts: ConsolidationOptions): ConsolidationPassResult {
+  const t0 = Date.now();
+  const db = getDb();
+  const dryRun = opts.dry_run ?? false;
+  const issues: string[] = [];
+
+  // Orphaned memories: no edges, old (> 30 days), low confidence
+  const orphanedMemories = db.prepare(`
+    SELECT COUNT(*) AS cnt FROM memories m
+    LEFT JOIN knowledge_edges ke ON ke.from_type = 'memory' AND ke.from_id = m.id
+    WHERE m.agent_id = @agent_id AND m.retired_at IS NULL
+      AND ke.id IS NULL
+      AND julianday('now') - julianday(m.created_at) > 30
+      AND m.confidence < 0.4
+  `).get({ agent_id: agentId }) as { cnt: number };
+
+  if (orphanedMemories.cnt > 0) {
+    issues.push(`${orphanedMemories.cnt} orphaned low-confidence memories older than 30 days`);
+  }
+
+  // Entities with no observations and no edges
+  const emptyEntities = db.prepare(`
+    SELECT COUNT(*) AS cnt FROM entities e
+    LEFT JOIN knowledge_edges ke ON ke.from_type = 'entity' AND ke.from_id = e.id
+    WHERE e.agent_id = @agent_id AND e.observations IS NULL AND ke.id IS NULL
+  `).get({ agent_id: agentId }) as { cnt: number };
+
+  if (emptyEntities.cnt > 0) {
+    issues.push(`${emptyEntities.cnt} entities with no observations or edges`);
+  }
+
+  // Broken edges (pointing to retired memories)
+  const brokenEdges = db.prepare(`
+    SELECT COUNT(*) AS cnt FROM knowledge_edges ke
+    JOIN memories m ON m.id = ke.from_id
+    WHERE ke.from_type = 'memory' AND m.retired_at IS NOT NULL
+    UNION ALL
+    SELECT COUNT(*) AS cnt FROM knowledge_edges ke
+    JOIN memories m ON m.id = ke.to_id
+    WHERE ke.to_type = 'memory' AND m.retired_at IS NOT NULL
+  `).all() as Array<{ cnt: number }>;
+
+  const totalBroken = brokenEdges.reduce((s, r) => s + r.cnt, 0);
+  if (totalBroken > 0) {
+    issues.push(`${totalBroken} knowledge edges pointing to retired memories`);
+  }
+
+  // Memories missing vector embeddings (if vec is available)
+  if (isVecLoaded()) {
+    try {
+      const missingVec = db.prepare(`
+        SELECT COUNT(*) AS cnt FROM memories m
+        LEFT JOIN vec_memories v ON v.rowid = m.id
+        WHERE m.agent_id = @agent_id AND m.retired_at IS NULL AND v.rowid IS NULL
+      `).get({ agent_id: agentId }) as { cnt: number };
+
+      if (missingVec.cnt > 0) {
+        issues.push(`${missingVec.cnt} memories missing vector embeddings (run POST /embeddings/backfill)`);
+      }
+    } catch { /* vec table not ready */ }
+  }
+
+  return {
+    pass: 'gap_scan',
+    processed: 1,
+    issues,
+    duration_ms: Date.now() - t0,
+    dry_run: dryRun,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pass 6 — Entity tier promotion
+// ---------------------------------------------------------------------------
+
+export function runEntityTierPass(agentId: string, opts: ConsolidationOptions): ConsolidationPassResult {
+  const t0 = Date.now();
+  const db = getDb();
+  const dryRun = opts.dry_run ?? false;
+
+  const entities = db.prepare(`
+    SELECT e.id,
+      (SELECT COUNT(*) FROM knowledge_edges ke WHERE ke.from_id = e.id OR ke.to_id = e.id) AS edge_count
+    FROM entities e
+    WHERE e.agent_id = @agent_id
+  `).all({ agent_id: agentId }) as Array<{ id: number; edge_count: number }>;
+
+  const updates: Array<{ id: number; tier: number }> = [];
+  for (const e of entities) {
+    const tier = e.edge_count >= 20 ? 3 : e.edge_count >= 5 ? 2 : 1;
+    updates.push({ id: e.id, tier });
+  }
+
+  if (!dryRun && updates.length) {
+    const stmt = db.prepare('UPDATE entities SET tier = @tier WHERE id = @id');
+    const tx = db.transaction(() => { for (const u of updates) stmt.run(u); });
+    tx();
+  }
+
+  const promoted = updates.filter((u) => u.tier >= 2).length;
+  return {
+    pass: 'entity_tiers',
+    processed: entities.length,
+    promoted,
+    duration_ms: Date.now() - t0,
+    dry_run: dryRun,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator — full cycle
+// ---------------------------------------------------------------------------
+
+const ALL_PASSES = ['decay', 'promote', 'compress', 'hebbian', 'gap_scan', 'entity_tiers'] as const;
+
+export async function runConsolidationCycle(
+  agentId: string,
+  opts: ConsolidationOptions = {}
+): Promise<ConsolidationReport> {
+  const db = getDb();
+  const startedAt = new Date().toISOString();
+  const passes = (opts.passes ?? ALL_PASSES) as string[];
+  const dryRun = opts.dry_run ?? false;
+
+  const logId = (db.prepare(`
+    INSERT INTO consolidation_log (agent_id, started_at, status)
+    VALUES (@agent_id, @started_at, 'running')
+  `).run({ agent_id: agentId, started_at: startedAt }).lastInsertRowid) as number;
+
+  const results: ConsolidationPassResult[] = [];
+
+  try {
+    if (passes.includes('decay')) results.push(runDecayPass(agentId, opts));
+    if (passes.includes('promote')) results.push(runPromotionPass(agentId, opts));
+    if (passes.includes('compress')) results.push(await runCompressionPass(agentId, opts));
+    if (passes.includes('hebbian')) results.push(runHebbianPass(agentId, opts));
+    if (passes.includes('gap_scan')) results.push(runGapScanPass(agentId, opts));
+    if (passes.includes('entity_tiers')) results.push(runEntityTierPass(agentId, opts));
+  } catch (err) {
+    const completedAt = new Date().toISOString();
+    const report: ConsolidationReport = {
+      agent_id: agentId,
+      started_at: startedAt,
+      completed_at: completedAt,
+      passes: results,
+      total_duration_ms: new Date(completedAt).getTime() - new Date(startedAt).getTime(),
+      dry_run: dryRun,
+    };
+    if (!dryRun) {
+      db.prepare(`UPDATE consolidation_log SET completed_at = @t, status = 'failed', report = @r WHERE id = @id`)
+        .run({ t: completedAt, r: JSON.stringify(report), id: logId });
+    }
+    throw err;
+  }
+
+  const completedAt = new Date().toISOString();
+  const report: ConsolidationReport = {
+    agent_id: agentId,
+    started_at: startedAt,
+    completed_at: completedAt,
+    passes: results,
+    total_duration_ms: new Date(completedAt).getTime() - new Date(startedAt).getTime(),
+    dry_run: dryRun,
+  };
+
+  if (!dryRun) {
+    db.prepare(`UPDATE consolidation_log SET completed_at = @t, status = 'complete', report = @r WHERE id = @id`)
+      .run({ t: completedAt, r: JSON.stringify(report), id: logId });
+  }
+
+  return report;
+}
+
+export function getLastConsolidation(agentId: string) {
+  const db = getDb();
+  const row = db.prepare(`
+    SELECT * FROM consolidation_log
+    WHERE agent_id = @agent_id
+    ORDER BY started_at DESC LIMIT 1
+  `).get({ agent_id: agentId }) as { id: number; started_at: string; completed_at: string | null; status: string; report: string | null } | undefined;
+
+  if (!row) return null;
+  return {
+    ...row,
+    report: row.report ? JSON.parse(row.report) : null,
+  };
+}
+
+export function getConsolidationHistory(agentId: string, limit = 10) {
+  const db = getDb();
+  return (db.prepare(`
+    SELECT id, agent_id, started_at, completed_at, status
+    FROM consolidation_log
+    WHERE agent_id = @agent_id
+    ORDER BY started_at DESC LIMIT @limit
+  `).all({ agent_id: agentId, limit }) as Array<Record<string, unknown>>);
+}

--- a/apps/brainctl/src/app/services/context.service.ts
+++ b/apps/brainctl/src/app/services/context.service.ts
@@ -1,0 +1,214 @@
+import { getDb, isVecLoaded } from '../db/database.js';
+import { embed, serializeVec } from './embeddings.service.js';
+
+export interface ContextChunk {
+  id: number;
+  agent_id: string;
+  document: string;
+  chunk_index: number;
+  content: string;
+  metadata: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface DocumentSummary {
+  document: string;
+  chunks: number;
+  last_updated: string;
+}
+
+function ensureContextTable(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS context (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      document TEXT NOT NULL,
+      chunk_index INTEGER NOT NULL,
+      content TEXT NOT NULL,
+      metadata TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_context_doc_chunk_agent
+      ON context(document, chunk_index, agent_id);
+    CREATE INDEX IF NOT EXISTS idx_context_agent ON context(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_context_document ON context(document, agent_id);
+    CREATE VIRTUAL TABLE IF NOT EXISTS context_fts USING fts5(
+      content, document, metadata,
+      content='context', content_rowid='id'
+    );
+    CREATE TRIGGER IF NOT EXISTS context_ai AFTER INSERT ON context BEGIN
+      INSERT INTO context_fts(rowid, content, document, metadata)
+      VALUES (new.id, new.content, new.document, COALESCE(new.metadata, ''));
+    END;
+    CREATE TRIGGER IF NOT EXISTS context_au AFTER UPDATE ON context BEGIN
+      INSERT INTO context_fts(context_fts, rowid, content, document, metadata)
+      VALUES ('delete', old.id, old.content, old.document, COALESCE(old.metadata, ''));
+      INSERT INTO context_fts(rowid, content, document, metadata)
+      VALUES (new.id, new.content, new.document, COALESCE(new.metadata, ''));
+    END;
+    CREATE TRIGGER IF NOT EXISTS context_ad AFTER DELETE ON context BEGIN
+      INSERT INTO context_fts(context_fts, rowid, content, document, metadata)
+      VALUES ('delete', old.id, old.content, old.document, COALESCE(old.metadata, ''));
+    END;
+  `);
+}
+
+function chunkText(text: string, chunkSize: number, overlap: number): string[] {
+  const words = text.split(/\s+/).filter(Boolean);
+  const chunks: string[] = [];
+  const step = Math.max(1, chunkSize - overlap);
+
+  for (let i = 0; i < words.length; i += step) {
+    const slice = words.slice(i, i + chunkSize).join(' ');
+    if (slice) chunks.push(slice);
+    if (i + chunkSize >= words.length) break;
+  }
+
+  return chunks;
+}
+
+export async function ingestDocument(input: {
+  document: string;
+  content: string;
+  agent_id?: string;
+  chunk_size?: number;
+  overlap?: number;
+  metadata?: string;
+}): Promise<{ document: string; chunks: number; ids: number[] }> {
+  ensureContextTable();
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const chunkSize = input.chunk_size ?? 300;
+  const overlap = input.overlap ?? 50;
+
+  // Remove existing chunks for this document before reingest
+  const existing = db.prepare('SELECT id FROM context WHERE document = ? AND agent_id = ?')
+    .all(input.document, agentId) as Array<{ id: number }>;
+  if (existing.length) {
+    const ids = existing.map((r) => r.id);
+    db.prepare(`DELETE FROM context WHERE id IN (${ids.map(() => '?').join(',')})`).run(...ids);
+    if (isVecLoaded()) {
+      db.prepare(`DELETE FROM vec_context WHERE rowid IN (${ids.map(() => '?').join(',')})`).run(...ids);
+    }
+  }
+
+  const chunks = chunkText(input.content, chunkSize, overlap);
+  const insertedIds: number[] = [];
+
+  for (let i = 0; i < chunks.length; i++) {
+    const result = db.prepare(`
+      INSERT INTO context (agent_id, document, chunk_index, content, metadata)
+      VALUES (?, ?, ?, ?, ?)
+    `).run(agentId, input.document, i, chunks[i], input.metadata ?? null);
+    const rowId = result.lastInsertRowid as number;
+    insertedIds.push(rowId);
+
+    if (isVecLoaded()) {
+      const vec = await embed(chunks[i]);
+      if (vec) {
+        db.prepare('INSERT OR REPLACE INTO vec_context(rowid, embedding) VALUES (?, ?)')
+          .run(rowId, serializeVec(vec));
+      }
+    }
+  }
+
+  return { document: input.document, chunks: chunks.length, ids: insertedIds };
+}
+
+export function getDocument(document: string, agentId: string): ContextChunk[] {
+  ensureContextTable();
+  return getDb()
+    .prepare('SELECT * FROM context WHERE document = ? AND agent_id = ? ORDER BY chunk_index')
+    .all(document, agentId) as ContextChunk[];
+}
+
+export function listDocuments(agentId: string): DocumentSummary[] {
+  ensureContextTable();
+  return getDb().prepare(`
+    SELECT document, COUNT(*) AS chunks, MAX(updated_at) AS last_updated
+    FROM context WHERE agent_id = ?
+    GROUP BY document ORDER BY last_updated DESC
+  `).all(agentId) as DocumentSummary[];
+}
+
+export function deleteDocument(document: string, agentId: string): number {
+  ensureContextTable();
+  const db = getDb();
+  const rows = db.prepare('SELECT id FROM context WHERE document = ? AND agent_id = ?')
+    .all(document, agentId) as Array<{ id: number }>;
+  if (!rows.length) return 0;
+
+  const ids = rows.map((r) => r.id);
+  if (isVecLoaded()) {
+    db.prepare(`DELETE FROM vec_context WHERE rowid IN (${ids.map(() => '?').join(',')})`).run(...ids);
+  }
+  const result = db.prepare(`DELETE FROM context WHERE id IN (${ids.map(() => '?').join(',')})`).run(...ids);
+  return result.changes;
+}
+
+export async function searchContext(input: {
+  query: string;
+  agent_id?: string;
+  document?: string;
+  limit?: number;
+}): Promise<Array<ContextChunk & { score: number }>> {
+  ensureContextTable();
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const limit = input.limit ?? 10;
+  const docFilter = input.document ? 'AND c.document = ?' : '';
+  const docParams: unknown[] = input.document ? [input.document] : [];
+
+  // FTS5 results
+  const ftsRows = db.prepare(`
+    SELECT c.*, cf.rank AS fts_rank
+    FROM context_fts cf
+    JOIN context c ON c.id = cf.rowid
+    WHERE context_fts MATCH ? AND c.agent_id = ? ${docFilter}
+    ORDER BY cf.rank LIMIT ?
+  `).all(input.query, agentId, ...docParams, limit * 2) as Array<ContextChunk & { fts_rank: number }>;
+
+  const ftsMap = new Map<number, number>();
+  ftsRows.forEach((r, i) => ftsMap.set(r.id, i + 1));
+
+  // Vector results (if available)
+  const vecMap = new Map<number, number>();
+  if (isVecLoaded()) {
+    const vec = await embed(input.query);
+    if (vec) {
+      const vecRows = db.prepare(`
+        SELECT c.id, v.distance
+        FROM vec_context v
+        JOIN context c ON c.id = v.rowid
+        WHERE c.agent_id = ? ${docFilter}
+        ORDER BY v.distance LIMIT ?
+      `).all(agentId, ...docParams, limit * 2) as Array<{ id: number; distance: number }>;
+      vecRows.forEach((r, i) => vecMap.set(r.id, i + 1));
+    }
+  }
+
+  // RRF merge (K=60)
+  const K = 60;
+  const allIds = new Set([...ftsMap.keys(), ...vecMap.keys()]);
+  const scored = Array.from(allIds).map((id) => {
+    const ftsRank = ftsMap.has(id) ? 1 / (K + ftsMap.get(id)!) : 0;
+    const vecRank = vecMap.has(id) ? 1 / (K + vecMap.get(id)!) : 0;
+    return { id, score: ftsRank + vecRank };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  const topIds = scored.slice(0, limit).map((s) => s.id);
+  if (!topIds.length) return [];
+
+  const rows = db.prepare(
+    `SELECT * FROM context WHERE id IN (${topIds.map(() => '?').join(',')})`,
+  ).all(...topIds) as ContextChunk[];
+
+  const rowMap = new Map(rows.map((r) => [r.id, r]));
+  return topIds
+    .filter((id) => rowMap.has(id))
+    .map((id) => ({ ...rowMap.get(id)!, score: scored.find((s) => s.id === id)!.score }));
+}

--- a/apps/brainctl/src/app/services/context.service.ts
+++ b/apps/brainctl/src/app/services/context.service.ts
@@ -134,6 +134,13 @@ export function listDocuments(agentId: string): DocumentSummary[] {
   `).all(agentId) as DocumentSummary[];
 }
 
+export function getChunk(document: string, chunkIndex: number, agentId: string): ContextChunk | undefined {
+  ensureContextTable();
+  return getDb().prepare(
+    'SELECT * FROM context WHERE document = ? AND chunk_index = ? AND agent_id = ?',
+  ).get(document, chunkIndex, agentId) as ContextChunk | undefined;
+}
+
 export function deleteDocument(document: string, agentId: string): number {
   ensureContextTable();
   const db = getDb();

--- a/apps/brainctl/src/app/services/decision.service.ts
+++ b/apps/brainctl/src/app/services/decision.service.ts
@@ -30,6 +30,16 @@ export function createDecision(input: CreateDecisionInput): number {
   return result.lastInsertRowid as number;
 }
 
+export function getDecision(id: number, agentId = 'default'): Decision | undefined {
+  return getDb().prepare('SELECT * FROM decisions WHERE id = ? AND agent_id = ?')
+    .get(id, agentId) as Decision | undefined;
+}
+
+export function deleteDecision(id: number, agentId = 'default'): boolean {
+  return getDb().prepare('DELETE FROM decisions WHERE id = ? AND agent_id = ?')
+    .run(id, agentId).changes > 0;
+}
+
 export function listDecisions(agentId = 'default', project?: string, limit = 20): Decision[] {
   const db = getDb();
   let sql = 'SELECT * FROM decisions WHERE agent_id = @agent_id';

--- a/apps/brainctl/src/app/services/decision.service.ts
+++ b/apps/brainctl/src/app/services/decision.service.ts
@@ -1,0 +1,45 @@
+import { getDb } from '../db/database.js';
+
+export interface Decision {
+  id: number;
+  agent_id: string;
+  title: string;
+  rationale: string;
+  project: string | null;
+  created_at: string;
+}
+
+export interface CreateDecisionInput {
+  title: string;
+  rationale: string;
+  project?: string;
+  agent_id?: string;
+}
+
+export function createDecision(input: CreateDecisionInput): number {
+  const db = getDb();
+  const result = db.prepare(`
+    INSERT INTO decisions (agent_id, title, rationale, project)
+    VALUES (@agent_id, @title, @rationale, @project)
+  `).run({
+    agent_id: input.agent_id ?? 'default',
+    title: input.title,
+    rationale: input.rationale,
+    project: input.project ?? null,
+  });
+  return result.lastInsertRowid as number;
+}
+
+export function listDecisions(agentId = 'default', project?: string, limit = 20): Decision[] {
+  const db = getDb();
+  let sql = 'SELECT * FROM decisions WHERE agent_id = @agent_id';
+  const params: Record<string, unknown> = { agent_id: agentId, limit };
+
+  if (project) {
+    sql += ' AND project = @project';
+    params['project'] = project;
+  }
+
+  sql += ' ORDER BY created_at DESC LIMIT @limit';
+  return db.prepare(sql).all(params) as Decision[];
+}

--- a/apps/brainctl/src/app/services/diagnostics.service.ts
+++ b/apps/brainctl/src/app/services/diagnostics.service.ts
@@ -1,10 +1,12 @@
-import { getDb } from '../db/database.js';
+import { getDb, isVecLoaded } from '../db/database.js';
+import { isEmbeddingAvailable, EMBEDDING_DIMENSIONS } from './embeddings.service.js';
 import { statSync } from 'fs';
 import { join } from 'path';
 
 export function getStats(agentId = 'default') {
   const db = getDb();
-  return db.prepare(`
+
+  const base = db.prepare(`
     SELECT
       (SELECT COUNT(*) FROM memories WHERE agent_id = @a AND retired_at IS NULL) AS memories,
       (SELECT COUNT(*) FROM memories WHERE agent_id = @a AND retired_at IS NOT NULL) AS retired_memories,
@@ -15,7 +17,23 @@ export function getStats(agentId = 'default') {
       (SELECT COUNT(*) FROM triggers WHERE agent_id = @a AND active = 1) AS triggers,
       (SELECT COUNT(*) FROM handoffs WHERE agent_id = @a AND consumed_at IS NULL) AS pending_handoffs,
       (SELECT COUNT(*) FROM knowledge_edges) AS knowledge_edges
-  `).get({ a: agentId });
+  `).get({ a: agentId }) as Record<string, number>;
+
+  if (isVecLoaded()) {
+    try {
+      const vecStats = db.prepare(`
+        SELECT
+          (SELECT COUNT(*) FROM vec_memories) AS vec_memories,
+          (SELECT COUNT(*) FROM vec_entities) AS vec_entities,
+          (SELECT COUNT(*) FROM vec_events) AS vec_events
+      `).get() as Record<string, number>;
+      return { ...base, ...vecStats };
+    } catch {
+      // vec tables not yet created
+    }
+  }
+
+  return base;
 }
 
 export function checkHealth(agentId = 'default') {
@@ -56,13 +74,21 @@ export function checkHealth(agentId = 'default') {
   }
 
   const stats = getStats(agentId);
+  const vecAvailable = isVecLoaded();
+  const embeddingAvailable = isEmbeddingAvailable();
+
+  if (!vecAvailable) issues.push('sqlite-vec extension not loaded');
+  if (!embeddingAvailable) issues.push('LITELLM_BASE_URL not set — embeddings disabled');
 
   return {
-    ok: issues.length === 0,
-    healthy: issues.length === 0 && integrityOk,
+    ok: issues.filter((i) => !i.startsWith('sqlite-vec') && !i.startsWith('LITELLM')).length === 0,
+    healthy: integrityOk,
     issues,
     fts5_available: fts5Available,
-    vec_available: false,
+    vec_available: vecAvailable,
+    embedding_available: embeddingAvailable,
+    embedding_dimensions: EMBEDDING_DIMENSIONS,
+    embedding_model: process.env['LITELLM_EMBEDDING_MODEL'] ?? 'text-embedding-3-small',
     db_size_mb: Math.round(dbSizeMb * 100) / 100,
     db_path: dbPath,
     ...(stats as object),

--- a/apps/brainctl/src/app/services/diagnostics.service.ts
+++ b/apps/brainctl/src/app/services/diagnostics.service.ts
@@ -1,0 +1,70 @@
+import { getDb } from '../db/database.js';
+import { statSync } from 'fs';
+import { join } from 'path';
+
+export function getStats(agentId = 'default') {
+  const db = getDb();
+  return db.prepare(`
+    SELECT
+      (SELECT COUNT(*) FROM memories WHERE agent_id = @a AND retired_at IS NULL) AS memories,
+      (SELECT COUNT(*) FROM memories WHERE agent_id = @a AND retired_at IS NOT NULL) AS retired_memories,
+      (SELECT COUNT(*) FROM events WHERE agent_id = @a) AS events,
+      (SELECT COUNT(*) FROM entities WHERE agent_id = @a) AS entities,
+      (SELECT COUNT(*) FROM decisions WHERE agent_id = @a) AS decisions,
+      (SELECT COUNT(*) FROM procedures WHERE agent_id = @a AND status = 'active') AS procedures,
+      (SELECT COUNT(*) FROM triggers WHERE agent_id = @a AND active = 1) AS triggers,
+      (SELECT COUNT(*) FROM handoffs WHERE agent_id = @a AND consumed_at IS NULL) AS pending_handoffs,
+      (SELECT COUNT(*) FROM knowledge_edges) AS knowledge_edges
+  `).get({ a: agentId });
+}
+
+export function checkHealth(agentId = 'default') {
+  const db = getDb();
+  const issues: string[] = [];
+
+  try {
+    db.prepare('SELECT 1 FROM memories LIMIT 1').get();
+  } catch {
+    issues.push('memories table missing or corrupt');
+  }
+
+  let fts5Available = false;
+  try {
+    db.prepare("SELECT 1 FROM memories_fts WHERE memories_fts MATCH 'test' LIMIT 1").get();
+    fts5Available = true;
+  } catch {
+    fts5Available = false;
+  }
+
+  let integrityOk = false;
+  try {
+    const result = db.prepare('PRAGMA integrity_check').get() as { integrity_check: string };
+    integrityOk = result.integrity_check === 'ok';
+    if (!integrityOk) issues.push(`integrity check: ${result.integrity_check}`);
+  } catch {
+    issues.push('integrity check failed');
+  }
+
+  const dbPath = process.env['BRAIN_DB'] ??
+    join(process.env['HOME'] ?? '/tmp', 'brainctl', 'brain.db');
+
+  let dbSizeMb = 0;
+  try {
+    dbSizeMb = statSync(dbPath).size / (1024 * 1024);
+  } catch {
+    // file may not exist yet
+  }
+
+  const stats = getStats(agentId);
+
+  return {
+    ok: issues.length === 0,
+    healthy: issues.length === 0 && integrityOk,
+    issues,
+    fts5_available: fts5Available,
+    vec_available: false,
+    db_size_mb: Math.round(dbSizeMb * 100) / 100,
+    db_path: dbPath,
+    ...(stats as object),
+  };
+}

--- a/apps/brainctl/src/app/services/embeddings.service.ts
+++ b/apps/brainctl/src/app/services/embeddings.service.ts
@@ -1,0 +1,78 @@
+const BASE_URL = process.env['LITELLM_BASE_URL'] ?? '';
+const API_KEY = process.env['LITELLM_API_KEY'] ?? 'no-key';
+const MODEL = process.env['LITELLM_EMBEDDING_MODEL'] ?? 'text-embedding-3-small';
+export const EMBEDDING_DIMENSIONS = parseInt(process.env['LITELLM_EMBEDDING_DIMENSIONS'] ?? '1536', 10);
+
+let _available: boolean | null = null;
+
+export function isEmbeddingAvailable(): boolean {
+  return Boolean(BASE_URL);
+}
+
+export async function embed(text: string): Promise<Float32Array | null> {
+  if (!BASE_URL) return null;
+
+  try {
+    const res = await fetch(`${BASE_URL}/v1/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({ model: MODEL, input: text }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`LiteLLM ${res.status}: ${body}`);
+    }
+
+    const json = (await res.json()) as { data: Array<{ embedding: number[] }> };
+    const vec = json.data[0]?.embedding;
+    if (!vec?.length) throw new Error('Empty embedding returned');
+
+    return new Float32Array(vec);
+  } catch (err) {
+    // Log and degrade gracefully — callers skip vector storage on null
+    console.warn('[embeddings] failed:', (err as Error).message);
+    return null;
+  }
+}
+
+export async function embedBatch(texts: string[]): Promise<Array<Float32Array | null>> {
+  if (!BASE_URL || !texts.length) return texts.map(() => null);
+
+  try {
+    const res = await fetch(`${BASE_URL}/v1/embeddings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${API_KEY}`,
+      },
+      body: JSON.stringify({ model: MODEL, input: texts }),
+    });
+
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`LiteLLM ${res.status}: ${body}`);
+    }
+
+    const json = (await res.json()) as { data: Array<{ embedding: number[]; index: number }> };
+    const results: Array<Float32Array | null> = new Array(texts.length).fill(null);
+
+    for (const item of json.data) {
+      if (item.embedding?.length) {
+        results[item.index] = new Float32Array(item.embedding);
+      }
+    }
+
+    return results;
+  } catch (err) {
+    console.warn('[embeddings] batch failed:', (err as Error).message);
+    return texts.map(() => null);
+  }
+}
+
+export function serializeVec(vec: Float32Array): Buffer {
+  return Buffer.from(vec.buffer);
+}

--- a/apps/brainctl/src/app/services/embeddings.service.ts
+++ b/apps/brainctl/src/app/services/embeddings.service.ts
@@ -1,3 +1,7 @@
+// LiteLLM proxy is used as an OpenAI-compatible gateway.
+// Any model it can serve (OpenAI, local via Ollama, HuggingFace, etc.) works here —
+// change LITELLM_EMBEDDING_MODEL and LITELLM_EMBEDDING_DIMENSIONS to match.
+// When BASE_URL is unset all embedding calls degrade gracefully (null returned).
 const BASE_URL = process.env['LITELLM_BASE_URL'] ?? '';
 const API_KEY = process.env['LITELLM_API_KEY'] ?? 'no-key';
 const MODEL = process.env['LITELLM_EMBEDDING_MODEL'] ?? 'text-embedding-3-small';

--- a/apps/brainctl/src/app/services/entity.service.ts
+++ b/apps/brainctl/src/app/services/entity.service.ts
@@ -1,0 +1,159 @@
+import { getDb } from '../db/database.js';
+
+export interface Entity {
+  id: number;
+  agent_id: string;
+  name: string;
+  entity_type: string;
+  properties: string | null;
+  observations: string | null;
+  compiled_truth: string | null;
+  tier: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateEntityInput {
+  name: string;
+  entity_type?: string;
+  properties?: Record<string, unknown>;
+  observations?: string[];
+  agent_id?: string;
+}
+
+export interface SearchEntitiesInput {
+  query: string;
+  limit?: number;
+  entity_type?: string;
+  agent_id?: string;
+}
+
+export function createOrGetEntity(input: CreateEntityInput): number {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+
+  const existing = db.prepare(
+    'SELECT id FROM entities WHERE name = @name AND agent_id = @agent_id'
+  ).get({ name: input.name, agent_id: agentId }) as { id: number } | undefined;
+
+  if (existing) {
+    if (input.observations?.length) {
+      const current = db.prepare(
+        'SELECT observations FROM entities WHERE id = @id'
+      ).get({ id: existing.id }) as { observations: string | null };
+
+      const obs: string[] = current.observations ? JSON.parse(current.observations) : [];
+      obs.push(...input.observations);
+
+      db.prepare(`
+        UPDATE entities SET observations = @observations, updated_at = datetime('now')
+        WHERE id = @id
+      `).run({ observations: JSON.stringify(obs), id: existing.id });
+    }
+    return existing.id;
+  }
+
+  const result = db.prepare(`
+    INSERT INTO entities (agent_id, name, entity_type, properties, observations)
+    VALUES (@agent_id, @name, @entity_type, @properties, @observations)
+  `).run({
+    agent_id: agentId,
+    name: input.name,
+    entity_type: input.entity_type ?? 'concept',
+    properties: input.properties ? JSON.stringify(input.properties) : null,
+    observations: input.observations?.length ? JSON.stringify(input.observations) : null,
+  });
+
+  return result.lastInsertRowid as number;
+}
+
+export function getEntity(name: string, agentId = 'default'): Entity | undefined {
+  const db = getDb();
+  return db.prepare(
+    'SELECT * FROM entities WHERE name = @name AND agent_id = @agent_id'
+  ).get({ name, agent_id: agentId }) as Entity | undefined;
+}
+
+export function searchEntities(input: SearchEntitiesInput): Entity[] {
+  const db = getDb();
+  const limit = input.limit ?? 10;
+  const agentId = input.agent_id ?? 'default';
+
+  const sanitized = input.query
+    .replace(/[^\w\s]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 1)
+    .join(' OR ');
+
+  if (!sanitized) return [];
+
+  let sql = `
+    SELECT e.* FROM entities e
+    JOIN entities_fts fts ON fts.rowid = e.id
+    WHERE entities_fts MATCH @query AND e.agent_id = @agent_id
+  `;
+  const params: Record<string, unknown> = { query: sanitized, agent_id: agentId, limit };
+
+  if (input.entity_type) {
+    sql += ' AND e.entity_type = @entity_type';
+    params['entity_type'] = input.entity_type;
+  }
+
+  sql += ' ORDER BY rank LIMIT @limit';
+
+  try {
+    return db.prepare(sql).all(params) as Entity[];
+  } catch {
+    const fallback = `
+      SELECT * FROM entities
+      WHERE agent_id = @agent_id AND name LIKE @like
+      ORDER BY updated_at DESC LIMIT @limit
+    `;
+    return db.prepare(fallback).all({ agent_id: agentId, like: `%${input.query}%`, limit }) as Entity[];
+  }
+}
+
+export function relateEntities(
+  fromName: string,
+  relation: string,
+  toName: string,
+  agentId = 'default'
+): void {
+  const db = getDb();
+
+  const from = db.prepare(
+    'SELECT id FROM entities WHERE name = @name AND agent_id = @agent_id'
+  ).get({ name: fromName, agent_id: agentId }) as { id: number } | undefined;
+
+  const to = db.prepare(
+    'SELECT id FROM entities WHERE name = @name AND agent_id = @agent_id'
+  ).get({ name: toName, agent_id: agentId }) as { id: number } | undefined;
+
+  if (!from || !to) {
+    throw new Error(`Entity not found: ${!from ? fromName : toName}`);
+  }
+
+  db.prepare(`
+    INSERT OR REPLACE INTO knowledge_edges (from_type, from_id, relation, to_type, to_id)
+    VALUES ('entity', @from_id, @relation, 'entity', @to_id)
+  `).run({ from_id: from.id, relation, to_id: to.id });
+}
+
+export function getEntityRelations(name: string, agentId = 'default') {
+  const db = getDb();
+  const entity = getEntity(name, agentId);
+  if (!entity) return [];
+
+  return db.prepare(`
+    SELECT ke.relation, ke.weight, e.name as to_name, e.entity_type as to_type
+    FROM knowledge_edges ke
+    JOIN entities e ON e.id = ke.to_id
+    WHERE ke.from_type = 'entity' AND ke.from_id = @id AND ke.to_type = 'entity'
+    UNION ALL
+    SELECT ke.relation, ke.weight, e.name as to_name, e.entity_type as to_type
+    FROM knowledge_edges ke
+    JOIN entities e ON e.id = ke.from_id
+    WHERE ke.to_type = 'entity' AND ke.to_id = @id AND ke.from_type = 'entity'
+  `).all({ id: entity.id });
+}

--- a/apps/brainctl/src/app/services/entity.service.ts
+++ b/apps/brainctl/src/app/services/entity.service.ts
@@ -1,4 +1,5 @@
-import { getDb } from '../db/database.js';
+import { getDb, isVecLoaded } from '../db/database.js';
+import { embed, serializeVec } from './embeddings.service.js';
 
 export interface Entity {
   id: number;
@@ -28,7 +29,7 @@ export interface SearchEntitiesInput {
   agent_id?: string;
 }
 
-export function createOrGetEntity(input: CreateEntityInput): number {
+export async function createOrGetEntity(input: CreateEntityInput): Promise<number> {
   const db = getDb();
   const agentId = input.agent_id ?? 'default';
 
@@ -64,7 +65,18 @@ export function createOrGetEntity(input: CreateEntityInput): number {
     observations: input.observations?.length ? JSON.stringify(input.observations) : null,
   });
 
-  return result.lastInsertRowid as number;
+  const id = result.lastInsertRowid as number;
+
+  if (isVecLoaded()) {
+    const text = [input.name, input.entity_type ?? '', ...(input.observations ?? [])].join(' ');
+    const vec = await embed(text);
+    if (vec) {
+      db.prepare('INSERT OR REPLACE INTO vec_entities(rowid, embedding) VALUES (?, ?)')
+        .run(id, serializeVec(vec));
+    }
+  }
+
+  return id;
 }
 
 export function getEntity(name: string, agentId = 'default'): Entity | undefined {
@@ -112,6 +124,40 @@ export function searchEntities(input: SearchEntitiesInput): Entity[] {
     `;
     return db.prepare(fallback).all({ agent_id: agentId, like: `%${input.query}%`, limit }) as Entity[];
   }
+}
+
+export async function searchEntitiesVec(input: SearchEntitiesInput): Promise<Entity[]> {
+  if (!isVecLoaded()) return [];
+  const db = getDb();
+  const vec = await embed(input.query);
+  if (!vec) return [];
+  const agentId = input.agent_id ?? 'default';
+  const limit = input.limit ?? 10;
+  try {
+    return db.prepare(`
+      SELECT e.* FROM vec_entities v
+      JOIN entities e ON e.id = v.rowid
+      WHERE v.embedding MATCH ? AND k = ? AND e.agent_id = ?
+      ${input.entity_type ? 'AND e.entity_type = ?' : ''}
+      ORDER BY v.distance
+    `).all(
+      ...(input.entity_type
+        ? [serializeVec(vec), limit, agentId, input.entity_type]
+        : [serializeVec(vec), limit, agentId])
+    ) as Entity[];
+  } catch {
+    return [];
+  }
+}
+
+export function getEntitiesWithoutEmbeddings(agentId: string, limit: number): Entity[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT e.* FROM entities e
+    LEFT JOIN vec_entities v ON v.rowid = e.id
+    WHERE e.agent_id = @agent_id AND v.rowid IS NULL
+    LIMIT @limit
+  `).all({ agent_id: agentId, limit }) as Entity[];
 }
 
 export function relateEntities(

--- a/apps/brainctl/src/app/services/entity.service.ts
+++ b/apps/brainctl/src/app/services/entity.service.ts
@@ -150,6 +150,55 @@ export async function searchEntitiesVec(input: SearchEntitiesInput): Promise<Ent
   }
 }
 
+export async function updateEntity(name: string, input: {
+  entity_type?: string; properties?: Record<string, unknown>;
+  observations?: string[]; compiled_truth?: string; agent_id?: string;
+}): Promise<boolean> {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const existing = db.prepare(
+    'SELECT id, observations FROM entities WHERE name = @name AND agent_id = @agent_id',
+  ).get({ name, agent_id: agentId }) as { id: number; observations: string | null } | undefined;
+  if (!existing) return false;
+
+  const fields: string[] = [];
+  const params: Record<string, unknown> = { name, agent_id: agentId };
+
+  if (input.entity_type !== undefined) { fields.push('entity_type = @entity_type'); params['entity_type'] = input.entity_type; }
+  if (input.properties !== undefined) { fields.push('properties = @properties'); params['properties'] = JSON.stringify(input.properties); }
+  if (input.compiled_truth !== undefined) { fields.push('compiled_truth = @compiled_truth'); params['compiled_truth'] = input.compiled_truth; }
+  if (input.observations?.length) {
+    const obs: string[] = existing.observations ? JSON.parse(existing.observations) : [];
+    obs.push(...input.observations);
+    fields.push('observations = @observations');
+    params['observations'] = JSON.stringify(obs);
+  }
+
+  if (!fields.length) return true;
+  fields.push("updated_at = datetime('now')");
+
+  const changed = db.prepare(
+    `UPDATE entities SET ${fields.join(', ')} WHERE name = @name AND agent_id = @agent_id`,
+  ).run(params).changes > 0;
+
+  // Re-embed if text changed
+  if (changed && isVecLoaded() && (input.entity_type || input.observations?.length || input.compiled_truth)) {
+    const updated = db.prepare('SELECT * FROM entities WHERE id = ?').get(existing.id) as Entity;
+    const text = [updated.name, updated.entity_type, ...(updated.observations ? JSON.parse(updated.observations) as string[] : [])].join(' ');
+    const vec = await embed(text);
+    if (vec) db.prepare('INSERT OR REPLACE INTO vec_entities(rowid, embedding) VALUES (?, ?)').run(existing.id, serializeVec(vec));
+  }
+  return changed;
+}
+
+export function deleteEntity(name: string, agentId = 'default'): boolean {
+  const db = getDb();
+  const row = db.prepare('SELECT id FROM entities WHERE name = ? AND agent_id = ?').get(name, agentId) as { id: number } | undefined;
+  if (!row) return false;
+  if (isVecLoaded()) db.prepare('DELETE FROM vec_entities WHERE rowid = ?').run(row.id);
+  return db.prepare('DELETE FROM entities WHERE id = ?').run(row.id).changes > 0;
+}
+
 export function getEntitiesWithoutEmbeddings(agentId: string, limit: number): Entity[] {
   const db = getDb();
   return db.prepare(`

--- a/apps/brainctl/src/app/services/event.service.ts
+++ b/apps/brainctl/src/app/services/event.service.ts
@@ -1,0 +1,94 @@
+import { getDb } from '../db/database.js';
+
+export interface BrainEvent {
+  id: number;
+  agent_id: string;
+  summary: string;
+  event_type: string;
+  project: string | null;
+  importance: number;
+  created_at: string;
+}
+
+export interface LogEventInput {
+  summary: string;
+  event_type?: string;
+  project?: string;
+  importance?: number;
+  agent_id?: string;
+}
+
+export interface SearchEventsInput {
+  query: string;
+  limit?: number;
+  event_type?: string;
+  project?: string;
+  agent_id?: string;
+}
+
+export function logEvent(input: LogEventInput): number {
+  const db = getDb();
+  const result = db.prepare(`
+    INSERT INTO events (agent_id, summary, event_type, project, importance)
+    VALUES (@agent_id, @summary, @event_type, @project, @importance)
+  `).run({
+    agent_id: input.agent_id ?? 'default',
+    summary: input.summary,
+    event_type: input.event_type ?? 'observation',
+    project: input.project ?? null,
+    importance: input.importance ?? 0.5,
+  });
+  return result.lastInsertRowid as number;
+}
+
+export function searchEvents(input: SearchEventsInput): BrainEvent[] {
+  const db = getDb();
+  const limit = input.limit ?? 10;
+  const agentId = input.agent_id ?? 'default';
+
+  const sanitized = input.query
+    .replace(/[^\w\s]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 1)
+    .join(' OR ');
+
+  if (!sanitized) return [];
+
+  let sql = `
+    SELECT e.* FROM events e
+    JOIN events_fts fts ON fts.rowid = e.id
+    WHERE events_fts MATCH @query AND e.agent_id = @agent_id
+  `;
+  const params: Record<string, unknown> = { query: sanitized, agent_id: agentId, limit };
+
+  if (input.event_type) {
+    sql += ' AND e.event_type = @event_type';
+    params['event_type'] = input.event_type;
+  }
+  if (input.project) {
+    sql += ' AND e.project = @project';
+    params['project'] = input.project;
+  }
+
+  sql += ' ORDER BY rank LIMIT @limit';
+
+  try {
+    return db.prepare(sql).all(params) as BrainEvent[];
+  } catch {
+    const fallback = `
+      SELECT * FROM events
+      WHERE agent_id = @agent_id AND summary LIKE @like
+      ORDER BY created_at DESC LIMIT @limit
+    `;
+    return db.prepare(fallback).all({ agent_id: agentId, like: `%${input.query}%`, limit }) as BrainEvent[];
+  }
+}
+
+export function getRecentEvents(agentId = 'default', limit = 10): BrainEvent[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT * FROM events WHERE agent_id = @agent_id
+    ORDER BY created_at DESC LIMIT @limit
+  `).all({ agent_id: agentId, limit }) as BrainEvent[];
+}

--- a/apps/brainctl/src/app/services/event.service.ts
+++ b/apps/brainctl/src/app/services/event.service.ts
@@ -139,6 +139,31 @@ function rrfMergeEvents(fts: BrainEvent[], vec: BrainEvent[], limit: number): Br
     .map(([id]) => byId.get(id)!);
 }
 
+export function getEvent(id: number, agentId = 'default'): BrainEvent | undefined {
+  return getDb().prepare('SELECT * FROM events WHERE id = ? AND agent_id = ?')
+    .get(id, agentId) as BrainEvent | undefined;
+}
+
+export function deleteEvent(id: number, agentId = 'default'): boolean {
+  const db = getDb();
+  if (isVecLoaded()) db.prepare('DELETE FROM vec_events WHERE rowid = ?').run(id);
+  return db.prepare('DELETE FROM events WHERE id = ? AND agent_id = ?').run(id, agentId).changes > 0;
+}
+
+export function listEvents(input: {
+  agent_id?: string; event_type?: string; project?: string;
+  limit?: number; offset?: number;
+}): BrainEvent[] {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  let sql = 'SELECT * FROM events WHERE agent_id = @agent_id';
+  const params: Record<string, unknown> = { agent_id: agentId, limit: input.limit ?? 50, offset: input.offset ?? 0 };
+  if (input.event_type) { sql += ' AND event_type = @event_type'; params['event_type'] = input.event_type; }
+  if (input.project) { sql += ' AND project = @project'; params['project'] = input.project; }
+  sql += ' ORDER BY created_at DESC LIMIT @limit OFFSET @offset';
+  return db.prepare(sql).all(params) as BrainEvent[];
+}
+
 export function getRecentEvents(agentId = 'default', limit = 10): BrainEvent[] {
   const db = getDb();
   return db.prepare(`

--- a/apps/brainctl/src/app/services/event.service.ts
+++ b/apps/brainctl/src/app/services/event.service.ts
@@ -1,4 +1,5 @@
-import { getDb } from '../db/database.js';
+import { getDb, isVecLoaded } from '../db/database.js';
+import { embed, serializeVec } from './embeddings.service.js';
 
 export interface BrainEvent {
   id: number;
@@ -26,7 +27,7 @@ export interface SearchEventsInput {
   agent_id?: string;
 }
 
-export function logEvent(input: LogEventInput): number {
+export async function logEvent(input: LogEventInput): Promise<number> {
   const db = getDb();
   const result = db.prepare(`
     INSERT INTO events (agent_id, summary, event_type, project, importance)
@@ -38,10 +39,21 @@ export function logEvent(input: LogEventInput): number {
     project: input.project ?? null,
     importance: input.importance ?? 0.5,
   });
-  return result.lastInsertRowid as number;
+
+  const id = result.lastInsertRowid as number;
+
+  if (isVecLoaded()) {
+    const vec = await embed(input.summary);
+    if (vec) {
+      db.prepare('INSERT OR REPLACE INTO vec_events(rowid, embedding) VALUES (?, ?)')
+        .run(id, serializeVec(vec));
+    }
+  }
+
+  return id;
 }
 
-export function searchEvents(input: SearchEventsInput): BrainEvent[] {
+export function searchEventsFts(input: SearchEventsInput): BrainEvent[] {
   const db = getDb();
   const limit = input.limit ?? 10;
   const agentId = input.agent_id ?? 'default';
@@ -85,10 +97,62 @@ export function searchEvents(input: SearchEventsInput): BrainEvent[] {
   }
 }
 
+export async function searchEventsVec(input: SearchEventsInput): Promise<BrainEvent[]> {
+  if (!isVecLoaded()) return [];
+  const db = getDb();
+  const vec = await embed(input.query);
+  if (!vec) return [];
+  const agentId = input.agent_id ?? 'default';
+  const limit = input.limit ?? 10;
+  try {
+    return db.prepare(`
+      SELECT e.* FROM vec_events v
+      JOIN events e ON e.id = v.rowid
+      WHERE v.embedding MATCH ? AND k = ? AND e.agent_id = ?
+      ORDER BY v.distance
+    `).all(serializeVec(vec), limit, agentId) as BrainEvent[];
+  } catch {
+    return [];
+  }
+}
+
+export async function searchEvents(input: SearchEventsInput): Promise<BrainEvent[]> {
+  const [fts, vec] = await Promise.all([searchEventsFts(input), searchEventsVec(input)]);
+  return rrfMergeEvents(fts, vec, input.limit ?? 10);
+}
+
+function rrfMergeEvents(fts: BrainEvent[], vec: BrainEvent[], limit: number): BrainEvent[] {
+  const K = 60;
+  const scores = new Map<number, number>();
+  const byId = new Map<number, BrainEvent>();
+  for (let i = 0; i < fts.length; i++) {
+    scores.set(fts[i].id, (scores.get(fts[i].id) ?? 0) + 1 / (K + i + 1));
+    byId.set(fts[i].id, fts[i]);
+  }
+  for (let i = 0; i < vec.length; i++) {
+    scores.set(vec[i].id, (scores.get(vec[i].id) ?? 0) + 1 / (K + i + 1));
+    byId.set(vec[i].id, vec[i]);
+  }
+  return Array.from(scores.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([id]) => byId.get(id)!);
+}
+
 export function getRecentEvents(agentId = 'default', limit = 10): BrainEvent[] {
   const db = getDb();
   return db.prepare(`
     SELECT * FROM events WHERE agent_id = @agent_id
     ORDER BY created_at DESC LIMIT @limit
+  `).all({ agent_id: agentId, limit }) as BrainEvent[];
+}
+
+export function getEventsWithoutEmbeddings(agentId: string, limit: number): BrainEvent[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT e.* FROM events e
+    LEFT JOIN vec_events v ON v.rowid = e.id
+    WHERE e.agent_id = @agent_id AND v.rowid IS NULL
+    LIMIT @limit
   `).all({ agent_id: agentId, limit }) as BrainEvent[];
 }

--- a/apps/brainctl/src/app/services/graph.edges.service.ts
+++ b/apps/brainctl/src/app/services/graph.edges.service.ts
@@ -1,0 +1,186 @@
+import { getDb } from '../db/database.js';
+
+export interface KnowledgeEdge {
+  id: number;
+  from_type: string;
+  from_id: number;
+  relation: string;
+  to_type: string;
+  to_id: number;
+  weight: number;
+  created_at: string;
+}
+
+export interface EpochRecord {
+  id: number;
+  agent_id: string;
+  label: string;
+  starts_at: string;
+  ends_at: string | null;
+  description: string | null;
+  created_at: string;
+}
+
+function ensureEpochTable(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS epochs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      label TEXT NOT NULL,
+      starts_at TEXT NOT NULL,
+      ends_at TEXT,
+      description TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_epochs_label_agent ON epochs(label, agent_id);
+    CREATE INDEX IF NOT EXISTS idx_epochs_agent ON epochs(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_epochs_starts ON epochs(starts_at);
+  `);
+}
+
+// ---------------------------------------------------------------------------
+// weights — direct CRUD for knowledge edge weights
+// ---------------------------------------------------------------------------
+
+export function listEdges(input: {
+  from_type?: string; from_id?: number;
+  to_type?: string; to_id?: number;
+  relation?: string; limit?: number;
+}): KnowledgeEdge[] {
+  const db = getDb();
+  let sql = 'SELECT * FROM knowledge_edges WHERE 1=1';
+  const params: unknown[] = [];
+
+  if (input.from_type) { sql += ' AND from_type = ?'; params.push(input.from_type); }
+  if (input.from_id !== undefined) { sql += ' AND from_id = ?'; params.push(input.from_id); }
+  if (input.to_type) { sql += ' AND to_type = ?'; params.push(input.to_type); }
+  if (input.to_id !== undefined) { sql += ' AND to_id = ?'; params.push(input.to_id); }
+  if (input.relation) { sql += ' AND relation = ?'; params.push(input.relation); }
+
+  sql += ' ORDER BY weight DESC LIMIT ?';
+  params.push(input.limit ?? 50);
+
+  return db.prepare(sql).all(...params) as KnowledgeEdge[];
+}
+
+export function setEdgeWeight(id: number, weight: number): boolean {
+  return getDb().prepare(
+    'UPDATE knowledge_edges SET weight = ? WHERE id = ?',
+  ).run(Math.max(0, weight), id).changes > 0;
+}
+
+export function createEdge(input: {
+  from_type: string; from_id: number;
+  relation: string;
+  to_type: string; to_id: number;
+  weight?: number;
+}): number {
+  const result = getDb().prepare(`
+    INSERT INTO knowledge_edges (from_type, from_id, relation, to_type, to_id, weight)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(
+    input.from_type, input.from_id, input.relation,
+    input.to_type, input.to_id, input.weight ?? 1.0,
+  );
+  return result.lastInsertRowid as number;
+}
+
+export function deleteEdge(id: number): boolean {
+  return getDb().prepare('DELETE FROM knowledge_edges WHERE id = ?').run(id).changes > 0;
+}
+
+// ---------------------------------------------------------------------------
+// event_link — explicitly link an event to memories / entities
+// ---------------------------------------------------------------------------
+
+export function linkEvent(input: {
+  event_id: number;
+  targets: Array<{ type: 'memory' | 'entity'; id: number; relation?: string }>;
+  weight?: number;
+}): number[] {
+  const db = getDb();
+  const ids: number[] = [];
+
+  for (const target of input.targets) {
+    const result = db.prepare(`
+      INSERT INTO knowledge_edges (from_type, from_id, relation, to_type, to_id, weight)
+      VALUES ('event', ?, ?, ?, ?, ?)
+    `).run(
+      input.event_id,
+      target.relation ?? 'related_to',
+      target.type,
+      target.id,
+      input.weight ?? 1.0,
+    );
+    ids.push(result.lastInsertRowid as number);
+  }
+
+  return ids;
+}
+
+export function getEventLinks(eventId: number): KnowledgeEdge[] {
+  return getDb().prepare(
+    "SELECT * FROM knowledge_edges WHERE from_type = 'event' AND from_id = ? ORDER BY weight DESC",
+  ).all(eventId) as KnowledgeEdge[];
+}
+
+// ---------------------------------------------------------------------------
+// epoch — temporal segmentation of the memory store
+// ---------------------------------------------------------------------------
+
+export function createEpoch(input: {
+  label: string; starts_at: string; ends_at?: string;
+  description?: string; agent_id?: string;
+}): number {
+  ensureEpochTable();
+  const result = getDb().prepare(`
+    INSERT INTO epochs (agent_id, label, starts_at, ends_at, description)
+    VALUES (?, ?, ?, ?, ?)
+    ON CONFLICT (label, agent_id) DO UPDATE SET
+      starts_at = excluded.starts_at, ends_at = excluded.ends_at,
+      description = excluded.description
+  `).run(
+    input.agent_id ?? 'default',
+    input.label, input.starts_at,
+    input.ends_at ?? null, input.description ?? null,
+  );
+  return result.lastInsertRowid as number;
+}
+
+export function closeEpoch(label: string, agentId: string, endsAt?: string): boolean {
+  ensureEpochTable();
+  return getDb().prepare(`
+    UPDATE epochs SET ends_at = COALESCE(?, datetime('now'))
+    WHERE label = ? AND agent_id = ? AND ends_at IS NULL
+  `).run(endsAt ?? null, label, agentId).changes > 0;
+}
+
+export function listEpochs(agentId: string): EpochRecord[] {
+  ensureEpochTable();
+  return getDb().prepare(
+    'SELECT * FROM epochs WHERE agent_id = ? ORDER BY starts_at DESC',
+  ).all(agentId) as EpochRecord[];
+}
+
+export function getEpochMemories(label: string, agentId: string, limit = 50) {
+  ensureEpochTable();
+  const db = getDb();
+  const epoch = db.prepare('SELECT * FROM epochs WHERE label = ? AND agent_id = ?')
+    .get(label, agentId) as EpochRecord | undefined;
+
+  if (!epoch) return { epoch: null, memories: [] };
+
+  let sql = `
+    SELECT * FROM memories
+    WHERE agent_id = ? AND retired_at IS NULL
+      AND created_at >= ?
+  `;
+  const params: unknown[] = [agentId, epoch.starts_at];
+
+  if (epoch.ends_at) { sql += ' AND created_at <= ?'; params.push(epoch.ends_at); }
+  sql += ' ORDER BY created_at DESC LIMIT ?';
+  params.push(limit);
+
+  const memories = db.prepare(sql).all(...params);
+  return { epoch, memories };
+}

--- a/apps/brainctl/src/app/services/graph.service.ts
+++ b/apps/brainctl/src/app/services/graph.service.ts
@@ -27,7 +27,10 @@ export interface TraversalNode {
 }
 
 // ---------------------------------------------------------------------------
-// PageRank over knowledge_edges
+// Weighted iterative PageRank over the agent's knowledge_edges subgraph.
+// PR(u) = (1-d)/N + d * Σ_v [ PR(v) * w(v→u) / Σ_w w(v→w) ]
+// Edge weight is used as the transfer probability — higher-weight edges
+// propagate more score. Retired memories are excluded from the graph.
 // ---------------------------------------------------------------------------
 
 export function computePageRank(

--- a/apps/brainctl/src/app/services/graph.service.ts
+++ b/apps/brainctl/src/app/services/graph.service.ts
@@ -1,0 +1,254 @@
+import { getDb } from '../db/database.js';
+
+export interface PageRankNode {
+  type: string;
+  id: number;
+  label: string;
+  score: number;
+  in_degree: number;
+  out_degree: number;
+}
+
+export interface WhosKnowsResult {
+  entity: string;
+  entity_type: string;
+  edge_count: number;
+  memory_count: number;
+  score: number;
+}
+
+export interface TraversalNode {
+  type: string;
+  id: number;
+  label: string;
+  depth: number;
+  relation: string | null;
+  weight: number;
+}
+
+// ---------------------------------------------------------------------------
+// PageRank over knowledge_edges
+// ---------------------------------------------------------------------------
+
+export function computePageRank(
+  agentId: string,
+  iterations = 20,
+  damping = 0.85,
+  topK = 50
+): PageRankNode[] {
+  const db = getDb();
+
+  // Build adjacency from knowledge_edges for this agent's memories + entities
+  const edges = db.prepare(`
+    SELECT ke.from_type, ke.from_id, ke.to_type, ke.to_id, ke.weight
+    FROM knowledge_edges ke
+    WHERE (ke.from_type = 'memory' AND EXISTS (
+        SELECT 1 FROM memories m WHERE m.id = ke.from_id AND m.agent_id = @a AND m.retired_at IS NULL
+      ))
+      OR (ke.from_type = 'entity' AND EXISTS (
+        SELECT 1 FROM entities e WHERE e.id = ke.from_id AND e.agent_id = @a
+      ))
+  `).all({ a: agentId }) as Array<{
+    from_type: string; from_id: number; to_type: string; to_id: number; weight: number;
+  }>;
+
+  if (!edges.length) return [];
+
+  // Collect all unique nodes
+  const nodeKeys = new Set<string>();
+  for (const e of edges) {
+    nodeKeys.add(`${e.from_type}:${e.from_id}`);
+    nodeKeys.add(`${e.to_type}:${e.to_id}`);
+  }
+
+  const N = nodeKeys.size;
+  const scores = new Map<string, number>();
+  const outEdges = new Map<string, Array<{ to: string; weight: number }>>();
+  const inDegree = new Map<string, number>();
+  const outDegree = new Map<string, number>();
+
+  for (const key of nodeKeys) {
+    scores.set(key, 1 / N);
+    outEdges.set(key, []);
+    inDegree.set(key, 0);
+    outDegree.set(key, 0);
+  }
+
+  for (const e of edges) {
+    const from = `${e.from_type}:${e.from_id}`;
+    const to = `${e.to_type}:${e.to_id}`;
+    outEdges.get(from)!.push({ to, weight: e.weight });
+    outDegree.set(from, (outDegree.get(from) ?? 0) + 1);
+    inDegree.set(to, (inDegree.get(to) ?? 0) + 1);
+  }
+
+  for (let iter = 0; iter < iterations; iter++) {
+    const next = new Map<string, number>();
+    for (const key of nodeKeys) next.set(key, (1 - damping) / N);
+
+    for (const [from, neighbors] of outEdges) {
+      const fromScore = scores.get(from) ?? 0;
+      const totalWeight = neighbors.reduce((s, n) => s + n.weight, 0);
+      if (totalWeight === 0) continue;
+      for (const { to, weight } of neighbors) {
+        next.set(to, (next.get(to) ?? 0) + damping * fromScore * (weight / totalWeight));
+      }
+    }
+
+    for (const [key, val] of next) scores.set(key, val);
+  }
+
+  // Resolve labels
+  const memoryLabels = new Map<number, string>();
+  const entityLabels = new Map<number, string>();
+
+  const memIds = [...nodeKeys].filter((k) => k.startsWith('memory:')).map((k) => parseInt(k.split(':')[1]));
+  const entIds = [...nodeKeys].filter((k) => k.startsWith('entity:')).map((k) => parseInt(k.split(':')[1]));
+
+  if (memIds.length) {
+    const rows = db.prepare(
+      `SELECT id, content FROM memories WHERE id IN (${memIds.map(() => '?').join(',')})`
+    ).all(...memIds) as Array<{ id: number; content: string }>;
+    for (const r of rows) memoryLabels.set(r.id, r.content.slice(0, 80));
+  }
+  if (entIds.length) {
+    const rows = db.prepare(
+      `SELECT id, name FROM entities WHERE id IN (${entIds.map(() => '?').join(',')})`
+    ).all(...entIds) as Array<{ id: number; name: string }>;
+    for (const r of rows) entityLabels.set(r.id, r.name);
+  }
+
+  return Array.from(scores.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, topK)
+    .map(([key, score]) => {
+      const [type, idStr] = key.split(':');
+      const id = parseInt(idStr);
+      const label = type === 'memory'
+        ? (memoryLabels.get(id) ?? `memory:${id}`)
+        : (entityLabels.get(id) ?? `entity:${id}`);
+      return { type, id, label, score, in_degree: inDegree.get(key) ?? 0, out_degree: outDegree.get(key) ?? 0 };
+    });
+}
+
+// ---------------------------------------------------------------------------
+// whosknows — which entities have the most knowledge about a topic
+// ---------------------------------------------------------------------------
+
+export async function whosKnows(
+  query: string,
+  agentId: string,
+  limit = 10
+): Promise<WhosKnowsResult[]> {
+  const db = getDb();
+
+  // Find entities whose name, type, or observations match the query
+  const sanitized = query
+    .replace(/[^\w\s]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 1)
+    .join(' OR ');
+
+  let matchedEntities: Array<{ id: number; name: string; entity_type: string }> = [];
+
+  if (sanitized) {
+    try {
+      matchedEntities = db.prepare(`
+        SELECT e.id, e.name, e.entity_type
+        FROM entities e
+        JOIN entities_fts fts ON fts.rowid = e.id
+        WHERE entities_fts MATCH @q AND e.agent_id = @a
+        ORDER BY rank LIMIT @limit
+      `).all({ q: sanitized, a: agentId, limit: limit * 2 }) as typeof matchedEntities;
+    } catch {
+      matchedEntities = db.prepare(`
+        SELECT id, name, entity_type FROM entities
+        WHERE agent_id = @a AND name LIKE @like
+        LIMIT @limit
+      `).all({ a: agentId, like: `%${query}%`, limit: limit * 2 }) as typeof matchedEntities;
+    }
+  }
+
+  if (!matchedEntities.length) return [];
+
+  return matchedEntities.slice(0, limit).map((e) => {
+    const edgeCount = (db.prepare(`
+      SELECT COUNT(*) AS cnt FROM knowledge_edges
+      WHERE (from_type = 'entity' AND from_id = ?) OR (to_type = 'entity' AND to_id = ?)
+    `).get(e.id, e.id) as { cnt: number }).cnt;
+
+    const memoryCount = (db.prepare(`
+      SELECT COUNT(*) AS cnt FROM knowledge_edges ke
+      JOIN memories m ON m.id = ke.from_id OR m.id = ke.to_id
+      WHERE ((ke.from_type = 'entity' AND ke.from_id = ?) OR (ke.to_type = 'entity' AND ke.to_id = ?))
+        AND m.retired_at IS NULL
+    `).get(e.id, e.id) as { cnt: number }).cnt;
+
+    return {
+      entity: e.name,
+      entity_type: e.entity_type,
+      edge_count: edgeCount,
+      memory_count: memoryCount,
+      score: edgeCount + memoryCount * 0.5,
+    };
+  }).sort((a, b) => b.score - a.score);
+}
+
+// ---------------------------------------------------------------------------
+// Multi-hop traversal from a named entity or memory id
+// ---------------------------------------------------------------------------
+
+export function traverse(
+  startType: 'memory' | 'entity',
+  startId: number,
+  agentId: string,
+  maxDepth = 3,
+  maxNodes = 50
+): TraversalNode[] {
+  const db = getDb();
+  const visited = new Set<string>();
+  const result: TraversalNode[] = [];
+
+  function labelFor(type: string, id: number): string {
+    if (type === 'memory') {
+      const r = db.prepare('SELECT content FROM memories WHERE id = ?').get(id) as { content: string } | undefined;
+      return r ? r.content.slice(0, 80) : `memory:${id}`;
+    }
+    const r = db.prepare('SELECT name FROM entities WHERE id = ?').get(id) as { name: string } | undefined;
+    return r ? r.name : `entity:${id}`;
+  }
+
+  const queue: Array<{ type: string; id: number; depth: number; relation: string | null; weight: number }> = [
+    { type: startType, id: startId, depth: 0, relation: null, weight: 1 },
+  ];
+
+  while (queue.length && result.length < maxNodes) {
+    const node = queue.shift()!;
+    const key = `${node.type}:${node.id}`;
+    if (visited.has(key)) continue;
+    visited.add(key);
+
+    result.push({ type: node.type, id: node.id, label: labelFor(node.type, node.id), depth: node.depth, relation: node.relation, weight: node.weight });
+
+    if (node.depth >= maxDepth) continue;
+
+    const neighbors = db.prepare(`
+      SELECT 'out' AS dir, to_type AS ntype, to_id AS nid, relation, weight
+      FROM knowledge_edges WHERE from_type = @type AND from_id = @id
+      UNION ALL
+      SELECT 'in' AS dir, from_type AS ntype, from_id AS nid, relation, weight
+      FROM knowledge_edges WHERE to_type = @type AND to_id = @id
+    `).all({ type: node.type, id: node.id }) as Array<{
+      dir: string; ntype: string; nid: number; relation: string; weight: number;
+    }>;
+
+    for (const n of neighbors) {
+      if (!visited.has(`${n.ntype}:${n.nid}`)) {
+        queue.push({ type: n.ntype, id: n.nid, depth: node.depth + 1, relation: n.relation, weight: n.weight });
+      }
+    }
+  }
+
+  return result;
+}

--- a/apps/brainctl/src/app/services/llm.service.ts
+++ b/apps/brainctl/src/app/services/llm.service.ts
@@ -1,0 +1,49 @@
+const BASE_URL = process.env['LITELLM_BASE_URL'] ?? '';
+const API_KEY = process.env['LITELLM_API_KEY'] ?? 'no-key';
+const DEFAULT_MODEL = process.env['LITELLM_CHAT_MODEL'] ?? 'gpt-4o-mini';
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface ChatOptions {
+  model?: string;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export function isLlmAvailable(): boolean {
+  return Boolean(BASE_URL);
+}
+
+export async function chat(messages: ChatMessage[], opts: ChatOptions = {}): Promise<string> {
+  if (!BASE_URL) throw new Error('LITELLM_BASE_URL is not set');
+
+  const res = await fetch(`${BASE_URL}/v1/chat/completions`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${API_KEY}`,
+    },
+    body: JSON.stringify({
+      model: opts.model ?? DEFAULT_MODEL,
+      messages,
+      temperature: opts.temperature ?? 0.3,
+      max_tokens: opts.max_tokens ?? 1024,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`LiteLLM chat ${res.status}: ${body}`);
+  }
+
+  const json = (await res.json()) as {
+    choices: Array<{ message: { content: string } }>;
+  };
+
+  const text = json.choices[0]?.message?.content;
+  if (!text) throw new Error('Empty response from LiteLLM');
+  return text;
+}

--- a/apps/brainctl/src/app/services/memory.lifecycle.service.ts
+++ b/apps/brainctl/src/app/services/memory.lifecycle.service.ts
@@ -1,0 +1,316 @@
+import { getDb, isVecLoaded } from '../db/database.js';
+import { embed, serializeVec } from './embeddings.service.js';
+import { chat, isLlmAvailable } from './llm.service.js';
+import { searchMemories, addMemory } from './memory.service.js';
+import type { Memory } from './memory.service.js';
+
+// ---------------------------------------------------------------------------
+// zoom_in — find more granular/specific memories around a seed memory
+// ---------------------------------------------------------------------------
+
+export async function zoomIn(input: {
+  id: number; agent_id?: string; limit?: number;
+}): Promise<Memory[]> {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const limit = input.limit ?? 10;
+
+  const seed = db.prepare('SELECT * FROM memories WHERE id = ? AND agent_id = ?')
+    .get(input.id, agentId) as Memory | undefined;
+  if (!seed) return [];
+
+  if (isVecLoaded()) {
+    const vec = await embed(seed.content);
+    if (vec) {
+      try {
+        return db.prepare(`
+          SELECT m.* FROM vec_memories v
+          JOIN memories m ON m.id = v.rowid
+          WHERE v.embedding MATCH ? AND k = ?
+            AND m.agent_id = ? AND m.retired_at IS NULL AND m.id != ?
+            AND m.memory_type = 'episodic'
+          ORDER BY v.distance
+        `).all(serializeVec(vec), limit, agentId, input.id) as Memory[];
+      } catch { /* fall through to FTS */ }
+    }
+  }
+
+  // FTS fallback — use most distinctive words from the seed
+  const words = seed.content
+    .split(/\W+/)
+    .filter((w) => w.length > 4)
+    .slice(0, 6)
+    .join(' OR ');
+
+  if (!words) return [];
+  return db.prepare(`
+    SELECT m.* FROM memories m
+    JOIN memories_fts fts ON fts.rowid = m.id
+    WHERE memories_fts MATCH ?
+      AND m.agent_id = ? AND m.retired_at IS NULL AND m.id != ?
+      AND m.memory_type = 'episodic'
+    ORDER BY rank LIMIT ?
+  `).all(words, agentId, input.id, limit) as Memory[];
+}
+
+// ---------------------------------------------------------------------------
+// zoom_out — abstractly summarize a cluster of memories
+// ---------------------------------------------------------------------------
+
+export async function zoomOut(input: {
+  ids?: number[]; query?: string; agent_id?: string;
+  model?: string; store?: boolean;
+}): Promise<{ summary: string; source_ids: number[]; stored_id?: number }> {
+  const agentId = input.agent_id ?? 'default';
+  let memories: Memory[] = [];
+
+  if (input.ids?.length) {
+    const db = getDb();
+    memories = db.prepare(
+      `SELECT * FROM memories WHERE id IN (${input.ids.map(() => '?').join(',')}) AND agent_id = ? AND retired_at IS NULL`,
+    ).all(...input.ids, agentId) as Memory[];
+  } else if (input.query) {
+    memories = await searchMemories({ query: input.query, limit: 10, agent_id: agentId });
+  }
+
+  if (!memories.length) return { summary: 'No memories found.', source_ids: [] };
+
+  const sourceIds = memories.map((m) => m.id);
+  const context = memories.map((m, i) => `${i + 1}. ${m.content}`).join('\n');
+
+  if (!isLlmAvailable()) {
+    return { summary: `[${memories.length} memories — LLM unavailable]`, source_ids: sourceIds };
+  }
+
+  const summary = await chat([
+    { role: 'system', content: 'Synthesize the following memories into a single abstract summary sentence. Be concise.' },
+    { role: 'user', content: context },
+  ], { model: input.model, temperature: 0.2, max_tokens: 200 });
+
+  let storedId: number | undefined;
+  if (input.store) {
+    storedId = await addMemory({
+      content: summary, category: 'abstraction', memory_type: 'semantic',
+      confidence: 0.75, agent_id: agentId,
+    });
+  }
+
+  return { summary, source_ids: sourceIds, stored_id: storedId };
+}
+
+// ---------------------------------------------------------------------------
+// abstract_summarize — multi-level summary (broad → specific)
+// ---------------------------------------------------------------------------
+
+export async function abstractSummarize(input: {
+  query: string; levels?: number; agent_id?: string; model?: string;
+}): Promise<Array<{ level: number; label: string; summary: string; memory_count: number }>> {
+  const agentId = input.agent_id ?? 'default';
+  const levels = Math.min(input.levels ?? 3, 5);
+  const results: Array<{ level: number; label: string; summary: string; memory_count: number }> = [];
+
+  for (let lvl = 1; lvl <= levels; lvl++) {
+    const limit = 5 * lvl;
+    const memories = await searchMemories({ query: input.query, limit, agent_id: agentId });
+
+    if (!memories.length) break;
+
+    let summary: string;
+    if (isLlmAvailable()) {
+      const context = memories.map((m) => m.content).join('\n');
+      const granularity = lvl === 1 ? 'high-level (1 sentence)' : lvl <= 3 ? 'medium detail (2-3 sentences)' : 'detailed (4-5 sentences)';
+      summary = await chat([
+        { role: 'system', content: `Summarize at ${granularity} granularity. No preamble.` },
+        { role: 'user', content: context },
+      ], { model: input.model, temperature: 0.2, max_tokens: lvl * 100 });
+    } else {
+      summary = memories.slice(0, lvl).map((m) => m.content).join(' | ');
+    }
+
+    results.push({
+      level: lvl,
+      label: ['abstract', 'overview', 'summary', 'detailed', 'granular'][lvl - 1],
+      summary,
+      memory_count: memories.length,
+    });
+  }
+
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// retirement_analysis — score low-confidence memories as retirement candidates
+// ---------------------------------------------------------------------------
+
+export async function retirementAnalysis(input: {
+  agent_id?: string; limit?: number; model?: string; explain?: boolean;
+}): Promise<Array<{ memory: Memory; retire_score: number; reason: string }>> {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const limit = input.limit ?? 20;
+
+  const candidates = db.prepare(`
+    SELECT * FROM memories
+    WHERE agent_id = ? AND retired_at IS NULL AND quarantined_at IS NULL
+      AND (confidence < 0.3 OR (recalled_count = 0 AND julianday('now') - julianday(created_at) > 30))
+    ORDER BY confidence ASC, recalled_count ASC, created_at ASC
+    LIMIT ?
+  `).all(agentId, limit) as Memory[];
+
+  if (!candidates.length) return [];
+
+  const results = await Promise.all(candidates.map(async (m) => {
+    const ageDays = (Date.now() - new Date(m.created_at).getTime()) / 86400000;
+    const retire_score = Math.min(1, (1 - m.confidence) * 0.6 + (m.recalled_count === 0 ? 0.3 : 0) + Math.min(0.1, ageDays / 365));
+
+    let reason = `confidence=${m.confidence.toFixed(2)}, recalled=${m.recalled_count}, age=${Math.round(ageDays)}d`;
+
+    if (input.explain && isLlmAvailable()) {
+      try {
+        reason = await chat([
+          { role: 'system', content: 'In one sentence, explain why this memory should be retired (low usefulness, staleness, etc).' },
+          { role: 'user', content: m.content },
+        ], { model: input.model, temperature: 0, max_tokens: 80 });
+      } catch { /* keep default reason */ }
+    }
+
+    return { memory: m, retire_score, reason };
+  }));
+
+  return results.sort((a, b) => b.retire_score - a.retire_score);
+}
+
+// ---------------------------------------------------------------------------
+// resolve_conflict — detect contradictions between memories and resolve
+// ---------------------------------------------------------------------------
+
+export async function resolveConflict(input: {
+  id_a: number; id_b: number; agent_id?: string; model?: string; store?: boolean;
+}): Promise<{ conflict_detected: boolean; resolution: string; stored_id?: number }> {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+
+  const [memA, memB] = [
+    db.prepare('SELECT * FROM memories WHERE id = ? AND agent_id = ?').get(input.id_a, agentId) as Memory | undefined,
+    db.prepare('SELECT * FROM memories WHERE id = ? AND agent_id = ?').get(input.id_b, agentId) as Memory | undefined,
+  ];
+
+  if (!memA || !memB) {
+    return { conflict_detected: false, resolution: 'One or both memories not found.' };
+  }
+
+  if (!isLlmAvailable()) {
+    return { conflict_detected: false, resolution: 'LLM unavailable — cannot evaluate conflict.' };
+  }
+
+  const raw = await chat([
+    { role: 'system', content: 'Analyze if these two memories contradict each other. Respond with JSON: {"conflict": true/false, "resolution": "..."}' },
+    { role: 'user', content: `Memory A: ${memA.content}\nMemory B: ${memB.content}` },
+  ], { model: input.model, temperature: 0, max_tokens: 300 });
+
+  let conflict_detected = false;
+  let resolution = raw;
+
+  try {
+    const parsed = JSON.parse(raw.match(/\{[\s\S]*\}/)![0]);
+    conflict_detected = Boolean(parsed.conflict);
+    resolution = parsed.resolution ?? raw;
+  } catch { /* use raw */ }
+
+  let storedId: number | undefined;
+  if (conflict_detected && input.store) {
+    storedId = await addMemory({
+      content: `[Conflict resolution] Memory #${input.id_a} vs #${input.id_b}: ${resolution}`,
+      category: 'conflict_resolution', memory_type: 'semantic',
+      confidence: 0.8, agent_id: agentId,
+    });
+  }
+
+  return { conflict_detected, resolution, stored_id: storedId };
+}
+
+// ---------------------------------------------------------------------------
+// quarantine — isolate a memory pending review
+// ---------------------------------------------------------------------------
+
+export function quarantineMemory(id: number, agentId = 'default'): boolean {
+  return getDb().prepare(`
+    UPDATE memories SET quarantined_at = datetime('now')
+    WHERE id = ? AND agent_id = ? AND quarantined_at IS NULL AND retired_at IS NULL
+  `).run(id, agentId).changes > 0;
+}
+
+export function unquarantineMemory(id: number, agentId = 'default'): boolean {
+  return getDb().prepare(
+    'UPDATE memories SET quarantined_at = NULL WHERE id = ? AND agent_id = ?',
+  ).run(id, agentId).changes > 0;
+}
+
+export function listQuarantined(agentId: string, limit = 50): Memory[] {
+  return getDb().prepare(`
+    SELECT * FROM memories
+    WHERE agent_id = ? AND quarantined_at IS NOT NULL AND retired_at IS NULL
+    ORDER BY quarantined_at DESC LIMIT ?
+  `).all(agentId, limit) as Memory[];
+}
+
+// ---------------------------------------------------------------------------
+// search_patterns — detect recurring themes across memories (statistical)
+// ---------------------------------------------------------------------------
+
+export async function searchPatterns(input: {
+  agent_id?: string; limit?: number; min_count?: number; model?: string;
+}): Promise<Array<{ pattern: string; count: number; example_ids: number[] }>> {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const limit = input.limit ?? 15;
+  const minCount = input.min_count ?? 3;
+
+  // Extract top N-gram tags from the tag field
+  const rows = db.prepare(`
+    SELECT tags, id FROM memories
+    WHERE agent_id = ? AND retired_at IS NULL AND tags IS NOT NULL AND tags != ''
+    ORDER BY recalled_count DESC
+  `).all(agentId) as Array<{ tags: string; id: number }>;
+
+  const tagCount = new Map<string, number[]>();
+  for (const row of rows) {
+    for (const tag of row.tags.split(',').map((t) => t.trim().toLowerCase()).filter(Boolean)) {
+      if (!tagCount.has(tag)) tagCount.set(tag, []);
+      tagCount.get(tag)!.push(row.id);
+    }
+  }
+
+  const patterns = Array.from(tagCount.entries())
+    .filter(([, ids]) => ids.length >= minCount)
+    .sort((a, b) => b[1].length - a[1].length)
+    .slice(0, limit)
+    .map(([tag, ids]) => ({ pattern: tag, count: ids.length, example_ids: ids.slice(0, 5) }));
+
+  // If LLM available and few tag patterns, augment with LLM category detection
+  if (patterns.length < 5 && isLlmAvailable()) {
+    const sample = db.prepare(`
+      SELECT content FROM memories
+      WHERE agent_id = ? AND retired_at IS NULL
+      ORDER BY recalled_count DESC, RANDOM() LIMIT 50
+    `).all(agentId) as Array<{ content: string }>;
+
+    if (sample.length >= 10) {
+      try {
+        const raw = await chat([
+          { role: 'system', content: 'Identify 5 recurring themes in these memory entries. Respond with JSON array: [{"pattern":"...","description":"..."}]' },
+          { role: 'user', content: sample.map((s) => s.content).join('\n---\n') },
+        ], { model: input.model, temperature: 0.3, max_tokens: 300 });
+
+        const parsed = JSON.parse(raw.match(/\[[\s\S]*\]/)![0]) as Array<{ pattern: string }>;
+        for (const p of parsed) {
+          if (!patterns.find((existing) => existing.pattern === p.pattern)) {
+            patterns.push({ pattern: p.pattern, count: 0, example_ids: [] });
+          }
+        }
+      } catch { /* skip LLM augmentation */ }
+    }
+  }
+
+  return patterns;
+}

--- a/apps/brainctl/src/app/services/memory.service.ts
+++ b/apps/brainctl/src/app/services/memory.service.ts
@@ -12,6 +12,10 @@ export interface Memory {
   scope: string;
   replay_priority: number;
   ripple_tags: number;
+  recalled_count: number;
+  temporal_class: string;
+  last_accessed_at: string | null;
+  compressed_into: number | null;
   created_at: string;
   retired_at: string | null;
 }
@@ -31,6 +35,22 @@ export interface SearchMemoryInput {
   limit?: number;
   memory_type?: string;
   agent_id?: string;
+}
+
+// Record that a set of memories were accessed: bump recalled_count,
+// last_accessed_at, replay_priority, and ripple_tags in one UPDATE.
+function recordAccess(ids: number[]): void {
+  if (!ids.length) return;
+  const db = getDb();
+  const placeholders = ids.map(() => '?').join(',');
+  db.prepare(`
+    UPDATE memories
+    SET recalled_count   = recalled_count + 1,
+        last_accessed_at = datetime('now'),
+        replay_priority  = min(1.0, replay_priority + 0.05),
+        ripple_tags      = ripple_tags + 1
+    WHERE id IN (${placeholders})
+  `).run(...ids);
 }
 
 export async function addMemory(input: AddMemoryInput): Promise<number> {
@@ -121,7 +141,7 @@ export async function searchMemoriesVec(input: SearchMemoryInput): Promise<Memor
   const limit = input.limit ?? 10;
 
   try {
-    const rows = db.prepare(`
+    return db.prepare(`
       SELECT m.*, v.distance
       FROM vec_memories v
       JOIN memories m ON m.id = v.rowid
@@ -135,21 +155,21 @@ export async function searchMemoriesVec(input: SearchMemoryInput): Promise<Memor
         ? [serializeVec(vec), limit, agentId, input.memory_type]
         : [serializeVec(vec), limit, agentId])
     ) as Memory[];
-
-    return rows;
   } catch {
     return [];
   }
 }
 
-// Merged hybrid search using Reciprocal Rank Fusion
+// Hybrid search: FTS5 + vector, merged via RRF, then access recorded.
 export async function searchMemories(input: SearchMemoryInput): Promise<Memory[]> {
   const [ftsResults, vecResults] = await Promise.all([
     searchMemoriesFts(input),
     searchMemoriesVec(input),
   ]);
 
-  return rrfMergeMemories(ftsResults, vecResults, input.limit ?? 10);
+  const merged = rrfMergeMemories(ftsResults, vecResults, input.limit ?? 10);
+  recordAccess(merged.map((m) => m.id));
+  return merged;
 }
 
 function rrfMergeMemories(fts: Memory[], vec: Memory[], limit: number): Memory[] {
@@ -158,14 +178,12 @@ function rrfMergeMemories(fts: Memory[], vec: Memory[], limit: number): Memory[]
   const byId = new Map<number, Memory>();
 
   for (let i = 0; i < fts.length; i++) {
-    const m = fts[i];
-    scores.set(m.id, (scores.get(m.id) ?? 0) + 1 / (K + i + 1));
-    byId.set(m.id, m);
+    scores.set(fts[i].id, (scores.get(fts[i].id) ?? 0) + 1 / (K + i + 1));
+    byId.set(fts[i].id, fts[i]);
   }
   for (let i = 0; i < vec.length; i++) {
-    const m = vec[i];
-    scores.set(m.id, (scores.get(m.id) ?? 0) + 1 / (K + i + 1));
-    byId.set(m.id, m);
+    scores.set(vec[i].id, (scores.get(vec[i].id) ?? 0) + 1 / (K + i + 1));
+    byId.set(vec[i].id, vec[i]);
   }
 
   return Array.from(scores.entries())
@@ -185,9 +203,11 @@ export function forgetMemory(id: number, agentId = 'default'): boolean {
 
 export function getMemory(id: number, agentId = 'default'): Memory | undefined {
   const db = getDb();
-  return db.prepare(
+  const memory = db.prepare(
     'SELECT * FROM memories WHERE id = @id AND agent_id = @agent_id'
   ).get({ id, agent_id: agentId }) as Memory | undefined;
+  if (memory) recordAccess([memory.id]);
+  return memory;
 }
 
 export function getMemoriesWithoutEmbeddings(agentId: string, limit: number): Memory[] {

--- a/apps/brainctl/src/app/services/memory.service.ts
+++ b/apps/brainctl/src/app/services/memory.service.ts
@@ -209,6 +209,57 @@ export function forgetMemory(id: number, agentId = 'default'): boolean {
   return result.changes > 0;
 }
 
+export function updateMemory(id: number, input: {
+  content?: string; category?: string; tags?: string | string[];
+  confidence?: number; memory_type?: string; temporal_class?: string; scope?: string;
+  agent_id?: string;
+}): boolean {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const fields: string[] = [];
+  const params: Record<string, unknown> = { id, agent_id: agentId };
+
+  if (input.content !== undefined) { fields.push('content = @content'); params['content'] = input.content; }
+  if (input.category !== undefined) { fields.push('category = @category'); params['category'] = input.category; }
+  if (input.confidence !== undefined) { fields.push('confidence = @confidence'); params['confidence'] = input.confidence; }
+  if (input.memory_type !== undefined) { fields.push('memory_type = @memory_type'); params['memory_type'] = input.memory_type; }
+  if (input.temporal_class !== undefined) { fields.push('temporal_class = @temporal_class'); params['temporal_class'] = input.temporal_class; }
+  if (input.scope !== undefined) { fields.push('scope = @scope'); params['scope'] = input.scope; }
+  if (input.tags !== undefined) {
+    const tags = Array.isArray(input.tags) ? input.tags.join(',') : input.tags;
+    fields.push('tags = @tags');
+    params['tags'] = tags;
+  }
+
+  if (!fields.length) return false;
+
+  return db.prepare(`
+    UPDATE memories SET ${fields.join(', ')} WHERE id = @id AND agent_id = @agent_id AND retired_at IS NULL
+  `).run(params).changes > 0;
+}
+
+export function listMemories(input: {
+  agent_id?: string; category?: string; memory_type?: string;
+  scope?: string; limit?: number; offset?: number;
+  include_retired?: boolean;
+}): Memory[] {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const limit = input.limit ?? 50;
+  const offset = input.offset ?? 0;
+
+  let sql = 'SELECT * FROM memories WHERE agent_id = @agent_id';
+  const params: Record<string, unknown> = { agent_id: agentId, limit, offset };
+
+  if (!input.include_retired) { sql += ' AND retired_at IS NULL'; }
+  if (input.category) { sql += ' AND category = @category'; params['category'] = input.category; }
+  if (input.memory_type) { sql += ' AND memory_type = @memory_type'; params['memory_type'] = input.memory_type; }
+  if (input.scope) { sql += ' AND scope = @scope'; params['scope'] = input.scope; }
+
+  sql += ' ORDER BY created_at DESC LIMIT @limit OFFSET @offset';
+  return db.prepare(sql).all(params) as Memory[];
+}
+
 export function getMemory(id: number, agentId = 'default'): Memory | undefined {
   const db = getDb();
   const memory = db.prepare(

--- a/apps/brainctl/src/app/services/memory.service.ts
+++ b/apps/brainctl/src/app/services/memory.service.ts
@@ -1,4 +1,5 @@
-import { getDb } from '../db/database.js';
+import { getDb, isVecLoaded } from '../db/database.js';
+import { embed, serializeVec } from './embeddings.service.js';
 
 export interface Memory {
   id: number;
@@ -32,16 +33,14 @@ export interface SearchMemoryInput {
   agent_id?: string;
 }
 
-export function addMemory(input: AddMemoryInput): number {
+export async function addMemory(input: AddMemoryInput): Promise<number> {
   const db = getDb();
   const tags = Array.isArray(input.tags) ? input.tags.join(',') : (input.tags ?? null);
 
-  const stmt = db.prepare(`
+  const result = db.prepare(`
     INSERT INTO memories (agent_id, content, category, tags, confidence, memory_type, scope)
     VALUES (@agent_id, @content, @category, @tags, @confidence, @memory_type, @scope)
-  `);
-
-  const result = stmt.run({
+  `).run({
     agent_id: input.agent_id ?? 'default',
     content: input.content,
     category: input.category ?? 'general',
@@ -51,10 +50,20 @@ export function addMemory(input: AddMemoryInput): number {
     scope: input.scope ?? 'global',
   });
 
-  return result.lastInsertRowid as number;
+  const id = result.lastInsertRowid as number;
+
+  if (isVecLoaded()) {
+    const vec = await embed(input.content);
+    if (vec) {
+      db.prepare('INSERT OR REPLACE INTO vec_memories(rowid, embedding) VALUES (?, ?)')
+        .run(id, serializeVec(vec));
+    }
+  }
+
+  return id;
 }
 
-export function searchMemories(input: SearchMemoryInput): Memory[] {
+export function searchMemoriesFts(input: SearchMemoryInput): Memory[] {
   const db = getDb();
   const limit = input.limit ?? 10;
   const agentId = input.agent_id ?? 'default';
@@ -87,19 +96,82 @@ export function searchMemories(input: SearchMemoryInput): Memory[] {
   try {
     return db.prepare(sql).all(params) as Memory[];
   } catch {
-    const fallback = `
-      SELECT * FROM memories
-      WHERE agent_id = @agent_id
-        AND retired_at IS NULL
-        AND content LIKE @like
-      ${input.memory_type ? 'AND memory_type = @memory_type' : ''}
-      ORDER BY created_at DESC
-      LIMIT @limit
-    `;
     const fp: Record<string, unknown> = { agent_id: agentId, like: `%${input.query}%`, limit };
-    if (input.memory_type) fp['memory_type'] = input.memory_type;
+    let fallback = `
+      SELECT * FROM memories
+      WHERE agent_id = @agent_id AND retired_at IS NULL AND content LIKE @like
+    `;
+    if (input.memory_type) {
+      fallback += ' AND memory_type = @memory_type';
+      fp['memory_type'] = input.memory_type;
+    }
+    fallback += ' ORDER BY created_at DESC LIMIT @limit';
     return db.prepare(fallback).all(fp) as Memory[];
   }
+}
+
+export async function searchMemoriesVec(input: SearchMemoryInput): Promise<Memory[]> {
+  if (!isVecLoaded()) return [];
+
+  const db = getDb();
+  const vec = await embed(input.query);
+  if (!vec) return [];
+
+  const agentId = input.agent_id ?? 'default';
+  const limit = input.limit ?? 10;
+
+  try {
+    const rows = db.prepare(`
+      SELECT m.*, v.distance
+      FROM vec_memories v
+      JOIN memories m ON m.id = v.rowid
+      WHERE v.embedding MATCH ? AND k = ?
+        AND m.agent_id = ?
+        AND m.retired_at IS NULL
+      ${input.memory_type ? 'AND m.memory_type = ?' : ''}
+      ORDER BY v.distance
+    `).all(
+      ...(input.memory_type
+        ? [serializeVec(vec), limit, agentId, input.memory_type]
+        : [serializeVec(vec), limit, agentId])
+    ) as Memory[];
+
+    return rows;
+  } catch {
+    return [];
+  }
+}
+
+// Merged hybrid search using Reciprocal Rank Fusion
+export async function searchMemories(input: SearchMemoryInput): Promise<Memory[]> {
+  const [ftsResults, vecResults] = await Promise.all([
+    searchMemoriesFts(input),
+    searchMemoriesVec(input),
+  ]);
+
+  return rrfMergeMemories(ftsResults, vecResults, input.limit ?? 10);
+}
+
+function rrfMergeMemories(fts: Memory[], vec: Memory[], limit: number): Memory[] {
+  const K = 60;
+  const scores = new Map<number, number>();
+  const byId = new Map<number, Memory>();
+
+  for (let i = 0; i < fts.length; i++) {
+    const m = fts[i];
+    scores.set(m.id, (scores.get(m.id) ?? 0) + 1 / (K + i + 1));
+    byId.set(m.id, m);
+  }
+  for (let i = 0; i < vec.length; i++) {
+    const m = vec[i];
+    scores.set(m.id, (scores.get(m.id) ?? 0) + 1 / (K + i + 1));
+    byId.set(m.id, m);
+  }
+
+  return Array.from(scores.entries())
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([id]) => byId.get(id)!);
 }
 
 export function forgetMemory(id: number, agentId = 'default'): boolean {
@@ -113,5 +185,17 @@ export function forgetMemory(id: number, agentId = 'default'): boolean {
 
 export function getMemory(id: number, agentId = 'default'): Memory | undefined {
   const db = getDb();
-  return db.prepare('SELECT * FROM memories WHERE id = @id AND agent_id = @agent_id').get({ id, agent_id: agentId }) as Memory | undefined;
+  return db.prepare(
+    'SELECT * FROM memories WHERE id = @id AND agent_id = @agent_id'
+  ).get({ id, agent_id: agentId }) as Memory | undefined;
+}
+
+export function getMemoriesWithoutEmbeddings(agentId: string, limit: number): Memory[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT m.* FROM memories m
+    LEFT JOIN vec_memories v ON v.rowid = m.id
+    WHERE m.agent_id = @agent_id AND m.retired_at IS NULL AND v.rowid IS NULL
+    LIMIT @limit
+  `).all({ agent_id: agentId, limit }) as Memory[];
 }

--- a/apps/brainctl/src/app/services/memory.service.ts
+++ b/apps/brainctl/src/app/services/memory.service.ts
@@ -1,0 +1,117 @@
+import { getDb } from '../db/database.js';
+
+export interface Memory {
+  id: number;
+  agent_id: string;
+  content: string;
+  category: string;
+  tags: string | null;
+  confidence: number;
+  memory_type: string;
+  scope: string;
+  replay_priority: number;
+  ripple_tags: number;
+  created_at: string;
+  retired_at: string | null;
+}
+
+export interface AddMemoryInput {
+  content: string;
+  category?: string;
+  tags?: string | string[];
+  confidence?: number;
+  memory_type?: string;
+  scope?: string;
+  agent_id?: string;
+}
+
+export interface SearchMemoryInput {
+  query: string;
+  limit?: number;
+  memory_type?: string;
+  agent_id?: string;
+}
+
+export function addMemory(input: AddMemoryInput): number {
+  const db = getDb();
+  const tags = Array.isArray(input.tags) ? input.tags.join(',') : (input.tags ?? null);
+
+  const stmt = db.prepare(`
+    INSERT INTO memories (agent_id, content, category, tags, confidence, memory_type, scope)
+    VALUES (@agent_id, @content, @category, @tags, @confidence, @memory_type, @scope)
+  `);
+
+  const result = stmt.run({
+    agent_id: input.agent_id ?? 'default',
+    content: input.content,
+    category: input.category ?? 'general',
+    tags,
+    confidence: input.confidence ?? 1.0,
+    memory_type: input.memory_type ?? 'episodic',
+    scope: input.scope ?? 'global',
+  });
+
+  return result.lastInsertRowid as number;
+}
+
+export function searchMemories(input: SearchMemoryInput): Memory[] {
+  const db = getDb();
+  const limit = input.limit ?? 10;
+  const agentId = input.agent_id ?? 'default';
+
+  const sanitized = input.query
+    .replace(/[^\w\s]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 1)
+    .join(' OR ');
+
+  if (!sanitized) return [];
+
+  let sql = `
+    SELECT m.* FROM memories m
+    JOIN memories_fts fts ON fts.rowid = m.id
+    WHERE memories_fts MATCH @query
+      AND m.agent_id = @agent_id
+      AND m.retired_at IS NULL
+  `;
+  const params: Record<string, unknown> = { query: sanitized, agent_id: agentId, limit };
+
+  if (input.memory_type) {
+    sql += ' AND m.memory_type = @memory_type';
+    params['memory_type'] = input.memory_type;
+  }
+
+  sql += ' ORDER BY rank LIMIT @limit';
+
+  try {
+    return db.prepare(sql).all(params) as Memory[];
+  } catch {
+    const fallback = `
+      SELECT * FROM memories
+      WHERE agent_id = @agent_id
+        AND retired_at IS NULL
+        AND content LIKE @like
+      ${input.memory_type ? 'AND memory_type = @memory_type' : ''}
+      ORDER BY created_at DESC
+      LIMIT @limit
+    `;
+    const fp: Record<string, unknown> = { agent_id: agentId, like: `%${input.query}%`, limit };
+    if (input.memory_type) fp['memory_type'] = input.memory_type;
+    return db.prepare(fallback).all(fp) as Memory[];
+  }
+}
+
+export function forgetMemory(id: number, agentId = 'default'): boolean {
+  const db = getDb();
+  const result = db.prepare(`
+    UPDATE memories SET retired_at = datetime('now')
+    WHERE id = @id AND agent_id = @agent_id AND retired_at IS NULL
+  `).run({ id, agent_id: agentId });
+  return result.changes > 0;
+}
+
+export function getMemory(id: number, agentId = 'default'): Memory | undefined {
+  const db = getDb();
+  return db.prepare('SELECT * FROM memories WHERE id = @id AND agent_id = @agent_id').get({ id, agent_id: agentId }) as Memory | undefined;
+}

--- a/apps/brainctl/src/app/services/memory.service.ts
+++ b/apps/brainctl/src/app/services/memory.service.ts
@@ -37,8 +37,10 @@ export interface SearchMemoryInput {
   agent_id?: string;
 }
 
-// Record that a set of memories were accessed: bump recalled_count,
-// last_accessed_at, replay_priority, and ripple_tags in one UPDATE.
+// Record that a set of memories were accessed in one batched UPDATE.
+// replay_priority drives the Promotion pass (episodic→semantic threshold is 0.3).
+// ripple_tags counts how many distinct searches surfaced this memory — high ripple
+// means the memory is broadly relevant, a stronger signal than simple recall count.
 function recordAccess(ids: number[]): void {
   if (!ids.length) return;
   const db = getDb();
@@ -88,6 +90,8 @@ export function searchMemoriesFts(input: SearchMemoryInput): Memory[] {
   const limit = input.limit ?? 10;
   const agentId = input.agent_id ?? 'default';
 
+  // Convert to FTS5 OR query; single-char tokens skipped (too common to be useful).
+  // Falls back to LIKE search if the FTS index throws (e.g. during a rebuild).
   const sanitized = input.query
     .replace(/[^\w\s]/g, ' ')
     .trim()
@@ -160,7 +164,8 @@ export async function searchMemoriesVec(input: SearchMemoryInput): Promise<Memor
   }
 }
 
-// Hybrid search: FTS5 + vector, merged via RRF, then access recorded.
+// Hybrid search: runs FTS5 and vector queries in parallel then merges with RRF.
+// Access is recorded on the merged result set so recall stats stay accurate.
 export async function searchMemories(input: SearchMemoryInput): Promise<Memory[]> {
   const [ftsResults, vecResults] = await Promise.all([
     searchMemoriesFts(input),
@@ -172,6 +177,9 @@ export async function searchMemories(input: SearchMemoryInput): Promise<Memory[]
   return merged;
 }
 
+// Reciprocal Rank Fusion: score(d) = Σ 1/(K + rank_i(d))
+// K=60 is the standard choice — it dampens position sensitivity near the top
+// of each ranked list without over-weighting documents that appear only in one source.
 function rrfMergeMemories(fts: Memory[], vec: Memory[], limit: number): Memory[] {
   const K = 60;
   const scores = new Map<number, number>();

--- a/apps/brainctl/src/app/services/procedure.service.ts
+++ b/apps/brainctl/src/app/services/procedure.service.ts
@@ -1,0 +1,165 @@
+import { getDb } from '../db/database.js';
+
+export interface Procedure {
+  id: number;
+  agent_id: string;
+  goal: string;
+  title: string | null;
+  description: string;
+  steps: string | null;
+  procedure_kind: string;
+  scope: string;
+  category: string;
+  confidence: number;
+  status: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CreateProcedureInput {
+  goal: string;
+  title?: string;
+  description?: string;
+  steps?: Array<{ step: number; action: string; notes?: string }>;
+  procedure_kind?: string;
+  scope?: string;
+  category?: string;
+  confidence?: number;
+  agent_id?: string;
+}
+
+export interface ListProceduresInput {
+  status?: string;
+  scope?: string;
+  limit?: number;
+  agent_id?: string;
+}
+
+export interface SearchProceduresInput {
+  query: string;
+  limit?: number;
+  scope?: string;
+  status?: string;
+  agent_id?: string;
+}
+
+export interface ProcedureFeedbackInput {
+  procedure_id: number;
+  success: boolean;
+  usefulness_score?: number;
+  outcome_summary?: string;
+  errors_seen?: string;
+  validated?: boolean;
+  task_signature?: string;
+  input_summary?: string;
+}
+
+export function createProcedure(input: CreateProcedureInput): number {
+  const db = getDb();
+  const result = db.prepare(`
+    INSERT INTO procedures (agent_id, goal, title, description, steps, procedure_kind, scope, category, confidence)
+    VALUES (@agent_id, @goal, @title, @description, @steps, @procedure_kind, @scope, @category, @confidence)
+  `).run({
+    agent_id: input.agent_id ?? 'default',
+    goal: input.goal,
+    title: input.title ?? null,
+    description: input.description ?? '',
+    steps: input.steps ? JSON.stringify(input.steps) : null,
+    procedure_kind: input.procedure_kind ?? 'workflow',
+    scope: input.scope ?? 'global',
+    category: input.category ?? 'convention',
+    confidence: input.confidence ?? 0.9,
+  });
+  return result.lastInsertRowid as number;
+}
+
+export function getProcedure(id: number, agentId = 'default'): Procedure | undefined {
+  const db = getDb();
+  return db.prepare(
+    'SELECT * FROM procedures WHERE id = @id AND agent_id = @agent_id'
+  ).get({ id, agent_id: agentId }) as Procedure | undefined;
+}
+
+export function listProcedures(input: ListProceduresInput): Procedure[] {
+  const db = getDb();
+  const limit = input.limit ?? 50;
+  const agentId = input.agent_id ?? 'default';
+
+  let sql = 'SELECT * FROM procedures WHERE agent_id = @agent_id';
+  const params: Record<string, unknown> = { agent_id: agentId, limit };
+
+  if (input.status && input.status !== 'all') {
+    sql += ' AND status = @status';
+    params['status'] = input.status;
+  }
+  if (input.scope) {
+    sql += ' AND scope = @scope';
+    params['scope'] = input.scope;
+  }
+
+  sql += ' ORDER BY updated_at DESC LIMIT @limit';
+  return db.prepare(sql).all(params) as Procedure[];
+}
+
+export function searchProcedures(input: SearchProceduresInput): Procedure[] {
+  const db = getDb();
+  const limit = input.limit ?? 10;
+  const agentId = input.agent_id ?? 'default';
+
+  const sanitized = input.query
+    .replace(/[^\w\s]/g, ' ')
+    .trim()
+    .split(/\s+/)
+    .filter((t) => t.length > 1)
+    .join(' OR ');
+
+  if (!sanitized) return [];
+
+  let sql = `
+    SELECT p.* FROM procedures p
+    JOIN procedures_fts fts ON fts.rowid = p.id
+    WHERE procedures_fts MATCH @query AND p.agent_id = @agent_id
+  `;
+  const params: Record<string, unknown> = { query: sanitized, agent_id: agentId, limit };
+
+  if (input.status && input.status !== 'all') {
+    sql += ' AND p.status = @status';
+    params['status'] = input.status;
+  }
+  if (input.scope) {
+    sql += ' AND p.scope = @scope';
+    params['scope'] = input.scope;
+  }
+
+  sql += ' ORDER BY rank LIMIT @limit';
+
+  try {
+    return db.prepare(sql).all(params) as Procedure[];
+  } catch {
+    const fallback = `
+      SELECT * FROM procedures WHERE agent_id = @agent_id AND goal LIKE @like
+      ORDER BY updated_at DESC LIMIT @limit
+    `;
+    return db.prepare(fallback).all({ agent_id: agentId, like: `%${input.query}%`, limit }) as Procedure[];
+  }
+}
+
+export function recordFeedback(input: ProcedureFeedbackInput): number {
+  const db = getDb();
+  const result = db.prepare(`
+    INSERT INTO procedure_feedback
+      (procedure_id, success, usefulness_score, outcome_summary, errors_seen, validated, task_signature, input_summary)
+    VALUES
+      (@procedure_id, @success, @usefulness_score, @outcome_summary, @errors_seen, @validated, @task_signature, @input_summary)
+  `).run({
+    procedure_id: input.procedure_id,
+    success: input.success ? 1 : 0,
+    usefulness_score: input.usefulness_score ?? null,
+    outcome_summary: input.outcome_summary ?? null,
+    errors_seen: input.errors_seen ?? null,
+    validated: input.validated ? 1 : 0,
+    task_signature: input.task_signature ?? null,
+    input_summary: input.input_summary ?? null,
+  });
+  return result.lastInsertRowid as number;
+}

--- a/apps/brainctl/src/app/services/procedure.service.ts
+++ b/apps/brainctl/src/app/services/procedure.service.ts
@@ -144,6 +144,34 @@ export function searchProcedures(input: SearchProceduresInput): Procedure[] {
   }
 }
 
+export function updateProcedure(id: number, input: {
+  goal?: string; title?: string; description?: string;
+  steps?: Array<{ step: number; action: string; notes?: string }>;
+  procedure_kind?: string; scope?: string; category?: string;
+  confidence?: number; status?: string; agent_id?: string;
+}): boolean {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const fields: string[] = ['updated_at = @updated_at'];
+  const params: Record<string, unknown> = { id, agent_id: agentId, updated_at: new Date().toISOString() };
+  if (input.goal !== undefined) { fields.push('goal = @goal'); params['goal'] = input.goal; }
+  if (input.title !== undefined) { fields.push('title = @title'); params['title'] = input.title; }
+  if (input.description !== undefined) { fields.push('description = @description'); params['description'] = input.description; }
+  if (input.steps !== undefined) { fields.push('steps = @steps'); params['steps'] = JSON.stringify(input.steps); }
+  if (input.procedure_kind !== undefined) { fields.push('procedure_kind = @procedure_kind'); params['procedure_kind'] = input.procedure_kind; }
+  if (input.scope !== undefined) { fields.push('scope = @scope'); params['scope'] = input.scope; }
+  if (input.category !== undefined) { fields.push('category = @category'); params['category'] = input.category; }
+  if (input.confidence !== undefined) { fields.push('confidence = @confidence'); params['confidence'] = input.confidence; }
+  if (input.status !== undefined) { fields.push('status = @status'); params['status'] = input.status; }
+  return db.prepare(`UPDATE procedures SET ${fields.join(', ')} WHERE id = @id AND agent_id = @agent_id`)
+    .run(params).changes > 0;
+}
+
+export function deleteProcedure(id: number, agentId = 'default'): boolean {
+  return getDb().prepare('DELETE FROM procedures WHERE id = ? AND agent_id = ?')
+    .run(id, agentId).changes > 0;
+}
+
 export function recordFeedback(input: ProcedureFeedbackInput): number {
   const db = getDb();
   const result = db.prepare(`

--- a/apps/brainctl/src/app/services/push.service.ts
+++ b/apps/brainctl/src/app/services/push.service.ts
@@ -1,0 +1,126 @@
+import { getDb } from '../db/database.js';
+import { searchMemories } from './memory.service.js';
+
+export interface Webhook {
+  id: number;
+  name: string;
+  url: string;
+  secret: string | null;
+  events: string;
+  active: number;
+  created_at: string;
+}
+
+function ensureWebhookTable(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS webhooks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      url TEXT NOT NULL,
+      secret TEXT,
+      events TEXT NOT NULL DEFAULT '*',
+      active INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+export function upsertWebhook(input: {
+  name: string; url: string; secret?: string; events?: string;
+}): number {
+  ensureWebhookTable();
+  const result = getDb().prepare(`
+    INSERT INTO webhooks (name, url, secret, events)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT (name) DO UPDATE SET url = excluded.url, secret = excluded.secret, events = excluded.events
+  `).run(input.name, input.url, input.secret ?? null, input.events ?? '*');
+  return result.lastInsertRowid as number;
+}
+
+export function listWebhooks(): Webhook[] {
+  ensureWebhookTable();
+  return getDb().prepare('SELECT * FROM webhooks WHERE active = 1 ORDER BY name').all() as Webhook[];
+}
+
+export function deleteWebhook(name: string): boolean {
+  ensureWebhookTable();
+  return getDb().prepare('DELETE FROM webhooks WHERE name = ?').run(name).changes > 0;
+}
+
+async function deliverPayload(url: string, payload: unknown, secret?: string | null): Promise<{ ok: boolean; status?: number; error?: string }> {
+  try {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+    if (secret) headers['X-Brainctl-Secret'] = secret;
+
+    const res = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(10000),
+    });
+    return { ok: res.ok, status: res.status };
+  } catch (err) {
+    return { ok: false, error: (err as Error).message };
+  }
+}
+
+export async function pushMemories(input: {
+  agent_id?: string;
+  query?: string;
+  memory_ids?: number[];
+  webhook: string;
+  event_type?: string;
+}): Promise<{ delivered: boolean; count: number; webhook: string; result: object }> {
+  ensureWebhookTable();
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+
+  const hook = db.prepare('SELECT * FROM webhooks WHERE name = ? AND active = 1')
+    .get(input.webhook) as Webhook | undefined;
+  if (!hook) throw new Error(`Webhook not found: ${input.webhook}`);
+
+  let memories: object[] = [];
+
+  if (input.memory_ids?.length) {
+    memories = db.prepare(
+      `SELECT * FROM memories WHERE id IN (${input.memory_ids.map(() => '?').join(',')}) AND agent_id = ?`,
+    ).all(...input.memory_ids, agentId) as object[];
+  } else if (input.query) {
+    memories = await searchMemories({ query: input.query, limit: 20, agent_id: agentId });
+  }
+
+  const payload = {
+    event_type: input.event_type ?? 'memory.push',
+    agent_id: agentId,
+    sent_at: new Date().toISOString(),
+    memories,
+  };
+
+  const result = await deliverPayload(hook.url, payload, hook.secret);
+  return { delivered: result.ok, count: memories.length, webhook: hook.name, result };
+}
+
+export async function pushReport(input: {
+  agent_id?: string;
+  title: string;
+  body: object;
+  webhook: string;
+}): Promise<{ delivered: boolean; webhook: string; result: object }> {
+  ensureWebhookTable();
+  const db = getDb();
+
+  const hook = db.prepare('SELECT * FROM webhooks WHERE name = ? AND active = 1')
+    .get(input.webhook) as Webhook | undefined;
+  if (!hook) throw new Error(`Webhook not found: ${input.webhook}`);
+
+  const payload = {
+    event_type: 'report',
+    agent_id: input.agent_id ?? 'default',
+    title: input.title,
+    sent_at: new Date().toISOString(),
+    body: input.body,
+  };
+
+  const result = await deliverPayload(hook.url, payload, hook.secret);
+  return { delivered: result.ok, webhook: hook.name, result };
+}

--- a/apps/brainctl/src/app/services/reasoning.service.ts
+++ b/apps/brainctl/src/app/services/reasoning.service.ts
@@ -1,0 +1,306 @@
+import { chat, ChatOptions } from './llm.service.js';
+import { searchMemories, Memory } from './memory.service.js';
+import { getDb } from '../db/database.js';
+
+export interface ReasonInput {
+  query: string;
+  context_limit?: number;
+  agent_id?: string;
+  model?: string;
+  temperature?: number;
+  max_tokens?: number;
+  memory_types?: string[];
+}
+
+export interface ReasonResult {
+  answer: string;
+  grounding: Memory[];
+  model: string;
+  tokens_used?: number;
+}
+
+export interface InferInput {
+  premise: string;
+  context?: string[];
+  depth?: 'shallow' | 'deep';
+  agent_id?: string;
+  model?: string;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface InferResult {
+  conclusions: string[];
+  reasoning: string;
+  grounding: Memory[];
+  model: string;
+}
+
+export interface DreamInput {
+  topic?: string;
+  memory_limit?: number;
+  min_confidence?: number;
+  agent_id?: string;
+  model?: string;
+  temperature?: number;
+  max_tokens?: number;
+}
+
+export interface DreamResult {
+  hypotheses: string[];
+  synthesis: string;
+  source_memories: Memory[];
+  model: string;
+}
+
+// ---------------------------------------------------------------------------
+// reason — grounded Q&A: retrieve relevant memories, feed as context to LLM
+// ---------------------------------------------------------------------------
+
+export async function reason(input: ReasonInput): Promise<ReasonResult> {
+  const agentId = input.agent_id ?? 'default';
+  const contextLimit = input.context_limit ?? 8;
+  const model = input.model ?? process.env['LITELLM_CHAT_MODEL'] ?? 'gpt-4o-mini';
+
+  const grounding = await searchMemories({ query: input.query, limit: contextLimit, agent_id: agentId });
+
+  const memoryBlock = grounding.length
+    ? grounding.map((m, i) => `[${i + 1}] (${m.memory_type}, conf=${m.confidence.toFixed(2)}) ${m.content}`).join('\n')
+    : '(no relevant memories found)';
+
+  const answer = await chat([
+    {
+      role: 'system',
+      content: `You are a reasoning assistant with access to an agent's memory store.
+Answer the user's question using ONLY the provided memory context.
+Cite memories by number [1], [2] etc. when you use them.
+If the memories are insufficient, say so clearly rather than guessing.`,
+    },
+    {
+      role: 'user',
+      content: `Memory context:\n${memoryBlock}\n\nQuestion: ${input.query}`,
+    },
+  ], { model, temperature: input.temperature ?? 0.2, max_tokens: input.max_tokens });
+
+  return { answer, grounding, model };
+}
+
+// ---------------------------------------------------------------------------
+// infer — draw conclusions from a premise + retrieved supporting facts
+// ---------------------------------------------------------------------------
+
+export async function infer(input: InferInput): Promise<InferResult> {
+  const agentId = input.agent_id ?? 'default';
+  const model = input.model ?? process.env['LITELLM_CHAT_MODEL'] ?? 'gpt-4o-mini';
+  const depth = input.depth ?? 'shallow';
+
+  const grounding = await searchMemories({ query: input.premise, limit: 6, agent_id: agentId });
+
+  const memoryBlock = grounding.length
+    ? grounding.map((m, i) => `[${i + 1}] ${m.content}`).join('\n')
+    : '(none)';
+
+  const extraContext = input.context?.length
+    ? `\nAdditional context provided:\n${input.context.map((c, i) => `- ${c}`).join('\n')}`
+    : '';
+
+  const depthInstruction = depth === 'deep'
+    ? 'Reason through multiple inferential steps, considering second-order implications.'
+    : 'Identify the most direct, well-supported conclusions only.';
+
+  const raw = await chat([
+    {
+      role: 'system',
+      content: `You are an inference engine. Given a premise and memory context, produce structured conclusions.
+${depthInstruction}
+Respond in this exact JSON format:
+{
+  "conclusions": ["conclusion 1", "conclusion 2", ...],
+  "reasoning": "step-by-step explanation"
+}`,
+    },
+    {
+      role: 'user',
+      content: `Premise: ${input.premise}${extraContext}\n\nMemory context:\n${memoryBlock}`,
+    },
+  ], { model, temperature: input.temperature ?? 0.1, max_tokens: input.max_tokens ?? 512 });
+
+  let conclusions: string[] = [];
+  let reasoning = '';
+
+  try {
+    const parsed = JSON.parse(extractJson(raw));
+    conclusions = Array.isArray(parsed.conclusions) ? parsed.conclusions : [];
+    reasoning = typeof parsed.reasoning === 'string' ? parsed.reasoning : raw;
+  } catch {
+    conclusions = [raw.trim()];
+    reasoning = raw;
+  }
+
+  return { conclusions, reasoning, grounding, model };
+}
+
+// ---------------------------------------------------------------------------
+// dream — synthesise hypotheses from recent high-confidence memories
+// ---------------------------------------------------------------------------
+
+export async function dream(input: DreamInput): Promise<DreamResult> {
+  const agentId = input.agent_id ?? 'default';
+  const model = input.model ?? process.env['LITELLM_CHAT_MODEL'] ?? 'gpt-4o-mini';
+  const minConf = input.min_confidence ?? 0.6;
+  const limit = input.memory_limit ?? 20;
+  const db = getDb();
+
+  // Pull recent high-confidence memories, optionally filtered by topic
+  let sourceMemories: Memory[];
+  if (input.topic) {
+    sourceMemories = await searchMemories({ query: input.topic, limit, agent_id: agentId });
+    sourceMemories = sourceMemories.filter((m) => m.confidence >= minConf);
+  } else {
+    sourceMemories = db.prepare(`
+      SELECT * FROM memories
+      WHERE agent_id = @agent_id
+        AND retired_at IS NULL
+        AND confidence >= @min_conf
+      ORDER BY last_accessed_at DESC NULLS LAST, confidence DESC
+      LIMIT @limit
+    `).all({ agent_id: agentId, min_conf: minConf, limit }) as Memory[];
+  }
+
+  if (!sourceMemories.length) {
+    return { hypotheses: [], synthesis: 'No memories available for synthesis.', source_memories: [], model };
+  }
+
+  const memBlock = sourceMemories
+    .map((m, i) => `[${i + 1}] (${m.category}) ${m.content}`)
+    .join('\n');
+
+  const topicLine = input.topic ? `Topic focus: ${input.topic}\n` : '';
+
+  const raw = await chat([
+    {
+      role: 'system',
+      content: `You are performing a memory consolidation dream cycle.
+Review the provided memories and synthesise emergent patterns, hypotheses,
+and insights that are NOT explicitly stated but are implied by the evidence.
+${topicLine}Respond in this exact JSON format:
+{
+  "hypotheses": ["hypothesis 1", "hypothesis 2", ...],
+  "synthesis": "a paragraph-length narrative synthesis of the patterns observed"
+}`,
+    },
+    {
+      role: 'user',
+      content: `Memories to synthesise:\n${memBlock}`,
+    },
+  ], { model, temperature: input.temperature ?? 0.7, max_tokens: input.max_tokens ?? 1024 });
+
+  let hypotheses: string[] = [];
+  let synthesis = '';
+
+  try {
+    const parsed = JSON.parse(extractJson(raw));
+    hypotheses = Array.isArray(parsed.hypotheses) ? parsed.hypotheses : [];
+    synthesis = typeof parsed.synthesis === 'string' ? parsed.synthesis : raw;
+  } catch {
+    hypotheses = [];
+    synthesis = raw;
+  }
+
+  return { hypotheses, synthesis, source_memories: sourceMemories, model };
+}
+
+// ---------------------------------------------------------------------------
+// infer_pretask — pre-task briefing: what does the agent know about this task?
+// ---------------------------------------------------------------------------
+
+export async function inferPretask(input: ReasonInput): Promise<ReasonResult> {
+  const agentId = input.agent_id ?? 'default';
+  const contextLimit = input.context_limit ?? 10;
+  const model = input.model ?? process.env['LITELLM_CHAT_MODEL'] ?? 'gpt-4o-mini';
+
+  const grounding = await searchMemories({ query: input.query, limit: contextLimit, agent_id: agentId });
+
+  const memoryBlock = grounding.length
+    ? grounding.map((m, i) => `[${i + 1}] (${m.memory_type}, conf=${m.confidence.toFixed(2)}) ${m.content}`).join('\n')
+    : '(no relevant memories found)';
+
+  const answer = await chat([
+    {
+      role: 'system',
+      content: `You are preparing an agent to begin a task.
+Review the memory context and produce a concise pre-task brief covering:
+1. What is already known that is relevant
+2. Known constraints or risks to be aware of
+3. Suggested starting approach based on past experience
+Be concise and actionable.`,
+    },
+    {
+      role: 'user',
+      content: `Task description: ${input.query}\n\nRelevant memories:\n${memoryBlock}`,
+    },
+  ], { model, temperature: input.temperature ?? 0.2, max_tokens: input.max_tokens });
+
+  return { answer, grounding, model };
+}
+
+// ---------------------------------------------------------------------------
+// infer_gapfill — what's missing? identify knowledge gaps for a topic
+// ---------------------------------------------------------------------------
+
+export async function inferGapfill(input: ReasonInput): Promise<{
+  known: string[]; gaps: string[]; questions: string[]; grounding: Memory[]; model: string;
+}> {
+  const agentId = input.agent_id ?? 'default';
+  const contextLimit = input.context_limit ?? 8;
+  const model = input.model ?? process.env['LITELLM_CHAT_MODEL'] ?? 'gpt-4o-mini';
+
+  const grounding = await searchMemories({ query: input.query, limit: contextLimit, agent_id: agentId });
+
+  const memoryBlock = grounding.length
+    ? grounding.map((m, i) => `[${i + 1}] ${m.content}`).join('\n')
+    : '(no relevant memories found)';
+
+  const raw = await chat([
+    {
+      role: 'system',
+      content: `You are a knowledge gap analyser.
+Given a topic and the agent's current memory context, identify what is known,
+what is missing, and what questions should be answered to fill the gaps.
+Respond in this exact JSON format:
+{
+  "known": ["known fact 1", ...],
+  "gaps": ["missing knowledge 1", ...],
+  "questions": ["question to answer 1", ...]
+}`,
+    },
+    {
+      role: 'user',
+      content: `Topic: ${input.query}\n\nCurrent memory context:\n${memoryBlock}`,
+    },
+  ], { model, temperature: input.temperature ?? 0.2, max_tokens: input.max_tokens ?? 768 });
+
+  let known: string[] = [];
+  let gaps: string[] = [];
+  let questions: string[] = [];
+
+  try {
+    const parsed = JSON.parse(extractJson(raw));
+    known = Array.isArray(parsed.known) ? parsed.known : [];
+    gaps = Array.isArray(parsed.gaps) ? parsed.gaps : [];
+    questions = Array.isArray(parsed.questions) ? parsed.questions : [];
+  } catch {
+    gaps = [raw];
+  }
+
+  return { known, gaps, questions, grounding, model };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function extractJson(text: string): string {
+  const match = text.match(/\{[\s\S]*\}/);
+  return match ? match[0] : text;
+}

--- a/apps/brainctl/src/app/services/scheduler.service.ts
+++ b/apps/brainctl/src/app/services/scheduler.service.ts
@@ -1,0 +1,120 @@
+import cron, { ScheduledTask } from 'node-cron';
+import { runConsolidationCycle, ConsolidationOptions } from './consolidation.service.js';
+
+export interface ScheduleConfig {
+  cron: string;
+  agent_id?: string;
+  options?: ConsolidationOptions;
+  enabled?: boolean;
+}
+
+export interface ScheduleEntry {
+  id: string;
+  cron: string;
+  agent_id: string;
+  options: ConsolidationOptions;
+  enabled: boolean;
+  last_run?: string;
+  next_run?: string;
+  task?: ScheduledTask;
+}
+
+const _schedules = new Map<string, ScheduleEntry>();
+let _nextId = 1;
+
+export function addSchedule(config: ScheduleConfig): ScheduleEntry {
+  if (!cron.validate(config.cron)) {
+    throw new Error(`Invalid cron expression: ${config.cron}`);
+  }
+
+  const id = String(_nextId++);
+  const agentId = config.agent_id ?? 'default';
+  const options = config.options ?? {};
+  const enabled = config.enabled !== false;
+
+  const entry: ScheduleEntry = { id, cron: config.cron, agent_id: agentId, options, enabled };
+
+  if (enabled) {
+    entry.task = cron.schedule(config.cron, () => runScheduled(entry), { timezone: 'UTC' });
+    entry.next_run = nextRunAt(config.cron);
+  }
+
+  _schedules.set(id, entry);
+  return sanitize(entry);
+}
+
+export function removeSchedule(id: string): boolean {
+  const entry = _schedules.get(id);
+  if (!entry) return false;
+  entry.task?.stop();
+  _schedules.delete(id);
+  return true;
+}
+
+export function listSchedules(): ScheduleEntry[] {
+  return Array.from(_schedules.values()).map(sanitize);
+}
+
+export function getSchedule(id: string): ScheduleEntry | undefined {
+  const e = _schedules.get(id);
+  return e ? sanitize(e) : undefined;
+}
+
+export function pauseSchedule(id: string): boolean {
+  const entry = _schedules.get(id);
+  if (!entry) return false;
+  entry.task?.stop();
+  entry.enabled = false;
+  entry.next_run = undefined;
+  return true;
+}
+
+export function resumeSchedule(id: string): boolean {
+  const entry = _schedules.get(id);
+  if (!entry) return false;
+  if (!entry.task) {
+    entry.task = cron.schedule(entry.cron, () => runScheduled(entry), { timezone: 'UTC' });
+  } else {
+    entry.task.start();
+  }
+  entry.enabled = true;
+  entry.next_run = nextRunAt(entry.cron);
+  return true;
+}
+
+// Seed a default nightly consolidation schedule on startup if env var is set.
+// BRAIN_CONSOLIDATION_CRON defaults to '0 3 * * *' (03:00 UTC daily).
+export function initDefaultSchedule(): void {
+  const expr = process.env['BRAIN_CONSOLIDATION_CRON'];
+  if (!expr) return;
+
+  try {
+    addSchedule({ cron: expr, agent_id: process.env['BRAIN_DEFAULT_AGENT'] ?? 'default' });
+    console.info(`[scheduler] consolidation scheduled: ${expr}`);
+  } catch (err) {
+    console.warn(`[scheduler] invalid BRAIN_CONSOLIDATION_CRON: ${(err as Error).message}`);
+  }
+}
+
+async function runScheduled(entry: ScheduleEntry): Promise<void> {
+  entry.last_run = new Date().toISOString();
+  entry.next_run = nextRunAt(entry.cron);
+
+  try {
+    const report = await runConsolidationCycle(entry.agent_id, entry.options);
+    console.info(`[scheduler] consolidation complete agent=${entry.agent_id} duration=${report.total_duration_ms}ms`);
+  } catch (err) {
+    console.error(`[scheduler] consolidation failed agent=${entry.agent_id}:`, (err as Error).message);
+  }
+}
+
+function sanitize(e: ScheduleEntry): ScheduleEntry {
+  const { task: _task, ...rest } = e;
+  return rest as ScheduleEntry;
+}
+
+// Best-effort next-run approximation: just note the expression since computing
+// the next exact time requires a cron parser — enough for status display.
+function nextRunAt(expr: string): string {
+  return `next occurrence of '${expr}' (UTC)`;
+}

--- a/apps/brainctl/src/app/services/search.service.ts
+++ b/apps/brainctl/src/app/services/search.service.ts
@@ -1,11 +1,16 @@
 import { getDb } from '../db/database.js';
-import { searchMemories, Memory } from './memory.service.js';
+import { searchMemories, searchMemoriesVec, Memory } from './memory.service.js';
 import { searchEvents, BrainEvent } from './event.service.js';
-import { searchEntities, Entity } from './entity.service.js';
+import { searchEntities, searchEntitiesVec, Entity } from './entity.service.js';
 
 export interface UnifiedSearchResult {
   memories: Memory[];
   events: BrainEvent[];
+  entities: Entity[];
+}
+
+export interface VsearchResult {
+  memories: Memory[];
   entities: Entity[];
 }
 
@@ -14,25 +19,42 @@ export interface ThinkResult {
   activated: Array<{ id: number; content: string; type: string; activation: number }>;
 }
 
-export function unifiedSearch(query: string, limit = 10, agentId = 'default'): UnifiedSearchResult {
+export async function unifiedSearch(
+  query: string,
+  limit = 10,
+  agentId = 'default'
+): Promise<UnifiedSearchResult> {
   const perType = Math.ceil(limit / 3);
-  return {
-    memories: searchMemories({ query, limit: perType, agent_id: agentId }),
-    events: searchEvents({ query, limit: perType, agent_id: agentId }),
-    entities: searchEntities({ query, limit: perType, agent_id: agentId }),
-  };
+  const [memories, events, entities] = await Promise.all([
+    searchMemories({ query, limit: perType, agent_id: agentId }),
+    searchEvents({ query, limit: perType, agent_id: agentId }),
+    searchEntities({ query, limit: perType, agent_id: agentId }),
+  ]);
+  return { memories, events, entities };
 }
 
-export function think(
+export async function vsearch(
+  query: string,
+  limit = 10,
+  agentId = 'default'
+): Promise<VsearchResult> {
+  const [memories, entities] = await Promise.all([
+    searchMemoriesVec({ query, limit, agent_id: agentId }),
+    searchEntitiesVec({ query, limit, agent_id: agentId }),
+  ]);
+  return { memories, entities };
+}
+
+export async function think(
   query: string,
   agentId = 'default',
   seedLimit = 5,
   hops = 2,
   decay = 0.6,
   topK = 20
-): ThinkResult {
+): Promise<ThinkResult> {
   const db = getDb();
-  const seeds = searchMemories({ query, limit: seedLimit, agent_id: agentId });
+  const seeds = await searchMemories({ query, limit: seedLimit, agent_id: agentId });
 
   if (!seeds.length) return { seeds: [], activated: [] };
 
@@ -56,13 +78,13 @@ export function think(
 
     for (const node of frontier) {
       const edges = db.prepare(`
-        SELECT ke.*, m.content, m.confidence
+        SELECT ke.to_type, ke.to_id, ke.from_type, ke.from_id, ke.weight, m.content, m.confidence
         FROM knowledge_edges ke
         JOIN memories m ON m.id = ke.to_id
         WHERE ke.from_type = @type AND ke.from_id = @id AND ke.to_type = 'memory'
           AND m.agent_id = @agent_id AND m.retired_at IS NULL
         UNION ALL
-        SELECT ke.*, m.content, m.confidence
+        SELECT ke.to_type, ke.to_id, ke.from_type, ke.from_id, ke.weight, m.content, m.confidence
         FROM knowledge_edges ke
         JOIN memories m ON m.id = ke.from_id
         WHERE ke.to_type = @type AND ke.to_id = @id AND ke.from_type = 'memory'

--- a/apps/brainctl/src/app/services/search.service.ts
+++ b/apps/brainctl/src/app/services/search.service.ts
@@ -1,0 +1,102 @@
+import { getDb } from '../db/database.js';
+import { searchMemories, Memory } from './memory.service.js';
+import { searchEvents, BrainEvent } from './event.service.js';
+import { searchEntities, Entity } from './entity.service.js';
+
+export interface UnifiedSearchResult {
+  memories: Memory[];
+  events: BrainEvent[];
+  entities: Entity[];
+}
+
+export interface ThinkResult {
+  seeds: Memory[];
+  activated: Array<{ id: number; content: string; type: string; activation: number }>;
+}
+
+export function unifiedSearch(query: string, limit = 10, agentId = 'default'): UnifiedSearchResult {
+  const perType = Math.ceil(limit / 3);
+  return {
+    memories: searchMemories({ query, limit: perType, agent_id: agentId }),
+    events: searchEvents({ query, limit: perType, agent_id: agentId }),
+    entities: searchEntities({ query, limit: perType, agent_id: agentId }),
+  };
+}
+
+export function think(
+  query: string,
+  agentId = 'default',
+  seedLimit = 5,
+  hops = 2,
+  decay = 0.6,
+  topK = 20
+): ThinkResult {
+  const db = getDb();
+  const seeds = searchMemories({ query, limit: seedLimit, agent_id: agentId });
+
+  if (!seeds.length) return { seeds: [], activated: [] };
+
+  const activations = new Map<string, { id: number; content: string; type: string; activation: number }>();
+
+  for (const seed of seeds) {
+    const key = `memory:${seed.id}`;
+    const existing = activations.get(key);
+    activations.set(key, {
+      id: seed.id,
+      content: seed.content,
+      type: 'memory',
+      activation: Math.max(existing?.activation ?? 0, seed.confidence),
+    });
+  }
+
+  let frontier = seeds.map((s) => ({ id: s.id, type: 'memory', activation: s.confidence }));
+
+  for (let hop = 0; hop < hops; hop++) {
+    const nextFrontier: typeof frontier = [];
+
+    for (const node of frontier) {
+      const edges = db.prepare(`
+        SELECT ke.*, m.content, m.confidence
+        FROM knowledge_edges ke
+        JOIN memories m ON m.id = ke.to_id
+        WHERE ke.from_type = @type AND ke.from_id = @id AND ke.to_type = 'memory'
+          AND m.agent_id = @agent_id AND m.retired_at IS NULL
+        UNION ALL
+        SELECT ke.*, m.content, m.confidence
+        FROM knowledge_edges ke
+        JOIN memories m ON m.id = ke.from_id
+        WHERE ke.to_type = @type AND ke.to_id = @id AND ke.from_type = 'memory'
+          AND m.agent_id = @agent_id AND m.retired_at IS NULL
+      `).all({ type: node.type, id: node.id, agent_id: agentId }) as Array<{
+        to_id: number; from_id: number; weight: number; content: string; confidence: number;
+        from_type: string; to_type: string;
+      }>;
+
+      for (const edge of edges) {
+        const neighborId = edge.to_type === 'memory' ? edge.to_id : edge.from_id;
+        const newActivation = node.activation * decay * edge.weight;
+        const nk = `memory:${neighborId}`;
+        const existing = activations.get(nk);
+
+        if (!existing || existing.activation < newActivation) {
+          activations.set(nk, {
+            id: neighborId,
+            content: edge.content,
+            type: 'memory',
+            activation: newActivation,
+          });
+          nextFrontier.push({ id: neighborId, type: 'memory', activation: newActivation });
+        }
+      }
+    }
+
+    frontier = nextFrontier;
+    if (!frontier.length) break;
+  }
+
+  const activated = Array.from(activations.values())
+    .sort((a, b) => b.activation - a.activation)
+    .slice(0, topK);
+
+  return { seeds, activated };
+}

--- a/apps/brainctl/src/app/services/session.service.ts
+++ b/apps/brainctl/src/app/services/session.service.ts
@@ -1,0 +1,139 @@
+import { getDb } from '../db/database.js';
+import { getRecentEvents, logEvent } from './event.service.js';
+import { searchMemories } from './memory.service.js';
+import { getActiveTriggers } from './trigger.service.js';
+import { listProcedures } from './procedure.service.js';
+
+export interface Handoff {
+  id: number;
+  agent_id: string;
+  goal: string;
+  current_state: string;
+  open_loops: string;
+  next_step: string;
+  project: string | null;
+  title: string | null;
+  created_at: string;
+  consumed_at: string | null;
+}
+
+export interface CreateHandoffInput {
+  goal: string;
+  current_state: string;
+  open_loops: string;
+  next_step: string;
+  project?: string;
+  title?: string;
+  agent_id?: string;
+}
+
+export interface WrapUpInput {
+  summary: string;
+  goal?: string;
+  open_loops?: string;
+  next_step?: string;
+  project?: string;
+  agent_id?: string;
+}
+
+export interface OrientInput {
+  project?: string;
+  query?: string;
+  agent_id?: string;
+}
+
+export function createHandoff(input: CreateHandoffInput): number {
+  const db = getDb();
+  const result = db.prepare(`
+    INSERT INTO handoffs (agent_id, goal, current_state, open_loops, next_step, project, title)
+    VALUES (@agent_id, @goal, @current_state, @open_loops, @next_step, @project, @title)
+  `).run({
+    agent_id: input.agent_id ?? 'default',
+    goal: input.goal,
+    current_state: input.current_state,
+    open_loops: input.open_loops,
+    next_step: input.next_step,
+    project: input.project ?? null,
+    title: input.title ?? null,
+  });
+  return result.lastInsertRowid as number;
+}
+
+export function getLatestHandoff(agentId = 'default', project?: string): Handoff | undefined {
+  const db = getDb();
+  let sql = `
+    SELECT * FROM handoffs
+    WHERE agent_id = @agent_id AND consumed_at IS NULL
+  `;
+  const params: Record<string, unknown> = { agent_id: agentId };
+
+  if (project) {
+    sql += ' AND project = @project';
+    params['project'] = project;
+  }
+
+  sql += ' ORDER BY created_at DESC LIMIT 1';
+  return db.prepare(sql).get(params) as Handoff | undefined;
+}
+
+export function consumeHandoff(id: number): void {
+  const db = getDb();
+  db.prepare(`
+    UPDATE handoffs SET consumed_at = datetime('now') WHERE id = @id
+  `).run({ id });
+}
+
+export function orient(input: OrientInput) {
+  const agentId = input.agent_id ?? 'default';
+  const db = getDb();
+
+  const handoff = getLatestHandoff(agentId, input.project);
+  if (handoff) consumeHandoff(handoff.id);
+
+  const recentEvents = getRecentEvents(agentId, 10);
+  const triggers = getActiveTriggers(agentId);
+  const memories = input.query ? searchMemories({ query: input.query, agent_id: agentId }) : [];
+  const procedures = listProcedures({ agent_id: agentId, status: 'active' });
+
+  const stats = db.prepare(`
+    SELECT
+      (SELECT COUNT(*) FROM memories WHERE agent_id = @a AND retired_at IS NULL) AS memories,
+      (SELECT COUNT(*) FROM events WHERE agent_id = @a) AS events,
+      (SELECT COUNT(*) FROM entities WHERE agent_id = @a) AS entities,
+      (SELECT COUNT(*) FROM decisions WHERE agent_id = @a) AS decisions,
+      (SELECT COUNT(*) FROM procedures WHERE agent_id = @a AND status = 'active') AS procedures
+  `).get({ a: agentId });
+
+  return {
+    agent_id: agentId,
+    handoff: handoff ?? null,
+    recent_events: recentEvents,
+    triggers,
+    memories,
+    procedures,
+    stats,
+  };
+}
+
+export function wrapUp(input: WrapUpInput) {
+  const agentId = input.agent_id ?? 'default';
+
+  const eventId = logEvent({
+    summary: input.summary,
+    event_type: 'session_end',
+    project: input.project,
+    importance: 0.8,
+    agent_id: agentId,
+  });
+
+  const handoffId = createHandoff({
+    goal: input.goal ?? 'Continue from previous session',
+    current_state: input.summary,
+    open_loops: input.open_loops ?? '',
+    next_step: input.next_step ?? '',
+    project: input.project,
+    agent_id: agentId,
+  });
+
+  return { event_id: eventId, handoff_id: handoffId };
+}

--- a/apps/brainctl/src/app/services/session.service.ts
+++ b/apps/brainctl/src/app/services/session.service.ts
@@ -78,21 +78,22 @@ export function getLatestHandoff(agentId = 'default', project?: string): Handoff
 
 export function consumeHandoff(id: number): void {
   const db = getDb();
-  db.prepare(`
-    UPDATE handoffs SET consumed_at = datetime('now') WHERE id = @id
-  `).run({ id });
+  db.prepare('UPDATE handoffs SET consumed_at = datetime(\'now\') WHERE id = @id').run({ id });
 }
 
-export function orient(input: OrientInput) {
+export async function orient(input: OrientInput) {
   const agentId = input.agent_id ?? 'default';
   const db = getDb();
 
   const handoff = getLatestHandoff(agentId, input.project);
   if (handoff) consumeHandoff(handoff.id);
 
-  const recentEvents = getRecentEvents(agentId, 10);
+  const [recentEvents, memories] = await Promise.all([
+    Promise.resolve(getRecentEvents(agentId, 10)),
+    input.query ? searchMemories({ query: input.query, agent_id: agentId }) : Promise.resolve([]),
+  ]);
+
   const triggers = getActiveTriggers(agentId);
-  const memories = input.query ? searchMemories({ query: input.query, agent_id: agentId }) : [];
   const procedures = listProcedures({ agent_id: agentId, status: 'active' });
 
   const stats = db.prepare(`
@@ -115,10 +116,10 @@ export function orient(input: OrientInput) {
   };
 }
 
-export function wrapUp(input: WrapUpInput) {
+export async function wrapUp(input: WrapUpInput) {
   const agentId = input.agent_id ?? 'default';
 
-  const eventId = logEvent({
+  const eventId = await logEvent({
     summary: input.summary,
     event_type: 'session_end',
     project: input.project,

--- a/apps/brainctl/src/app/services/session.service.ts
+++ b/apps/brainctl/src/app/services/session.service.ts
@@ -76,6 +76,16 @@ export function getLatestHandoff(agentId = 'default', project?: string): Handoff
   return db.prepare(sql).get(params) as Handoff | undefined;
 }
 
+export function listHandoffs(agentId = 'default', project?: string, includeConsumed = false): Handoff[] {
+  const db = getDb();
+  let sql = 'SELECT * FROM handoffs WHERE agent_id = @agent_id';
+  const params: Record<string, unknown> = { agent_id: agentId };
+  if (!includeConsumed) sql += ' AND consumed_at IS NULL';
+  if (project) { sql += ' AND project = @project'; params['project'] = project; }
+  sql += ' ORDER BY created_at DESC';
+  return db.prepare(sql).all(params) as Handoff[];
+}
+
 export function consumeHandoff(id: number): void {
   const db = getDb();
   db.prepare('UPDATE handoffs SET consumed_at = datetime(\'now\') WHERE id = @id').run({ id });

--- a/apps/brainctl/src/app/services/subsystems.service.ts
+++ b/apps/brainctl/src/app/services/subsystems.service.ts
@@ -102,6 +102,8 @@ export function recordInteraction(input: {
   ensureTrustTable();
   const db = getDb();
   const agentId = input.agent_id ?? 'default';
+  // Asymmetric update: negative outcomes reduce trust faster than positive ones restore it.
+  // This mirrors the negativity bias observed in human trust calibration.
   const delta = input.outcome === 'positive' ? 0.05 : input.outcome === 'negative' ? -0.08 : 0;
   const posInc = input.outcome === 'positive' ? 1 : 0;
   const negInc = input.outcome === 'negative' ? 1 : 0;

--- a/apps/brainctl/src/app/services/subsystems.service.ts
+++ b/apps/brainctl/src/app/services/subsystems.service.ts
@@ -1,0 +1,397 @@
+import { getDb } from '../db/database.js';
+import { chat, isLlmAvailable } from './llm.service.js';
+import { searchMemories } from './memory.service.js';
+import { addMemory } from './memory.service.js';
+
+// ---------------------------------------------------------------------------
+// belief — maintain a set of graded beliefs with confidence tracking
+// ---------------------------------------------------------------------------
+
+export interface Belief {
+  id: number;
+  agent_id: string;
+  claim: string;
+  confidence: number;
+  evidence_for: string | null;
+  evidence_against: string | null;
+  source: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export function ensureBeliefTable(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS beliefs (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      claim TEXT NOT NULL,
+      confidence REAL NOT NULL DEFAULT 0.5,
+      evidence_for TEXT,
+      evidence_against TEXT,
+      source TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_beliefs_claim_agent ON beliefs(claim, agent_id);
+    CREATE INDEX IF NOT EXISTS idx_beliefs_agent ON beliefs(agent_id);
+  `);
+}
+
+export function upsertBelief(input: {
+  claim: string; confidence?: number; evidence_for?: string;
+  evidence_against?: string; source?: string; agent_id?: string;
+}): number {
+  ensureBeliefTable();
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const result = db.prepare(`
+    INSERT INTO beliefs (agent_id, claim, confidence, evidence_for, evidence_against, source)
+    VALUES (@a, @claim, @conf, @ef, @ea, @src)
+    ON CONFLICT (claim, agent_id) DO UPDATE SET
+      confidence = @conf, evidence_for = @ef, evidence_against = @ea,
+      source = @src, updated_at = datetime('now')
+  `).run({ a: agentId, claim: input.claim, conf: input.confidence ?? 0.5,
+           ef: input.evidence_for ?? null, ea: input.evidence_against ?? null,
+           src: input.source ?? null });
+  return result.lastInsertRowid as number;
+}
+
+export function listBeliefs(agentId: string, minConf?: number): Belief[] {
+  ensureBeliefTable();
+  const db = getDb();
+  let sql = 'SELECT * FROM beliefs WHERE agent_id = @a';
+  const params: Record<string, unknown> = { a: agentId };
+  if (minConf !== undefined) { sql += ' AND confidence >= @min'; params['min'] = minConf; }
+  sql += ' ORDER BY confidence DESC';
+  return db.prepare(sql).all(params) as Belief[];
+}
+
+// ---------------------------------------------------------------------------
+// trust — track trust scores for named sources/agents
+// ---------------------------------------------------------------------------
+
+export interface TrustRecord {
+  id: number; agent_id: string; target: string; score: number;
+  interactions: number; positive: number; negative: number;
+  created_at: string; updated_at: string;
+}
+
+export function ensureTrustTable(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS trust_records (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      target TEXT NOT NULL,
+      score REAL NOT NULL DEFAULT 0.5,
+      interactions INTEGER NOT NULL DEFAULT 0,
+      positive INTEGER NOT NULL DEFAULT 0,
+      negative INTEGER NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_trust_target_agent ON trust_records(target, agent_id);
+  `);
+}
+
+export function recordInteraction(input: {
+  target: string; outcome: 'positive' | 'negative' | 'neutral';
+  agent_id?: string;
+}): TrustRecord {
+  ensureTrustTable();
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const delta = input.outcome === 'positive' ? 0.05 : input.outcome === 'negative' ? -0.08 : 0;
+  const posInc = input.outcome === 'positive' ? 1 : 0;
+  const negInc = input.outcome === 'negative' ? 1 : 0;
+
+  db.prepare(`
+    INSERT INTO trust_records (agent_id, target, score, interactions, positive, negative)
+    VALUES (@a, @t, 0.5 + @d, 1, @p, @n)
+    ON CONFLICT (target, agent_id) DO UPDATE SET
+      score = max(0, min(1, score + @d)),
+      interactions = interactions + 1,
+      positive = positive + @p,
+      negative = negative + @n,
+      updated_at = datetime('now')
+  `).run({ a: agentId, t: input.target, d: delta, p: posInc, n: negInc });
+
+  return db.prepare('SELECT * FROM trust_records WHERE target = ? AND agent_id = ?')
+    .get(input.target, agentId) as TrustRecord;
+}
+
+export function getTrust(target: string, agentId: string): TrustRecord | undefined {
+  ensureTrustTable();
+  return getDb().prepare('SELECT * FROM trust_records WHERE target = ? AND agent_id = ?')
+    .get(target, agentId) as TrustRecord | undefined;
+}
+
+export function listTrust(agentId: string): TrustRecord[] {
+  ensureTrustTable();
+  return getDb().prepare('SELECT * FROM trust_records WHERE agent_id = ? ORDER BY score DESC')
+    .all(agentId) as TrustRecord[];
+}
+
+// ---------------------------------------------------------------------------
+// reflexion — log reflections on past actions and extract lessons
+// ---------------------------------------------------------------------------
+
+export interface Reflection {
+  id: number; agent_id: string; action: string; outcome: string;
+  lesson: string | null; confidence_delta: number;
+  created_at: string;
+}
+
+export function ensureReflexionTable(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS reflections (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      action TEXT NOT NULL,
+      outcome TEXT NOT NULL,
+      lesson TEXT,
+      confidence_delta REAL NOT NULL DEFAULT 0,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_reflections_agent ON reflections(agent_id);
+  `);
+}
+
+export async function reflect(input: {
+  action: string; outcome: string; agent_id?: string;
+  model?: string; generate_lesson?: boolean;
+}): Promise<Reflection> {
+  ensureReflexionTable();
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+
+  let lesson: string | null = null;
+  const confidenceDelta = input.outcome.toLowerCase().includes('fail') ||
+    input.outcome.toLowerCase().includes('error') ? -0.05 : 0.03;
+
+  if (input.generate_lesson && isLlmAvailable()) {
+    const relatedMemories = await searchMemories({ query: `${input.action} ${input.outcome}`, limit: 4, agent_id: agentId });
+    const ctx = relatedMemories.map((m) => m.content).join('\n');
+    try {
+      lesson = await chat([
+        { role: 'system', content: 'Extract a single concise lesson (one sentence) from this action and its outcome. Be specific and actionable.' },
+        { role: 'user', content: `Action: ${input.action}\nOutcome: ${input.outcome}${ctx ? `\nContext:\n${ctx}` : ''}` },
+      ], { model: input.model, temperature: 0.2, max_tokens: 128 });
+    } catch { /* lesson stays null */ }
+  }
+
+  if (lesson) {
+    await addMemory({ content: `Lesson: ${lesson}`, category: 'reflexion', memory_type: 'semantic', confidence: 0.8, agent_id: agentId });
+  }
+
+  const result = db.prepare(`
+    INSERT INTO reflections (agent_id, action, outcome, lesson, confidence_delta)
+    VALUES (?, ?, ?, ?, ?)
+  `).run(agentId, input.action, input.outcome, lesson, confidenceDelta);
+
+  return db.prepare('SELECT * FROM reflections WHERE id = ?').get(result.lastInsertRowid) as Reflection;
+}
+
+export function listReflections(agentId: string, limit = 20): Reflection[] {
+  ensureReflexionTable();
+  return getDb().prepare('SELECT * FROM reflections WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?')
+    .all(agentId, limit) as Reflection[];
+}
+
+// ---------------------------------------------------------------------------
+// workspace — scoped scratchpad for in-progress work
+// ---------------------------------------------------------------------------
+
+export function ensureWorkspaceTable(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workspace (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      name TEXT NOT NULL,
+      content TEXT NOT NULL,
+      workspace_type TEXT NOT NULL DEFAULT 'note',
+      status TEXT NOT NULL DEFAULT 'active',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_workspace_agent ON workspace(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_workspace_name ON workspace(agent_id, name);
+  `);
+}
+
+export function upsertWorkspace(input: {
+  name: string; content: string; workspace_type?: string; agent_id?: string;
+}): number {
+  ensureWorkspaceTable();
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const result = db.prepare(`
+    INSERT INTO workspace (agent_id, name, content, workspace_type)
+    VALUES (@a, @n, @c, @t)
+    ON CONFLICT DO NOTHING
+  `).run({ a: agentId, n: input.name, c: input.content, t: input.workspace_type ?? 'note' });
+
+  if (result.changes === 0) {
+    db.prepare(`UPDATE workspace SET content = ?, workspace_type = ?, updated_at = datetime('now')
+                WHERE agent_id = ? AND name = ?`)
+      .run(input.content, input.workspace_type ?? 'note', agentId, input.name);
+    const row = db.prepare('SELECT id FROM workspace WHERE agent_id = ? AND name = ?').get(agentId, input.name) as { id: number };
+    return row.id;
+  }
+  return result.lastInsertRowid as number;
+}
+
+export function getWorkspace(name: string, agentId: string) {
+  ensureWorkspaceTable();
+  return getDb().prepare('SELECT * FROM workspace WHERE name = ? AND agent_id = ?').get(name, agentId);
+}
+
+export function listWorkspace(agentId: string, status?: string) {
+  ensureWorkspaceTable();
+  const db = getDb();
+  let sql = 'SELECT * FROM workspace WHERE agent_id = ?';
+  const params: unknown[] = [agentId];
+  if (status) { sql += ' AND status = ?'; params.push(status); }
+  sql += ' ORDER BY updated_at DESC';
+  return db.prepare(sql).all(...params);
+}
+
+// ---------------------------------------------------------------------------
+// task — shared task queue with status tracking
+// ---------------------------------------------------------------------------
+
+export function ensureTaskTable(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS tasks (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      title TEXT NOT NULL,
+      description TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      priority TEXT NOT NULL DEFAULT 'medium',
+      assignee TEXT,
+      due_at TEXT,
+      completed_at TEXT,
+      result TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_tasks_agent ON tasks(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_tasks_status ON tasks(status);
+  `);
+}
+
+export function createTask(input: {
+  title: string; description?: string; priority?: string;
+  assignee?: string; due_at?: string; agent_id?: string;
+}): number {
+  ensureTaskTable();
+  const result = getDb().prepare(`
+    INSERT INTO tasks (agent_id, title, description, priority, assignee, due_at)
+    VALUES (@a, @title, @desc, @prio, @assignee, @due)
+  `).run({ a: input.agent_id ?? 'default', title: input.title, desc: input.description ?? null,
+           prio: input.priority ?? 'medium', assignee: input.assignee ?? null, due: input.due_at ?? null });
+  return result.lastInsertRowid as number;
+}
+
+export function updateTaskStatus(id: number, status: string, result?: string, agentId = 'default'): boolean {
+  ensureTaskTable();
+  const db = getDb();
+  const completedAt = ['done', 'completed', 'cancelled'].includes(status) ? 'datetime(\'now\')' : 'NULL';
+  const changes = db.prepare(`
+    UPDATE tasks SET status = @s, result = @r,
+      completed_at = ${completedAt}, updated_at = datetime('now')
+    WHERE id = @id AND agent_id = @a
+  `).run({ s: status, r: result ?? null, id, a: agentId }).changes;
+  return changes > 0;
+}
+
+export function listTasks(agentId: string, status?: string, assignee?: string) {
+  ensureTaskTable();
+  const db = getDb();
+  let sql = 'SELECT * FROM tasks WHERE agent_id = ?';
+  const params: unknown[] = [agentId];
+  if (status) { sql += ' AND status = ?'; params.push(status); }
+  if (assignee) { sql += ' AND assignee = ?'; params.push(assignee); }
+  sql += ' ORDER BY priority DESC, created_at DESC';
+  return db.prepare(sql).all(...params);
+}
+
+// ---------------------------------------------------------------------------
+// policy — store and evaluate named rules/constraints
+// ---------------------------------------------------------------------------
+
+export interface Policy {
+  id: number; agent_id: string; name: string; rule: string;
+  scope: string; active: number; created_at: string;
+}
+
+export function ensurePolicyTable(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS policies (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL DEFAULT 'default',
+      name TEXT NOT NULL,
+      rule TEXT NOT NULL,
+      scope TEXT NOT NULL DEFAULT 'global',
+      active INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_policies_name_agent ON policies(name, agent_id);
+    CREATE INDEX IF NOT EXISTS idx_policies_agent ON policies(agent_id);
+  `);
+}
+
+export function upsertPolicy(input: { name: string; rule: string; scope?: string; agent_id?: string }): number {
+  ensurePolicyTable();
+  const db = getDb();
+  const result = db.prepare(`
+    INSERT INTO policies (agent_id, name, rule, scope)
+    VALUES (@a, @n, @r, @s)
+    ON CONFLICT (name, agent_id) DO UPDATE SET rule = @r, scope = @s
+  `).run({ a: input.agent_id ?? 'default', n: input.name, r: input.rule, s: input.scope ?? 'global' });
+  return result.lastInsertRowid as number;
+}
+
+export async function evaluatePolicy(input: {
+  name: string; context: string; agent_id?: string; model?: string;
+}): Promise<{ policy: Policy | undefined; allowed: boolean; reasoning: string }> {
+  ensurePolicyTable();
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const policy = db.prepare('SELECT * FROM policies WHERE name = ? AND agent_id = ? AND active = 1')
+    .get(input.name, agentId) as Policy | undefined;
+
+  if (!policy) return { policy: undefined, allowed: true, reasoning: 'Policy not found — defaulting to allow' };
+
+  if (!isLlmAvailable()) {
+    return { policy, allowed: true, reasoning: 'LLM unavailable — policy not evaluated, defaulting to allow' };
+  }
+
+  const raw = await chat([
+    { role: 'system', content: 'You are a policy evaluator. Respond with exactly: {"allowed": true/false, "reasoning": "..."}' },
+    { role: 'user', content: `Policy rule: ${policy.rule}\n\nContext to evaluate: ${input.context}` },
+  ], { model: input.model, temperature: 0, max_tokens: 256 });
+
+  try {
+    const parsed = JSON.parse(raw.match(/\{[\s\S]*\}/)![0]);
+    return { policy, allowed: Boolean(parsed.allowed), reasoning: parsed.reasoning ?? raw };
+  } catch {
+    return { policy, allowed: true, reasoning: raw };
+  }
+}
+
+export function listPolicies(agentId: string, activeOnly = true): Policy[] {
+  ensurePolicyTable();
+  const db = getDb();
+  let sql = 'SELECT * FROM policies WHERE agent_id = ?';
+  const params: unknown[] = [agentId];
+  if (activeOnly) { sql += ' AND active = 1'; }
+  sql += ' ORDER BY name';
+  return db.prepare(sql).all(...params) as Policy[];
+}

--- a/apps/brainctl/src/app/services/subsystems.service.ts
+++ b/apps/brainctl/src/app/services/subsystems.service.ts
@@ -57,6 +57,11 @@ export function upsertBelief(input: {
   return result.lastInsertRowid as number;
 }
 
+export function deleteBelief(id: number, agentId = 'default'): boolean {
+  ensureBeliefTable();
+  return getDb().prepare('DELETE FROM beliefs WHERE id = ? AND agent_id = ?').run(id, agentId).changes > 0;
+}
+
 export function listBeliefs(agentId: string, minConf?: number): Belief[] {
   ensureBeliefTable();
   const db = getDb();
@@ -251,6 +256,11 @@ export function getWorkspace(name: string, agentId: string) {
   return getDb().prepare('SELECT * FROM workspace WHERE name = ? AND agent_id = ?').get(name, agentId);
 }
 
+export function deleteWorkspace(name: string, agentId = 'default'): boolean {
+  ensureWorkspaceTable();
+  return getDb().prepare('DELETE FROM workspace WHERE name = ? AND agent_id = ?').run(name, agentId).changes > 0;
+}
+
 export function listWorkspace(agentId: string, status?: string) {
   ensureWorkspaceTable();
   const db = getDb();
@@ -310,6 +320,16 @@ export function updateTaskStatus(id: number, status: string, result?: string, ag
     WHERE id = @id AND agent_id = @a
   `).run({ s: status, r: result ?? null, id, a: agentId }).changes;
   return changes > 0;
+}
+
+export function getTask(id: number, agentId = 'default') {
+  ensureTaskTable();
+  return getDb().prepare('SELECT * FROM tasks WHERE id = ? AND agent_id = ?').get(id, agentId);
+}
+
+export function deleteTask(id: number, agentId = 'default'): boolean {
+  ensureTaskTable();
+  return getDb().prepare('DELETE FROM tasks WHERE id = ? AND agent_id = ?').run(id, agentId).changes > 0;
 }
 
 export function listTasks(agentId: string, status?: string, assignee?: string) {

--- a/apps/brainctl/src/app/services/tom.service.ts
+++ b/apps/brainctl/src/app/services/tom.service.ts
@@ -1,0 +1,241 @@
+import { getDb } from '../db/database.js';
+import { chat, isLlmAvailable } from './llm.service.js';
+import { searchMemories } from './memory.service.js';
+
+// ---------------------------------------------------------------------------
+// Theory of Mind — model what another agent likely believes/intends
+// ---------------------------------------------------------------------------
+
+export interface TomModel {
+  observer_agent: string;
+  subject_agent: string;
+  modeled_beliefs: string[];
+  modeled_intentions: string[];
+  confidence: number;
+  generated_at: string;
+  reasoning: string | null;
+}
+
+function ensureTomTable(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS tom_models (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      observer_agent TEXT NOT NULL,
+      subject_agent TEXT NOT NULL,
+      modeled_beliefs TEXT NOT NULL DEFAULT '[]',
+      modeled_intentions TEXT NOT NULL DEFAULT '[]',
+      confidence REAL NOT NULL DEFAULT 0.5,
+      reasoning TEXT,
+      generated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+    CREATE INDEX IF NOT EXISTS idx_tom_observer ON tom_models(observer_agent);
+    CREATE INDEX IF NOT EXISTS idx_tom_subject ON tom_models(subject_agent);
+  `);
+}
+
+export async function modelAgent(input: {
+  observer_agent: string;
+  subject_agent: string;
+  topic?: string;
+  model?: string;
+}): Promise<TomModel> {
+  ensureTomTable();
+  const db = getDb();
+
+  // Gather evidence: shared memories visible to observer, subject's events, beliefs
+  const subjectMemories = await searchMemories({
+    query: input.topic ?? 'goal intention belief',
+    limit: 10,
+    agent_id: input.subject_agent,
+  });
+
+  let modeled_beliefs: string[] = [];
+  let modeled_intentions: string[] = [];
+  let reasoning: string | null = null;
+
+  if (isLlmAvailable() && subjectMemories.length) {
+    const memText = subjectMemories.map((m) => `- ${m.content}`).join('\n');
+    const raw = await chat([
+      {
+        role: 'system',
+        content: 'You model another agent\'s mental state from their memory records. ' +
+          'Respond with JSON: {"beliefs": ["..."], "intentions": ["..."], "reasoning": "..."}',
+      },
+      {
+        role: 'user',
+        content: `Subject agent: ${input.subject_agent}\n` +
+          (input.topic ? `Topic: ${input.topic}\n` : '') +
+          `Memory records:\n${memText}`,
+      },
+    ], { model: input.model, temperature: 0.2, max_tokens: 400 });
+
+    try {
+      const parsed = JSON.parse(raw.match(/\{[\s\S]*\}/)![0]);
+      modeled_beliefs = Array.isArray(parsed.beliefs) ? parsed.beliefs : [];
+      modeled_intentions = Array.isArray(parsed.intentions) ? parsed.intentions : [];
+      reasoning = parsed.reasoning ?? null;
+    } catch {
+      modeled_beliefs = subjectMemories.slice(0, 3).map((m) => m.content);
+      reasoning = 'JSON parse failed — raw memory content used';
+    }
+  } else {
+    modeled_beliefs = subjectMemories.slice(0, 5).map((m) => m.content);
+  }
+
+  const confidence = subjectMemories.length > 0 ? Math.min(0.9, 0.4 + subjectMemories.length * 0.05) : 0.1;
+
+  const result = db.prepare(`
+    INSERT INTO tom_models (observer_agent, subject_agent, modeled_beliefs, modeled_intentions, confidence, reasoning)
+    VALUES (?, ?, ?, ?, ?, ?)
+  `).run(
+    input.observer_agent, input.subject_agent,
+    JSON.stringify(modeled_beliefs), JSON.stringify(modeled_intentions),
+    confidence, reasoning,
+  );
+
+  return {
+    observer_agent: input.observer_agent,
+    subject_agent: input.subject_agent,
+    modeled_beliefs,
+    modeled_intentions,
+    confidence,
+    generated_at: new Date().toISOString(),
+    reasoning,
+  };
+}
+
+export function getLatestTomModel(observerAgent: string, subjectAgent: string): TomModel | null {
+  ensureTomTable();
+  const row = getDb().prepare(`
+    SELECT * FROM tom_models
+    WHERE observer_agent = ? AND subject_agent = ?
+    ORDER BY generated_at DESC LIMIT 1
+  `).get(observerAgent, subjectAgent) as Record<string, unknown> | undefined;
+
+  if (!row) return null;
+  return {
+    observer_agent: row['observer_agent'] as string,
+    subject_agent: row['subject_agent'] as string,
+    modeled_beliefs: JSON.parse(row['modeled_beliefs'] as string) as string[],
+    modeled_intentions: JSON.parse(row['modeled_intentions'] as string) as string[],
+    confidence: row['confidence'] as number,
+    generated_at: row['generated_at'] as string,
+    reasoning: row['reasoning'] as string | null,
+  };
+}
+
+export function listTomModels(observerAgent: string): TomModel[] {
+  ensureTomTable();
+  const rows = getDb().prepare(`
+    SELECT * FROM tom_models WHERE observer_agent = ?
+    ORDER BY generated_at DESC
+  `).all(observerAgent) as Array<Record<string, unknown>>;
+
+  return rows.map((row) => ({
+    observer_agent: row['observer_agent'] as string,
+    subject_agent: row['subject_agent'] as string,
+    modeled_beliefs: JSON.parse(row['modeled_beliefs'] as string) as string[],
+    modeled_intentions: JSON.parse(row['modeled_intentions'] as string) as string[],
+    confidence: row['confidence'] as number,
+    generated_at: row['generated_at'] as string,
+    reasoning: row['reasoning'] as string | null,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Budget — token/compute budget management per agent
+// ---------------------------------------------------------------------------
+
+export interface BudgetStatus {
+  agent_id: string;
+  token_budget: number | null;
+  tokens_used: number;
+  tokens_remaining: number | null;
+  call_budget: number | null;
+  calls_used: number;
+  calls_remaining: number | null;
+  reset_at: string | null;
+  updated_at: string;
+}
+
+function ensureBudgetTable(): void {
+  getDb().exec(`
+    CREATE TABLE IF NOT EXISTS agent_budgets (
+      agent_id TEXT PRIMARY KEY,
+      token_budget INTEGER,
+      tokens_used INTEGER NOT NULL DEFAULT 0,
+      call_budget INTEGER,
+      calls_used INTEGER NOT NULL DEFAULT 0,
+      reset_at TEXT,
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+export function setBudget(input: {
+  agent_id: string; token_budget?: number; call_budget?: number; reset_at?: string;
+}): BudgetStatus {
+  ensureBudgetTable();
+  const db = getDb();
+  db.prepare(`
+    INSERT INTO agent_budgets (agent_id, token_budget, call_budget, reset_at)
+    VALUES (?, ?, ?, ?)
+    ON CONFLICT (agent_id) DO UPDATE SET
+      token_budget = COALESCE(excluded.token_budget, token_budget),
+      call_budget  = COALESCE(excluded.call_budget, call_budget),
+      reset_at     = COALESCE(excluded.reset_at, reset_at),
+      updated_at   = datetime('now')
+  `).run(
+    input.agent_id,
+    input.token_budget ?? null,
+    input.call_budget ?? null,
+    input.reset_at ?? null,
+  );
+  return getBudgetStatus(input.agent_id);
+}
+
+export function recordBudgetUsage(agentId: string, tokensUsed: number, calls = 1): BudgetStatus {
+  ensureBudgetTable();
+  const db = getDb();
+  db.prepare(`
+    INSERT INTO agent_budgets (agent_id, tokens_used, calls_used)
+    VALUES (?, ?, ?)
+    ON CONFLICT (agent_id) DO UPDATE SET
+      tokens_used = tokens_used + excluded.tokens_used,
+      calls_used  = calls_used  + excluded.calls_used,
+      updated_at  = datetime('now')
+  `).run(agentId, tokensUsed, calls);
+  return getBudgetStatus(agentId);
+}
+
+export function resetBudget(agentId: string): BudgetStatus {
+  ensureBudgetTable();
+  getDb().prepare(`
+    UPDATE agent_budgets SET tokens_used = 0, calls_used = 0, updated_at = datetime('now')
+    WHERE agent_id = ?
+  `).run(agentId);
+  return getBudgetStatus(agentId);
+}
+
+export function getBudgetStatus(agentId: string): BudgetStatus {
+  ensureBudgetTable();
+  const row = getDb().prepare('SELECT * FROM agent_budgets WHERE agent_id = ?')
+    .get(agentId) as Record<string, number | string | null> | undefined;
+
+  const tokens_used = (row?.['tokens_used'] as number) ?? 0;
+  const calls_used = (row?.['calls_used'] as number) ?? 0;
+  const token_budget = (row?.['token_budget'] as number | null) ?? null;
+  const call_budget = (row?.['call_budget'] as number | null) ?? null;
+
+  return {
+    agent_id: agentId,
+    token_budget,
+    tokens_used,
+    tokens_remaining: token_budget !== null ? Math.max(0, token_budget - tokens_used) : null,
+    call_budget,
+    calls_used,
+    calls_remaining: call_budget !== null ? Math.max(0, call_budget - calls_used) : null,
+    reset_at: (row?.['reset_at'] as string | null) ?? null,
+    updated_at: (row?.['updated_at'] as string) ?? new Date().toISOString(),
+  };
+}

--- a/apps/brainctl/src/app/services/trigger.service.ts
+++ b/apps/brainctl/src/app/services/trigger.service.ts
@@ -72,6 +72,35 @@ export function getActiveTriggers(agentId = 'default'): Trigger[] {
   `).all({ agent_id: agentId }) as Trigger[];
 }
 
+export function getTrigger(id: number, agentId = 'default'): Trigger | undefined {
+  return getDb().prepare('SELECT * FROM triggers WHERE id = ? AND agent_id = ?')
+    .get(id, agentId) as Trigger | undefined;
+}
+
+export function updateTrigger(id: number, input: {
+  active?: boolean; expires?: string | null; priority?: string; agent_id?: string;
+}): boolean {
+  const db = getDb();
+  const agentId = input.agent_id ?? 'default';
+  const fields: string[] = [];
+  const params: Record<string, unknown> = { id, agent_id: agentId };
+  if (input.active !== undefined) { fields.push('active = @active'); params['active'] = input.active ? 1 : 0; }
+  if (input.expires !== undefined) { fields.push('expires = @expires'); params['expires'] = input.expires; }
+  if (input.priority !== undefined) { fields.push('priority = @priority'); params['priority'] = input.priority; }
+  if (!fields.length) return false;
+  return db.prepare(`UPDATE triggers SET ${fields.join(', ')} WHERE id = @id AND agent_id = @agent_id`)
+    .run(params).changes > 0;
+}
+
+export function fireTrigger(id: number, agentId = 'default'): Trigger | undefined {
+  const db = getDb();
+  const now = new Date().toISOString();
+  db.prepare('UPDATE triggers SET fired_at = @now, active = 0 WHERE id = @id AND agent_id = @agent_id')
+    .run({ now, id, agent_id: agentId });
+  return db.prepare('SELECT * FROM triggers WHERE id = ? AND agent_id = ?')
+    .get(id, agentId) as Trigger | undefined;
+}
+
 export function deleteTrigger(id: number, agentId = 'default'): boolean {
   const db = getDb();
   const result = db.prepare(`

--- a/apps/brainctl/src/app/services/trigger.service.ts
+++ b/apps/brainctl/src/app/services/trigger.service.ts
@@ -1,0 +1,81 @@
+import { getDb } from '../db/database.js';
+
+export interface Trigger {
+  id: number;
+  agent_id: string;
+  condition: string;
+  keywords: string;
+  action: string;
+  priority: string;
+  expires: string | null;
+  created_at: string;
+  fired_at: string | null;
+  active: number;
+}
+
+export interface CreateTriggerInput {
+  condition: string;
+  keywords: string;
+  action: string;
+  priority?: string;
+  expires?: string;
+  agent_id?: string;
+}
+
+const PRIORITY_ORDER: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
+
+export function createTrigger(input: CreateTriggerInput): number {
+  const db = getDb();
+  const result = db.prepare(`
+    INSERT INTO triggers (agent_id, condition, keywords, action, priority, expires)
+    VALUES (@agent_id, @condition, @keywords, @action, @priority, @expires)
+  `).run({
+    agent_id: input.agent_id ?? 'default',
+    condition: input.condition,
+    keywords: input.keywords,
+    action: input.action,
+    priority: input.priority ?? 'medium',
+    expires: input.expires ?? null,
+  });
+  return result.lastInsertRowid as number;
+}
+
+export function checkTriggers(query: string, agentId = 'default'): Trigger[] {
+  const db = getDb();
+  const now = new Date().toISOString();
+
+  db.prepare(`
+    UPDATE triggers SET active = 0
+    WHERE agent_id = @agent_id AND active = 1 AND expires IS NOT NULL AND expires < @now
+  `).run({ agent_id: agentId, now });
+
+  const active = db.prepare(`
+    SELECT * FROM triggers WHERE agent_id = @agent_id AND active = 1
+  `).all({ agent_id: agentId }) as Trigger[];
+
+  const queryLower = query.toLowerCase();
+  const matched = active.filter((t) => {
+    const keywords = t.keywords.split(',').map((k) => k.trim().toLowerCase());
+    return keywords.some((k) => k && queryLower.includes(k));
+  });
+
+  matched.sort((a, b) => (PRIORITY_ORDER[a.priority] ?? 99) - (PRIORITY_ORDER[b.priority] ?? 99));
+
+  return matched.map((t) => ({ ...t, matched_keywords: t.keywords }));
+}
+
+export function getActiveTriggers(agentId = 'default'): Trigger[] {
+  const db = getDb();
+  return db.prepare(`
+    SELECT * FROM triggers WHERE agent_id = @agent_id AND active = 1
+    ORDER BY created_at DESC
+  `).all({ agent_id: agentId }) as Trigger[];
+}
+
+export function deleteTrigger(id: number, agentId = 'default'): boolean {
+  const db = getDb();
+  const result = db.prepare(`
+    UPDATE triggers SET active = 0 WHERE id = @id AND agent_id = @agent_id
+  `).run({ id, agent_id: agentId });
+  return result.changes > 0;
+}

--- a/apps/brainctl/src/main.ts
+++ b/apps/brainctl/src/main.ts
@@ -2,8 +2,10 @@ import { Application } from './app/app.js';
 import { starter } from '@ee/starter';
 import { appConfig } from './app/app.config.js';
 import { closeDb } from './app/db/database.js';
+import { initDefaultSchedule } from './app/services/scheduler.service.js';
 
 process.on('SIGTERM', () => { closeDb(); process.exit(0); });
 process.on('SIGINT', () => { closeDb(); process.exit(0); });
 
+initDefaultSchedule();
 starter(Application, appConfig).catch((error) => console.error(error));

--- a/apps/brainctl/src/main.ts
+++ b/apps/brainctl/src/main.ts
@@ -1,0 +1,9 @@
+import { Application } from './app/app.js';
+import { starter } from '@ee/starter';
+import { appConfig } from './app/app.config.js';
+import { closeDb } from './app/db/database.js';
+
+process.on('SIGTERM', () => { closeDb(); process.exit(0); });
+process.on('SIGINT', () => { closeDb(); process.exit(0); });
+
+starter(Application, appConfig).catch((error) => console.error(error));

--- a/apps/brainctl/tsconfig.app.json
+++ b/apps/brainctl/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "esnext",
+    "types": ["node"],
+    "target": "esnext"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/brainctl/tsconfig.json
+++ b/apps/brainctl/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,7 @@
         "@swc/core": "1.15.8",
         "@swc/helpers": "0.5.19",
         "@types/bcrypt": "^6.0.0",
+        "@types/better-sqlite3": "^7.6.13",
         "@types/crypto-js": "^4.2.2",
         "@types/express": "^5.0.6",
         "@types/fluent-ffmpeg": "^2.1.28",
@@ -1312,6 +1313,8 @@
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
 
     "@types/bcrypt": ["@types/bcrypt@6.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-/oJGukuH3D2+D+3H4JWLaAsJ/ji86dhRidzZ/Od7H/i8g+aCmvkeCc6Ni/f9uxGLSQVCRZkX2/lqEFG2BvWtlQ=="],
+
+    "@types/better-sqlite3": ["@types/better-sqlite3@7.6.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA=="],
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,7 @@
         "sharp": "^0.34.5",
         "socket.io": "^4.8.3",
         "socket.io-client": "^4.8.3",
+        "sqlite-vec": "^0.1.9",
         "sqlite3": "^5.1.7",
         "tslib": "^2.8.1",
         "typeorm": "^0.3.25",
@@ -3271,6 +3272,18 @@
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
 
     "sql-highlight": ["sql-highlight@6.1.0", "", {}, "sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA=="],
+
+    "sqlite-vec": ["sqlite-vec@0.1.9", "", { "optionalDependencies": { "sqlite-vec-darwin-arm64": "0.1.9", "sqlite-vec-darwin-x64": "0.1.9", "sqlite-vec-linux-arm64": "0.1.9", "sqlite-vec-linux-x64": "0.1.9", "sqlite-vec-windows-x64": "0.1.9" } }, "sha512-L7XJWRIBNvR9O5+vh1FQ+IGkh/3D2AzVksW5gdtk28m78Hy8skFD0pqReKH1Yp0/BUKRGcffgKvyO/EON5JXpA=="],
+
+    "sqlite-vec-darwin-arm64": ["sqlite-vec-darwin-arm64@0.1.9", "", { "os": "darwin", "cpu": "arm64" }, "sha512-jSsZpE42OfBkGL/ItyJTVCUwl6o6Ka3U5rc4j+UBDIQzC1ulSSKMEhQLthsOnF/MdAf1MuAkYhkdKmmcjaIZQg=="],
+
+    "sqlite-vec-darwin-x64": ["sqlite-vec-darwin-x64@0.1.9", "", { "os": "darwin", "cpu": "x64" }, "sha512-KDlVyqQT7pnOhU1ymB9gs7dMbSoVmKHitT+k1/xkjarcX8bBqPxWrGlK/R+C5WmWkfvWwyq5FfXfiBYCBs6PlA=="],
+
+    "sqlite-vec-linux-arm64": ["sqlite-vec-linux-arm64@0.1.9", "", { "os": "linux", "cpu": "arm64" }, "sha512-5wXVJ9c9kR4CHm/wVqXb/R+XUHTdpZ4nWbPHlS+gc9qQFVHs92Km4bPnCKX4rtcPMzvNis+SIzMJR1SCEwpuUw=="],
+
+    "sqlite-vec-linux-x64": ["sqlite-vec-linux-x64@0.1.9", "", { "os": "linux", "cpu": "x64" }, "sha512-w3tCH8xK2finW8fQJ/m8uqKodXUZ9KAuAar2UIhz4BHILfpE0WM/MTGCRfa7RjYbrYim5Luk3guvMOGI7T7JQA=="],
+
+    "sqlite-vec-windows-x64": ["sqlite-vec-windows-x64@0.1.9", "", { "os": "win32", "cpu": "x64" }, "sha512-y3gEIyy/17bq2QFPQOWLE68TYWcRZkBQVA2XLrTPHNTOp55xJi/BBBmOm40tVMDMjtP+Elpk6UBUXdaq+46b0Q=="],
 
     "sqlite3": ["sqlite3@5.1.7", "", { "dependencies": { "bindings": "^1.5.0", "node-addon-api": "^7.0.0", "prebuild-install": "^7.1.1", "tar": "^6.1.11" }, "optionalDependencies": { "node-gyp": "8.x" } }, "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog=="],
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "sharp": "^0.34.5",
     "socket.io": "^4.8.3",
     "socket.io-client": "^4.8.3",
+    "sqlite-vec": "^0.1.9",
     "sqlite3": "^5.1.7",
     "tslib": "^2.8.1",
     "typeorm": "^0.3.25",

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "@swc/core": "1.15.8",
     "@swc/helpers": "0.5.19",
     "@types/bcrypt": "^6.0.0",
+    "@types/better-sqlite3": "^7.6.13",
     "@types/crypto-js": "^4.2.2",
     "@types/express": "^5.0.6",
     "@types/fluent-ffmpeg": "^2.1.28",


### PR DESCRIPTION
Recreates brainctl as a REST API service in TypeScript using Fastify,
mirroring the MCP tools from the Python original as HTTP endpoints.

Endpoints:
- POST/GET/DELETE /memories — store, search, retire memories (FTS5 full-text search)
- POST/GET /events — append-only event log with search
- POST/GET /entities + /relate + /relations — entity graph with typed edges
- POST/GET /decisions — decision log with rationale
- GET /session/orient — one-call session start (handoff, events, triggers, memories)
- POST /session/wrap-up — one-call session end with auto-handoff
- POST/GET /session/handoff — create and retrieve handoff packets
- POST/GET/DELETE /triggers — prospective memory triggers with keyword matching
- POST/GET /procedures + /feedback — structured workflow store with feedback
- GET /search — unified cross-table search
- GET /think — spreading-activation recall via knowledge edges
- POST /affect — VAD affect classification with optional persistence
- GET /health + /stats — diagnostics

Storage: better-sqlite3 with WAL mode, FTS5 virtual tables, typed knowledge
edges for graph traversal. Schema defined in src/app/db/schema.sql.