### PR TITLE
feat(camera): add video playback around detection events

### DIFF
--- a/apps/camera-frontend/src/app/components/clip-player/clip-player.component.ts
+++ b/apps/camera-frontend/src/app/components/clip-player/clip-player.component.ts
@@ -1,0 +1,161 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule, DatePipe } from '@angular/common';
+import { Dialog } from 'primeng/dialog';
+import {
+  CameraApiService,
+  DetectionEvent,
+} from '../../services/camera-api.service';
+
+/**
+ * Modal video player for recorded clips around a detection event.
+ * Open it from anywhere via a template reference:
+ *   <app-clip-player #clipPlayer />
+ *   ... (click)="clipPlayer.open(event)"
+ */
+@Component({
+  selector: 'app-clip-player',
+  standalone: true,
+  imports: [CommonModule, DatePipe, Dialog],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <p-dialog
+      [visible]="visible()"
+      (visibleChange)="onVisibleChange($event)"
+      [modal]="true"
+      [dismissableMask]="true"
+      [draggable]="false"
+      [style]="{ width: 'min(900px, 95vw)' }"
+      [header]="title()"
+    >
+      @if (visible() && clipUrl(); as url) { @if (!error()) {
+      <video
+        class="clip-video"
+        [src]="url"
+        controls
+        autoplay
+        preload="auto"
+        (error)="onVideoError()"
+      ></video>
+      } @else {
+      <div class="clip-error">
+        <i class="pi pi-video"></i>
+        <p>No recorded video is available for this event.</p>
+        <span class="clip-error-hint">
+          Recordings may not cover this time range yet, or it has aged out of
+          the video retention window.
+        </span>
+      </div>
+      } @if (event(); as ev) {
+      <div class="clip-meta">
+        <span class="clip-label">{{ ev.label }}</span>
+        <span>{{ ev.timestamp | date : 'MMM d, y, HH:mm:ss' }}</span>
+        <span class="clip-window">
+          {{ prerollSec }}s before → {{ postrollSec }}s after
+        </span>
+      </div>
+      } }
+    </p-dialog>
+  `,
+  styles: `
+    .clip-video {
+      display: block;
+      width: 100%;
+      max-height: 70vh;
+      border-radius: var(--radius-sm);
+      background: #000;
+    }
+
+    .clip-error {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 8px;
+      padding: 48px 16px;
+      color: var(--text-muted);
+      text-align: center;
+
+      i {
+        font-size: 40px;
+        opacity: 0.4;
+      }
+
+      p {
+        margin: 0;
+        color: var(--text-secondary);
+      }
+    }
+
+    .clip-error-hint {
+      font-size: 12px;
+    }
+
+    .clip-meta {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      margin-top: 10px;
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .clip-label {
+      background: rgba(59, 130, 246, 0.15);
+      color: var(--accent-blue);
+      padding: 2px 10px;
+      border-radius: 12px;
+      font-weight: 500;
+      text-transform: capitalize;
+    }
+
+    .clip-window {
+      margin-left: auto;
+    }
+  `,
+})
+export class ClipPlayerComponent {
+  private readonly api = inject(CameraApiService);
+
+  /** Seconds of recorded video included before/after the event */
+  readonly prerollSec = 10;
+  readonly postrollSec = 20;
+
+  readonly visible = signal(false);
+  readonly error = signal(false);
+  readonly event = signal<DetectionEvent | null>(null);
+  readonly clipUrl = signal<string | null>(null);
+
+  readonly title = computed(() => {
+    const ev = this.event();
+    return ev ? `Playback — ${ev.label}` : 'Playback';
+  });
+
+  open(event: DetectionEvent): void {
+    const start = new Date(
+      new Date(event.timestamp).getTime() - this.prerollSec * 1000
+    );
+    this.event.set(event);
+    this.error.set(false);
+    this.clipUrl.set(
+      this.api.getClipUrl(start, this.prerollSec + this.postrollSec)
+    );
+    this.visible.set(true);
+  }
+
+  onVisibleChange(visible: boolean): void {
+    this.visible.set(visible);
+    if (!visible) {
+      // Drop the src so the <video> stops downloading/playing
+      this.clipUrl.set(null);
+    }
+  }
+
+  onVideoError(): void {
+    this.error.set(true);
+  }
+}

--- a/apps/camera-frontend/src/app/components/event-feed/event-feed.component.ts
+++ b/apps/camera-frontend/src/app/components/event-feed/event-feed.component.ts
@@ -2,24 +2,28 @@ import {
   ChangeDetectionStrategy,
   Component,
   Input,
+  OnInit,
   inject,
   signal,
   computed,
+  viewChild,
 } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { ButtonDirective } from 'primeng/button';
 import {
   CameraApiService,
   DetectionEvent,
+  RecordingStatus,
   SceneAnalysis,
   SceneEntity,
 } from '../../services/camera-api.service';
 import { EventService } from '../../services/event.service';
+import { ClipPlayerComponent } from '../clip-player/clip-player.component';
 
 @Component({
   selector: 'app-event-feed',
   standalone: true,
-  imports: [CommonModule, DatePipe, ButtonDirective],
+  imports: [CommonModule, DatePipe, ButtonDirective, ClipPlayerComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="feed-container glass-card">
@@ -72,6 +76,14 @@ import { EventService } from '../../services/event.service';
           </div>
           @if (event.snapshotFilename) {
           <i class="pi pi-camera snapshot-indicator"></i>
+          } @if (hasRecording(event)) {
+          <button
+            pButton
+            [text]="true"
+            icon="pi pi-play-circle"
+            (click)="playClip(event)"
+            class="play-btn"
+          ></button>
           }
           <button
             pButton
@@ -89,6 +101,8 @@ import { EventService } from '../../services/event.service';
         </div>
         }
       </div>
+
+      <app-clip-player #clipPlayer />
     </div>
   `,
   styles: `
@@ -273,7 +287,17 @@ import { EventService } from '../../services/event.service';
       }
     }
 
-    .event-item:hover .pin-btn {
+    .play-btn {
+      flex-shrink: 0;
+      font-size: 16px !important;
+      padding: 4px !important;
+      opacity: 0;
+      transition: opacity 0.15s;
+      color: var(--accent-blue) !important;
+    }
+
+    .event-item:hover .pin-btn,
+    .event-item:hover .play-btn {
       opacity: 1;
     }
 
@@ -299,11 +323,37 @@ import { EventService } from '../../services/event.service';
     }
   `,
 })
-export class EventFeedComponent {
+export class EventFeedComponent implements OnInit {
   private readonly api = inject(CameraApiService);
   private readonly eventService = inject(EventService);
 
+  private readonly clipPlayer =
+    viewChild.required<ClipPlayerComponent>('clipPlayer');
+
   @Input() events = signal<DetectionEvent[]>([]);
+
+  readonly recordingStatus = signal<RecordingStatus | null>(null);
+
+  ngOnInit(): void {
+    this.api.getRecordingStatus().subscribe({
+      next: (status) => this.recordingStatus.set(status),
+      error: () => this.recordingStatus.set(null),
+    });
+  }
+
+  /** True when the recording window still covers this event's timestamp. */
+  hasRecording(event: DetectionEvent): boolean {
+    const status = this.recordingStatus();
+    if (!status?.enabled || !status.oldestTimestamp) return false;
+    return (
+      new Date(event.timestamp).getTime() >=
+      new Date(status.oldestTimestamp).getTime()
+    );
+  }
+
+  playClip(event: DetectionEvent): void {
+    this.clipPlayer().open(event);
+  }
 
   getAnalysis(detectionEventId: string): SceneAnalysis | undefined {
     return this.eventService.analysisMap().get(detectionEventId);

--- a/apps/camera-frontend/src/app/components/recording-settings/recording-settings.component.ts
+++ b/apps/camera-frontend/src/app/components/recording-settings/recording-settings.component.ts
@@ -1,0 +1,273 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule, DecimalPipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ToggleSwitchModule } from 'primeng/toggleswitch';
+import { SelectModule } from 'primeng/select';
+import {
+  CameraApiService,
+  RecordingSettings,
+  RecordingStatus,
+} from '../../services/camera-api.service';
+
+@Component({
+  selector: 'app-recording-settings',
+  standalone: true,
+  imports: [CommonModule, DecimalPipe, FormsModule, ToggleSwitchModule, SelectModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="settings-container glass-card">
+      <div class="settings-header">
+        <i class="pi pi-video"></i>
+        <span>Recording Settings</span>
+        <span class="spacer"></span>
+        @if (saving()) {
+        <i class="pi pi-spin pi-spinner saving-icon"></i>
+        }
+      </div>
+
+      <!-- Enable -->
+      <div class="setting-section">
+        <div class="setting-row">
+          <span class="setting-label">
+            <i class="pi pi-circle-fill record-dot" [class.off]="!enabled"></i>
+            Continuous Recording
+          </span>
+          <p-toggleswitch
+            [(ngModel)]="enabled"
+            (ngModelChange)="onEnabledChange()"
+            [disabled]="loading()"
+          />
+        </div>
+        <span class="setting-hint">
+          Records the camera stream 24/7 so events can be played back.
+          Toggling restarts the stream pipeline (a few seconds of downtime).
+        </span>
+      </div>
+
+      <!-- Video Retention -->
+      <div class="setting-section">
+        <div class="setting-row">
+          <span class="setting-label">
+            <i class="pi pi-calendar"></i>
+            Video Retention
+          </span>
+          <p-select
+            [(ngModel)]="retentionDays"
+            [options]="retentionOptions"
+            optionLabel="label"
+            optionValue="value"
+            (ngModelChange)="onRetentionChange()"
+            [disabled]="loading() || !enabled"
+            [style]="{ width: '130px' }"
+          />
+        </div>
+        <span class="setting-hint">
+          Video older than {{ retentionDays }}
+          {{ retentionDays === 1 ? 'day' : 'days' }} is deleted immediately
+          and on every cleanup run.
+        </span>
+      </div>
+
+      <!-- Storage projection -->
+      @if (status(); as s) {
+      <div class="setting-section usage-section">
+        <div class="usage-row">
+          <span class="usage-label">Current footage</span>
+          <span class="usage-value">
+            {{ s.totalSizeMB / 1024 | number : '1.1-1' }} GB
+            ({{ s.segmentCount | number }} segments)
+          </span>
+        </div>
+        @if (s.estimatedDailyGB !== null) {
+        <div class="usage-row">
+          <span class="usage-label">Measured write rate</span>
+          <span class="usage-value">{{ s.estimatedDailyGB }} GB/day</span>
+        </div>
+        <div class="usage-row">
+          <span class="usage-label">Projected at {{ retentionDays }}d</span>
+          <span class="usage-value projected">
+            ~{{ projectedGB() | number : '1.0-1' }} GB
+          </span>
+        </div>
+        }
+      </div>
+      }
+    </div>
+  `,
+  styles: `
+    .settings-container {
+      overflow: hidden;
+    }
+
+    .settings-header {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border-color);
+      font-weight: 500;
+
+      i {
+        color: var(--accent-blue);
+        font-size: 20px;
+      }
+    }
+
+    .spacer {
+      flex: 1;
+    }
+
+    .saving-icon {
+      font-size: 14px !important;
+      color: var(--text-muted) !important;
+    }
+
+    .setting-section {
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border-color);
+
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+
+    .setting-row {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+    }
+
+    .setting-label {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      font-size: 14px;
+      font-weight: 500;
+
+      i {
+        color: var(--accent-yellow);
+        font-size: 16px;
+      }
+    }
+
+    .record-dot {
+      color: var(--accent-red) !important;
+      font-size: 10px !important;
+
+      &.off {
+        color: var(--text-muted) !important;
+      }
+    }
+
+    .setting-hint {
+      display: block;
+      margin-top: 6px;
+      font-size: 12px;
+      color: var(--text-muted);
+    }
+
+    .usage-section {
+      background: rgba(255, 255, 255, 0.02);
+    }
+
+    .usage-row {
+      display: flex;
+      justify-content: space-between;
+      padding: 3px 0;
+      font-size: 13px;
+    }
+
+    .usage-label {
+      color: var(--text-muted);
+    }
+
+    .usage-value {
+      color: var(--text-secondary);
+      font-weight: 500;
+
+      &.projected {
+        color: var(--accent-blue);
+      }
+    }
+  `,
+})
+export class RecordingSettingsComponent implements OnInit {
+  private readonly api = inject(CameraApiService);
+
+  readonly loading = signal(true);
+  readonly saving = signal(false);
+  readonly status = signal<RecordingStatus | null>(null);
+
+  /** Bound to the toggle/select controls */
+  enabled = true;
+  retentionDays = 3;
+
+  private readonly _retentionDaysSignal = signal(3);
+
+  readonly projectedGB = computed(() => {
+    const daily = this.status()?.estimatedDailyGB;
+    return daily !== null && daily !== undefined
+      ? daily * this._retentionDaysSignal()
+      : 0;
+  });
+
+  readonly retentionOptions = [
+    { label: '1 day', value: 1 },
+    { label: '2 days', value: 2 },
+    { label: '3 days', value: 3 },
+    { label: '5 days', value: 5 },
+    { label: '7 days', value: 7 },
+    { label: '14 days', value: 14 },
+  ];
+
+  ngOnInit(): void {
+    this.api.getRecordingSettings().subscribe({
+      next: (settings) => this._applySettings(settings),
+      error: () => this.loading.set(false),
+    });
+    this._loadStatus();
+  }
+
+  onEnabledChange(): void {
+    this._save({ enabled: this.enabled });
+  }
+
+  onRetentionChange(): void {
+    this._save({ retentionDays: this.retentionDays });
+  }
+
+  private _save(update: Partial<RecordingSettings>): void {
+    this.saving.set(true);
+    this.api.updateRecordingSettings(update).subscribe({
+      next: (settings) => {
+        this._applySettings(settings);
+        this.saving.set(false);
+        // Retention changes prune immediately — refresh the usage numbers
+        this._loadStatus();
+      },
+      error: () => this.saving.set(false),
+    });
+  }
+
+  private _applySettings(settings: RecordingSettings): void {
+    this.enabled = settings.enabled;
+    this.retentionDays = settings.retentionDays;
+    this._retentionDaysSignal.set(settings.retentionDays);
+    this.loading.set(false);
+  }
+
+  private _loadStatus(): void {
+    this.api.getRecordingStatus().subscribe({
+      next: (status) => this.status.set(status),
+      error: () => this.status.set(null),
+    });
+  }
+}

--- a/apps/camera-frontend/src/app/components/storage-status/storage-status.component.ts
+++ b/apps/camera-frontend/src/app/components/storage-status/storage-status.component.ts
@@ -93,6 +93,15 @@ import {
             <div class="breakdown-value">{{ status()!.dbSizeMB }} MB</div>
             <div class="breakdown-label">Database</div>
           </div>
+          <div class="breakdown-item">
+            <div class="breakdown-value">
+              {{ status()!.recordingSizeMB / 1024 | number : '1.1-1' }} GB
+            </div>
+            <div class="breakdown-label">Recordings</div>
+            <div class="breakdown-sub">
+              {{ status()!.recordingCount | number }} segments
+            </div>
+          </div>
         </div>
       </div>
 
@@ -101,6 +110,12 @@ import {
         <div class="limit-row">
           <span class="limit-label">Retention</span>
           <span class="limit-value">{{ status()!.retentionDays }} days</span>
+        </div>
+        <div class="limit-row">
+          <span class="limit-label">Video Retention</span>
+          <span class="limit-value">
+            {{ status()!.videoRetentionDays }} days
+          </span>
         </div>
         <div class="limit-row">
           <span class="limit-label">Snapshot Cap</span>
@@ -226,7 +241,7 @@ import {
 
     .breakdown-grid {
       display: grid;
-      grid-template-columns: repeat(4, 1fr);
+      grid-template-columns: repeat(auto-fit, minmax(90px, 1fr));
       gap: 8px;
     }
 

--- a/apps/camera-frontend/src/app/pages/events/events.component.ts
+++ b/apps/camera-frontend/src/app/pages/events/events.component.ts
@@ -4,6 +4,7 @@ import {
   OnInit,
   inject,
   signal,
+  viewChild,
 } from '@angular/core';
 import { CommonModule, DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
@@ -13,11 +14,13 @@ import { ButtonDirective } from 'primeng/button';
 import {
   CameraApiService,
   DetectionEvent,
+  RecordingStatus,
   SceneAnalysis,
   SceneEntity,
   AnomalyRating,
 } from '../../services/camera-api.service';
 import { LABEL_OPTIONS } from '../../constants/labels';
+import { ClipPlayerComponent } from '../../components/clip-player/clip-player.component';
 
 @Component({
   selector: 'app-events',
@@ -29,6 +32,7 @@ import { LABEL_OPTIONS } from '../../constants/labels';
     Select,
     Paginator,
     ButtonDirective,
+    ClipPlayerComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -78,6 +82,7 @@ import { LABEL_OPTIONS } from '../../constants/labels';
           <span class="col-confidence">Confidence</span>
           <span class="col-analysis">Analysis</span>
           <span class="col-snapshot">Snapshot</span>
+          <span class="col-video">Video</span>
         </div>
 
         @for (event of events(); track event.id) {
@@ -130,6 +135,19 @@ import { LABEL_OPTIONS } from '../../constants/labels';
             >
               <i class="pi pi-image"></i>
             </a>
+            } @else {
+            <i class="pi pi-minus no-snapshot"></i>
+            }
+          </span>
+          <span class="col-video">
+            @if (hasRecording(event)) {
+            <button
+              pButton
+              [text]="true"
+              icon="pi pi-play-circle"
+              class="play-clip-btn"
+              (click)="playClip(event); $event.stopPropagation()"
+            ></button>
             } @else {
             <i class="pi pi-minus no-snapshot"></i>
             }
@@ -195,6 +213,8 @@ import { LABEL_OPTIONS } from '../../constants/labels';
           [showFirstLastIcon]="true"
         />
       </div>
+
+      <app-clip-player #clipPlayer />
     </div>
   `,
   styles: `
@@ -238,7 +258,7 @@ import { LABEL_OPTIONS } from '../../constants/labels';
 
     .table-header {
       display: grid;
-      grid-template-columns: 180px 120px 160px 1fr 60px;
+      grid-template-columns: 180px 120px 160px 1fr 60px 60px;
       gap: 12px;
       padding: 12px 16px;
       background: rgba(255, 255, 255, 0.03);
@@ -251,7 +271,7 @@ import { LABEL_OPTIONS } from '../../constants/labels';
 
     .table-row {
       display: grid;
-      grid-template-columns: 180px 120px 160px 1fr 60px;
+      grid-template-columns: 180px 120px 160px 1fr 60px 60px;
       gap: 12px;
       padding: 10px 16px;
       align-items: center;
@@ -466,6 +486,12 @@ import { LABEL_OPTIONS } from '../../constants/labels';
       font-size: 18px;
     }
 
+    .play-clip-btn {
+      font-size: 18px !important;
+      padding: 4px !important;
+      color: var(--accent-blue) !important;
+    }
+
     .empty-row {
       display: flex;
       flex-direction: column;
@@ -484,10 +510,14 @@ import { LABEL_OPTIONS } from '../../constants/labels';
 export class EventsComponent implements OnInit {
   private readonly api = inject(CameraApiService);
 
+  private readonly clipPlayer =
+    viewChild.required<ClipPlayerComponent>('clipPlayer');
+
   readonly events = signal<DetectionEvent[]>([]);
   readonly totalEvents = signal(0);
   readonly expandedId = signal<string | null>(null);
   readonly loadingAnalysis = signal<Set<string>>(new Set());
+  readonly recordingStatus = signal<RecordingStatus | null>(null);
 
   /** Cache of fetched analyses keyed by detectionEventId */
   readonly analysisCache = new Map<string, SceneAnalysis>();
@@ -508,6 +538,24 @@ export class EventsComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadEvents();
+    this.api.getRecordingStatus().subscribe({
+      next: (status) => this.recordingStatus.set(status),
+      error: () => this.recordingStatus.set(null),
+    });
+  }
+
+  /** True when the recording window still covers this event's timestamp. */
+  hasRecording(event: DetectionEvent): boolean {
+    const status = this.recordingStatus();
+    if (!status?.enabled || !status.oldestTimestamp) return false;
+    return (
+      new Date(event.timestamp).getTime() >=
+      new Date(status.oldestTimestamp).getTime()
+    );
+  }
+
+  playClip(event: DetectionEvent): void {
+    this.clipPlayer().open(event);
   }
 
   loadEvents(): void {

--- a/apps/camera-frontend/src/app/pages/settings/settings.component.ts
+++ b/apps/camera-frontend/src/app/pages/settings/settings.component.ts
@@ -3,6 +3,7 @@ import { DetectionSettingsComponent } from '../../components/detection-settings/
 import { NotificationSettingsComponent } from '../../components/notification-settings/notification-settings.component';
 import { AnalysisSettingsComponent } from '../../components/analysis-settings/analysis-settings.component';
 import { StorageStatusComponent } from '../../components/storage-status/storage-status.component';
+import { RecordingSettingsComponent } from '../../components/recording-settings/recording-settings.component';
 
 @Component({
   selector: 'app-settings',
@@ -12,12 +13,14 @@ import { StorageStatusComponent } from '../../components/storage-status/storage-
     NotificationSettingsComponent,
     AnalysisSettingsComponent,
     StorageStatusComponent,
+    RecordingSettingsComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="settings-page">
       <h1 class="page-title">Settings</h1>
       <app-storage-status />
+      <app-recording-settings />
       <app-analysis-settings />
       <app-notification-settings />
       <app-detection-settings />

--- a/apps/camera-frontend/src/app/services/camera-api.service.ts
+++ b/apps/camera-frontend/src/app/services/camera-api.service.ts
@@ -140,6 +140,12 @@ export interface CleanupStatus {
   videoRetentionDays: number;
 }
 
+export interface RecordingSettings {
+  enabled: boolean;
+  retentionDays: number;
+  segmentSeconds: number;
+}
+
 export interface RecordingStatus {
   enabled: boolean;
   segmentCount: number;
@@ -329,6 +335,21 @@ export class CameraApiService {
 
   getRecordingStatus(): Observable<RecordingStatus> {
     return this.http.get<RecordingStatus>(`${this.baseUrl}/recordings/status`);
+  }
+
+  getRecordingSettings(): Observable<RecordingSettings> {
+    return this.http.get<RecordingSettings>(
+      `${this.baseUrl}/recordings/settings`
+    );
+  }
+
+  updateRecordingSettings(
+    update: Partial<RecordingSettings>
+  ): Observable<RecordingSettings> {
+    return this.http.put<RecordingSettings>(
+      `${this.baseUrl}/recordings/settings`,
+      update
+    );
   }
 
   getClipUrl(start: Date, durationSec: number): string {

--- a/apps/camera-frontend/src/app/services/camera-api.service.ts
+++ b/apps/camera-frontend/src/app/services/camera-api.service.ts
@@ -135,6 +135,20 @@ export interface CleanupStatus {
   dbSizeMB: number;
   detectionEventCount: number;
   analysisCount: number;
+  recordingCount: number;
+  recordingSizeMB: number;
+  videoRetentionDays: number;
+}
+
+export interface RecordingStatus {
+  enabled: boolean;
+  segmentCount: number;
+  totalSizeMB: number;
+  oldestTimestamp: string | null;
+  newestTimestamp: string | null;
+  retentionDays: number;
+  segmentSeconds: number;
+  estimatedDailyGB: number | null;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -309,6 +323,18 @@ export class CameraApiService {
       `${this.baseUrl}/analysis/settings`,
       update
     );
+  }
+
+  // ── Recordings ──
+
+  getRecordingStatus(): Observable<RecordingStatus> {
+    return this.http.get<RecordingStatus>(`${this.baseUrl}/recordings/status`);
+  }
+
+  getClipUrl(start: Date, durationSec: number): string {
+    return `${this.baseUrl}/recordings/clip?start=${encodeURIComponent(
+      start.toISOString()
+    )}&duration=${durationSec}`;
   }
 
   // ── Cleanup / Storage ──

--- a/apps/camera/src/app/app.ts
+++ b/apps/camera/src/app/app.ts
@@ -14,6 +14,7 @@ import { RecordingRouter } from './recording/recording.router';
 import { WebSocketService } from './websocket/websocket.service';
 import { StreamService } from './stream/stream.service';
 import { DetectionService } from './detection/detection.service';
+import { RecordingService } from './recording/recording.service';
 import { NotificationService } from './notification/notification.service';
 import { AnalysisService } from './analysis/analysis.service';
 import { CleanupService } from './cleanup/cleanup.service';
@@ -22,6 +23,7 @@ import { CleanupService } from './cleanup/cleanup.service';
 import './detection';
 import './notification';
 import './analysis';
+import './recording';
 
 export async function Application(fastify: FastifyInstance) {
   // Initialize Socket.io on the underlying HTTP server
@@ -81,6 +83,16 @@ export async function Application(fastify: FastifyInstance) {
   fastify.addHook('onReady', async () => {
     const streamService = inject(StreamService);
     const detectionService = inject(DetectionService);
+
+    // Recording settings must be loaded before the stream starts so the
+    // FFmpeg recording output reflects the persisted configuration.
+    const recordingService = inject(RecordingService);
+    try {
+      await recordingService.initialize();
+      console.log('🎞️ Recording service initialized');
+    } catch (err) {
+      console.error('❌ Failed to initialize recording service:', err);
+    }
 
     try {
       await streamService.start();

--- a/apps/camera/src/app/app.ts
+++ b/apps/camera/src/app/app.ts
@@ -10,6 +10,7 @@ import { SnapshotRouter } from './snapshot/snapshot.router';
 import { NotificationRouter } from './notification/notification.router';
 import { AnalysisRouter } from './analysis/analysis.router';
 import { CleanupRouter } from './cleanup/cleanup.router';
+import { RecordingRouter } from './recording/recording.router';
 import { WebSocketService } from './websocket/websocket.service';
 import { StreamService } from './stream/stream.service';
 import { DetectionService } from './detection/detection.service';
@@ -71,6 +72,10 @@ export async function Application(fastify: FastifyInstance) {
   fastify
     .withTypeProvider<ZodTypeProvider>()
     .register(CleanupRouter, { prefix: '/cleanup' });
+
+  fastify
+    .withTypeProvider<ZodTypeProvider>()
+    .register(RecordingRouter, { prefix: '/recordings' });
 
   // Start the stream and detection pipeline after server is ready
   fastify.addHook('onReady', async () => {

--- a/apps/camera/src/app/cleanup/cleanup.router.ts
+++ b/apps/camera/src/app/cleanup/cleanup.router.ts
@@ -14,6 +14,9 @@ const CleanupStatusSchema = z.object({
   dbSizeMB: z.number(),
   detectionEventCount: z.number(),
   analysisCount: z.number(),
+  recordingCount: z.number(),
+  recordingSizeMB: z.number(),
+  videoRetentionDays: z.number(),
 });
 
 export async function CleanupRouter(fastify: FastifyInstance) {

--- a/apps/camera/src/app/cleanup/cleanup.service.ts
+++ b/apps/camera/src/app/cleanup/cleanup.service.ts
@@ -7,6 +7,7 @@ import {
   DetectionSettingsEntity,
 } from '../detection/detection.entity';
 import { SceneAnalysis } from '../analysis/analysis.entity';
+import { RecordingService } from '../recording/recording.service';
 
 /**
  * CleanupService provides centralised, scheduled age-off for all
@@ -15,8 +16,9 @@ import { SceneAnalysis } from '../analysis/analysis.entity';
  * 1. Detection events & snapshots (respects retention + pinned flag)
  * 2. Scene-analysis records linked to expired detections
  * 3. Orphaned snapshot files not tracked in the DB
- * 4. Disk-space-aware emergency cleanup when usage exceeds a threshold
- * 5. SQLite VACUUM after large deletions to reclaim space
+ * 4. Continuous video recording segments (separate, shorter retention)
+ * 5. Disk-space-aware emergency cleanup when usage exceeds a threshold
+ * 6. SQLite VACUUM after large deletions to reclaim space
  *
  * Runs on startup and then at a configurable interval (default: 30 min).
  */
@@ -27,6 +29,7 @@ export class CleanupService {
     DetectionSettingsEntity
   );
   private readonly _analysisRepo = this._db.repositoryFor(SceneAnalysis);
+  private readonly _recordingService = inject(RecordingService);
 
   private _timer: ReturnType<typeof setInterval> | null = null;
   private _running = false;
@@ -113,13 +116,15 @@ export class CleanupService {
       const analysesDeleted = await this._purgeExpiredAnalyses(cutoff);
       const orphansDeleted = this._purgeOrphanedSnapshots(cutoff);
       const cappedDeleted = this._capSnapshotCount();
+      const recordingsDeleted = this._pruneRecordings();
 
       const totalDeleted =
         eventsDeleted.rows +
         eventsDeleted.files +
         analysesDeleted +
         orphansDeleted +
-        cappedDeleted;
+        cappedDeleted +
+        recordingsDeleted;
 
       // Reclaim SQLite space after large deletions
       if (eventsDeleted.rows + analysesDeleted > 100) {
@@ -154,7 +159,7 @@ export class CleanupService {
         console.log(
           `🧹 Cleanup: ${eventsDeleted.rows} events, ${eventsDeleted.files} event snapshots, ` +
             `${analysesDeleted} analyses, ${orphansDeleted} orphans, ` +
-            `${cappedDeleted} over cap${diskStr}`
+            `${cappedDeleted} over cap, ${recordingsDeleted} recordings${diskStr}`
         );
       }
     } catch (err) {
@@ -262,6 +267,21 @@ export class CleanupService {
     return deleted;
   }
 
+  // ── Recording segments ──
+
+  /**
+   * Delete recording segments older than the video retention period.
+   * Video retention is separate (and typically shorter) than snapshot
+   * retention because continuous video dominates disk usage.
+   */
+  private _pruneRecordings(retentionDaysOverride?: number): number {
+    const retentionDays =
+      retentionDaysOverride ?? this._recordingService.getRetentionDays();
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - retentionDays);
+    return this._recordingService.pruneOlderThan(cutoff);
+  }
+
   // ── Snapshot cap ──
 
   /**
@@ -349,7 +369,14 @@ export class CleanupService {
     const emergencyCap = Math.floor(this._maxSnapshots / 2);
     totalDeleted += this._capSnapshotsTo(emergencyCap);
 
-    // Phase 3: VACUUM to reclaim SQLite space
+    // Phase 3: Halve video retention — recordings are the biggest consumer
+    const emergencyVideoRetention = Math.max(
+      1,
+      Math.floor(this._recordingService.getRetentionDays() / 2)
+    );
+    totalDeleted += this._pruneRecordings(emergencyVideoRetention);
+
+    // Phase 4: VACUUM to reclaim SQLite space
     if (totalDeleted > 0) {
       try {
         await this._db.dataSource.query('VACUUM');
@@ -450,6 +477,8 @@ export class CleanupService {
       // ignore
     }
 
+    const recordingStats = this._recordingService.getStorageStats();
+
     return {
       retentionDays,
       maxSnapshots: this._maxSnapshots,
@@ -460,6 +489,9 @@ export class CleanupService {
       dbSizeMB,
       detectionEventCount: detectionCount,
       analysisCount,
+      recordingCount: recordingStats.segmentCount,
+      recordingSizeMB: recordingStats.sizeMB,
+      videoRetentionDays: this._recordingService.getRetentionDays(),
     };
   }
 }
@@ -474,4 +506,7 @@ export interface CleanupStatus {
   dbSizeMB: number;
   detectionEventCount: number;
   analysisCount: number;
+  recordingCount: number;
+  recordingSizeMB: number;
+  videoRetentionDays: number;
 }

--- a/apps/camera/src/app/recording/index.ts
+++ b/apps/camera/src/app/recording/index.ts
@@ -1,2 +1,3 @@
+export * from './recording.entity';
 export * from './recording.service';
 export * from './recording.router';

--- a/apps/camera/src/app/recording/index.ts
+++ b/apps/camera/src/app/recording/index.ts
@@ -1,0 +1,2 @@
+export * from './recording.service';
+export * from './recording.router';

--- a/apps/camera/src/app/recording/recording.entity.ts
+++ b/apps/camera/src/app/recording/recording.entity.ts
@@ -1,0 +1,48 @@
+import { provide } from '@ee/di';
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+import { z } from 'zod';
+import { ENTITIES } from '../data-source';
+
+/**
+ * Single-row table that persists user-configurable recording settings
+ * across backend restarts. Env vars provide the initial defaults only.
+ */
+@Entity('recording_settings')
+export class RecordingSettingsEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  /** Whether continuous video recording is enabled */
+  @Column('boolean', { default: true })
+  enabled!: boolean;
+
+  /** How many days of video to keep before purging */
+  @Column('integer', { default: 3 })
+  retentionDays!: number;
+
+  /** Target duration of each recording segment in seconds */
+  @Column('integer', { default: 10 })
+  segmentSeconds!: number;
+}
+
+// ── Zod Schemas ──
+
+export const RecordingSettingsSchema = z.object({
+  enabled: z.boolean(),
+  retentionDays: z.number().int().min(1).max(30),
+  segmentSeconds: z.number().int().min(2).max(60),
+});
+
+export type RecordingSettings = z.infer<typeof RecordingSettingsSchema>;
+
+export const UpdateRecordingSettingsSchema = z.object({
+  enabled: z.boolean().optional(),
+  retentionDays: z.number().int().min(1).max(30).optional(),
+  segmentSeconds: z.number().int().min(2).max(60).optional(),
+});
+
+export type UpdateRecordingSettings = z.infer<
+  typeof UpdateRecordingSettingsSchema
+>;
+
+provide(ENTITIES, RecordingSettingsEntity);

--- a/apps/camera/src/app/recording/recording.router.ts
+++ b/apps/camera/src/app/recording/recording.router.ts
@@ -3,6 +3,11 @@ import { createReadStream, statSync } from 'fs';
 import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
+import { StreamService } from '../stream/stream.service';
+import {
+  RecordingSettingsSchema,
+  UpdateRecordingSettingsSchema,
+} from './recording.entity';
 import { RecordingService } from './recording.service';
 
 const RecordingStatusSchema = z.object({
@@ -18,6 +23,49 @@ const RecordingStatusSchema = z.object({
 
 export async function RecordingRouter(fastify: FastifyInstance) {
   const recordingService = inject(RecordingService);
+  const streamService = inject(StreamService);
+
+  // Get recording settings
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/settings',
+    {
+      schema: {
+        response: {
+          200: RecordingSettingsSchema,
+        },
+      },
+    },
+    async () => {
+      return recordingService.getSettings();
+    }
+  );
+
+  // Update recording settings. Toggling recording or changing the
+  // segment length restarts the FFmpeg pipeline so the new outputs
+  // take effect immediately; retention changes apply right away.
+  fastify.withTypeProvider<ZodTypeProvider>().put(
+    '/settings',
+    {
+      schema: {
+        body: UpdateRecordingSettingsSchema,
+        response: {
+          200: RecordingSettingsSchema,
+        },
+      },
+    },
+    async (request) => {
+      const { settings, requiresStreamRestart } =
+        await recordingService.updateSettings(request.body);
+
+      if (requiresStreamRestart) {
+        console.log('🎞️ Recording settings changed — restarting stream');
+        streamService.stop();
+        await streamService.start();
+      }
+
+      return settings;
+    }
+  );
 
   // Get recording status (coverage window, size, write rate)
   fastify.withTypeProvider<ZodTypeProvider>().get(

--- a/apps/camera/src/app/recording/recording.router.ts
+++ b/apps/camera/src/app/recording/recording.router.ts
@@ -1,0 +1,98 @@
+import { inject } from '@ee/di';
+import { createReadStream, statSync } from 'fs';
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { RecordingService } from './recording.service';
+
+const RecordingStatusSchema = z.object({
+  enabled: z.boolean(),
+  segmentCount: z.number(),
+  totalSizeMB: z.number(),
+  oldestTimestamp: z.string().nullable(),
+  newestTimestamp: z.string().nullable(),
+  retentionDays: z.number(),
+  segmentSeconds: z.number(),
+  estimatedDailyGB: z.number().nullable(),
+});
+
+export async function RecordingRouter(fastify: FastifyInstance) {
+  const recordingService = inject(RecordingService);
+
+  // Get recording status (coverage window, size, write rate)
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/status',
+    {
+      schema: {
+        response: {
+          200: RecordingStatusSchema,
+        },
+      },
+    },
+    async () => {
+      return recordingService.getStatus();
+    }
+  );
+
+  // Extract and serve an MP4 clip for a time window.
+  // Supports HTTP Range requests so the <video> element can seek.
+  fastify.withTypeProvider<ZodTypeProvider>().get(
+    '/clip',
+    {
+      schema: {
+        querystring: z.object({
+          start: z.coerce.date(),
+          duration: z.coerce.number().min(5).max(300).default(30),
+        }),
+      },
+    },
+    async (request, reply) => {
+      const { start, duration } = request.query;
+
+      const clip = await recordingService.extractClip(start, duration);
+      if (!clip) {
+        reply
+          .code(404)
+          .send({ error: 'No recorded video available for this time range' });
+        return;
+      }
+
+      const { size } = statSync(clip.path);
+
+      reply
+        .header('Content-Type', 'video/mp4')
+        .header('Accept-Ranges', 'bytes')
+        .header('Cache-Control', 'private, max-age=300')
+        .header('Access-Control-Allow-Origin', '*');
+
+      const range = request.headers.range;
+      if (range) {
+        const match = /^bytes=(\d*)-(\d*)$/.exec(range);
+        const rangeStart = match?.[1] ? parseInt(match[1], 10) : 0;
+        const rangeEnd =
+          match?.[2] && match[2] !== ''
+            ? Math.min(parseInt(match[2], 10), size - 1)
+            : size - 1;
+
+        if (!match || rangeStart > rangeEnd || rangeStart >= size) {
+          reply
+            .code(416)
+            .header('Content-Range', `bytes */${size}`)
+            .send({ error: 'Range not satisfiable' });
+          return;
+        }
+
+        reply
+          .code(206)
+          .header('Content-Range', `bytes ${rangeStart}-${rangeEnd}/${size}`)
+          .header('Content-Length', rangeEnd - rangeStart + 1)
+          .send(createReadStream(clip.path, { start: rangeStart, end: rangeEnd }));
+        return;
+      }
+
+      reply
+        .header('Content-Length', size)
+        .send(createReadStream(clip.path));
+    }
+  );
+}

--- a/apps/camera/src/app/recording/recording.service.ts
+++ b/apps/camera/src/app/recording/recording.service.ts
@@ -1,3 +1,4 @@
+import { inject } from '@ee/di';
 import { spawn } from 'child_process';
 import {
   existsSync,
@@ -8,6 +9,12 @@ import {
   writeFileSync,
 } from 'fs';
 import { join } from 'path';
+import { Database } from '../data-source';
+import {
+  RecordingSettings,
+  RecordingSettingsEntity,
+  UpdateRecordingSettings,
+} from './recording.entity';
 
 /** A completed recording segment on disk. */
 interface SegmentInfo {
@@ -41,16 +48,21 @@ export interface RecordingStatus {
  * clip boundaries snap to segment boundaries (~±1 segment of slack).
  */
 export class RecordingService {
-  private readonly _enabled = process.env.RECORDING_ENABLED !== 'false';
+  private readonly _db = inject(Database);
+  private readonly _settingsRepo = this._db.repositoryFor(
+    RecordingSettingsEntity
+  );
 
-  /** Target duration of each recording segment in seconds */
-  private readonly _segmentSeconds = parseInt(
+  /** In-memory cache of the current settings (DB-backed) */
+  private _settings: RecordingSettingsEntity | null = null;
+
+  /** Env-var defaults, used to seed the settings row and as fallbacks */
+  private readonly _envEnabled = process.env.RECORDING_ENABLED !== 'false';
+  private readonly _envSegmentSeconds = parseInt(
     process.env.RECORDING_SEGMENT_SECONDS || '10',
     10
   );
-
-  /** How long to keep recorded video (separate from snapshot retention) */
-  private readonly _retentionDays = parseInt(
+  private readonly _envRetentionDays = parseInt(
     process.env.VIDEO_RETENTION_DAYS || '3',
     10
   );
@@ -79,16 +91,96 @@ export class RecordingService {
     return join(this._dataDir, 'clips');
   }
 
+  /**
+   * Load settings from the database (or create defaults from env vars).
+   * Called once during startup, before the stream starts.
+   */
+  async initialize(): Promise<void> {
+    try {
+      let row = await this._settingsRepo.findOne({ where: {} });
+      if (!row) {
+        row = this._settingsRepo.create({
+          enabled: this._envEnabled,
+          retentionDays: this._envRetentionDays,
+          segmentSeconds: this._envSegmentSeconds,
+        });
+        await this._settingsRepo.save(row);
+        console.log('🎞️ Initialized default recording settings');
+      }
+      this._settings = row;
+      console.log(
+        `🎞️ Recording ${row.enabled ? 'ENABLED' : 'disabled'} ` +
+          `(${row.segmentSeconds}s segments, ${row.retentionDays}d retention)`
+      );
+    } catch (err) {
+      console.error('Failed to load recording settings:', err);
+    }
+  }
+
   isEnabled(): boolean {
-    return this._enabled;
+    return this._settings?.enabled ?? this._envEnabled;
   }
 
   getSegmentSeconds(): number {
-    return this._segmentSeconds;
+    return this._settings?.segmentSeconds ?? this._envSegmentSeconds;
   }
 
   getRetentionDays(): number {
-    return this._retentionDays;
+    return this._settings?.retentionDays ?? this._envRetentionDays;
+  }
+
+  getSettings(): RecordingSettings {
+    return {
+      enabled: this.isEnabled(),
+      retentionDays: this.getRetentionDays(),
+      segmentSeconds: this.getSegmentSeconds(),
+    };
+  }
+
+  /**
+   * Update recording settings and persist them.
+   * Returns whether the FFmpeg stream must be restarted for the change
+   * to take effect (enabling/disabling recording or resizing segments).
+   * A lowered retention is applied to disk immediately.
+   */
+  async updateSettings(
+    update: UpdateRecordingSettings
+  ): Promise<{ settings: RecordingSettings; requiresStreamRestart: boolean }> {
+    if (!this._settings) {
+      await this.initialize();
+    }
+    const row = this._settings;
+    if (!row) {
+      throw new Error('Recording settings unavailable');
+    }
+
+    const requiresStreamRestart =
+      (update.enabled !== undefined && update.enabled !== row.enabled) ||
+      (update.segmentSeconds !== undefined &&
+        update.segmentSeconds !== row.segmentSeconds);
+
+    if (update.enabled !== undefined) row.enabled = update.enabled;
+    if (update.retentionDays !== undefined)
+      row.retentionDays = update.retentionDays;
+    if (update.segmentSeconds !== undefined)
+      row.segmentSeconds = update.segmentSeconds;
+
+    await this._settingsRepo.save(row);
+
+    // Apply a shortened retention right away so the storage card
+    // reflects the change without waiting for the next cleanup run.
+    if (update.retentionDays !== undefined) {
+      const cutoff = new Date();
+      cutoff.setDate(cutoff.getDate() - row.retentionDays);
+      const pruned = this.pruneOlderThan(cutoff);
+      if (pruned > 0) {
+        console.log(
+          `🎞️ Retention change pruned ${pruned} recording segments`
+        );
+      }
+    }
+
+    return { settings: this.getSettings(), requiresStreamRestart };
   }
 
   /**
@@ -120,17 +212,18 @@ export class RecordingService {
     start: Date,
     durationSec: number
   ): Promise<{ path: string; filename: string } | null> {
-    if (!this._enabled) return null;
+    if (!this.isEnabled()) return null;
     this.ensureDirs();
     this._pruneClips();
 
+    const segmentSeconds = this.getSegmentSeconds();
     const startEpoch = Math.floor(start.getTime() / 1000);
     const endEpoch = startEpoch + Math.ceil(durationSec);
     const nowEpoch = Math.floor(Date.now() / 1000);
 
     // Skip segments that may still be written by FFmpeg
     const completed = this._listSegments().filter(
-      (s) => s.epoch + this._segmentSeconds + 3 <= nowEpoch
+      (s) => s.epoch + segmentSeconds + 3 <= nowEpoch
     );
 
     const inWindow = completed.filter(
@@ -142,7 +235,7 @@ export class RecordingService {
     const before = completed
       .filter(
         (s) =>
-          s.epoch < startEpoch && s.epoch + this._segmentSeconds * 2 > startEpoch
+          s.epoch < startEpoch && s.epoch + segmentSeconds * 2 > startEpoch
       )
       .pop();
     const segments = before ? [before, ...inWindow] : inWindow;
@@ -198,6 +291,7 @@ export class RecordingService {
   }
 
   getStatus(): RecordingStatus {
+    const segmentSeconds = this.getSegmentSeconds();
     const segments = this._listSegments();
     const totalBytes = segments.reduce((sum, s) => sum + s.size, 0);
     const oldest = segments[0];
@@ -206,7 +300,7 @@ export class RecordingService {
     // Estimate the daily write rate once we have ≥10 minutes of footage
     let estimatedDailyGB: number | null = null;
     if (oldest && newest) {
-      const spanSec = newest.epoch + this._segmentSeconds - oldest.epoch;
+      const spanSec = newest.epoch + segmentSeconds - oldest.epoch;
       if (spanSec >= 600) {
         estimatedDailyGB =
           Math.round(((totalBytes / spanSec) * 86_400) / 1e7) / 100;
@@ -214,17 +308,17 @@ export class RecordingService {
     }
 
     return {
-      enabled: this._enabled,
+      enabled: this.isEnabled(),
       segmentCount: segments.length,
       totalSizeMB: Math.round(totalBytes / 1024 / 1024),
       oldestTimestamp: oldest
         ? new Date(oldest.epoch * 1000).toISOString()
         : null,
       newestTimestamp: newest
-        ? new Date((newest.epoch + this._segmentSeconds) * 1000).toISOString()
+        ? new Date((newest.epoch + segmentSeconds) * 1000).toISOString()
         : null,
-      retentionDays: this._retentionDays,
-      segmentSeconds: this._segmentSeconds,
+      retentionDays: this.getRetentionDays(),
+      segmentSeconds,
       estimatedDailyGB,
     };
   }

--- a/apps/camera/src/app/recording/recording.service.ts
+++ b/apps/camera/src/app/recording/recording.service.ts
@@ -1,0 +1,361 @@
+import { spawn } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+
+/** A completed recording segment on disk. */
+interface SegmentInfo {
+  filename: string;
+  /** Unix epoch (seconds) at which the segment starts */
+  epoch: number;
+  size: number;
+}
+
+export interface RecordingStatus {
+  enabled: boolean;
+  segmentCount: number;
+  totalSizeMB: number;
+  oldestTimestamp: string | null;
+  newestTimestamp: string | null;
+  retentionDays: number;
+  segmentSeconds: number;
+  /** Estimated GB written per day, measured from the segments on disk */
+  estimatedDailyGB: number | null;
+}
+
+/**
+ * RecordingService manages the continuous rolling video recording that
+ * StreamService produces (FFmpeg segment output) and extracts playable
+ * MP4 clips for time windows around detection events.
+ *
+ * Segments are MPEG-TS files named `rec_<epochSeconds>.ts` so the time
+ * range each one covers can be derived from the filename alone — no DB
+ * bookkeeping needed. Clips are built by concatenating the overlapping
+ * segments with `-c copy` (no re-encode), so extraction is fast and the
+ * clip boundaries snap to segment boundaries (~±1 segment of slack).
+ */
+export class RecordingService {
+  private readonly _enabled = process.env.RECORDING_ENABLED !== 'false';
+
+  /** Target duration of each recording segment in seconds */
+  private readonly _segmentSeconds = parseInt(
+    process.env.RECORDING_SEGMENT_SECONDS || '10',
+    10
+  );
+
+  /** How long to keep recorded video (separate from snapshot retention) */
+  private readonly _retentionDays = parseInt(
+    process.env.VIDEO_RETENTION_DAYS || '3',
+    10
+  );
+
+  /** Extracted clips are cached briefly, then removed */
+  private readonly _clipMaxAgeMs = 60 * 60 * 1000;
+
+  /** Dedupe concurrent extraction requests for the same clip */
+  private readonly _inFlight = new Map<
+    string,
+    Promise<{ path: string; filename: string } | null>
+  >();
+
+  private get _dataDir(): string {
+    return (
+      process.env.DATA_DIR ||
+      (process.env.NODE_ENV === 'production' ? '/app/data' : './data')
+    );
+  }
+
+  private get _recordingsDir(): string {
+    return process.env.RECORDINGS_DIR || join(this._dataDir, 'recordings');
+  }
+
+  private get _clipsDir(): string {
+    return join(this._dataDir, 'clips');
+  }
+
+  isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  getSegmentSeconds(): number {
+    return this._segmentSeconds;
+  }
+
+  getRetentionDays(): number {
+    return this._retentionDays;
+  }
+
+  /**
+   * FFmpeg output pattern for the recording segments.
+   * `%s` is expanded by FFmpeg (strftime) to the segment start epoch.
+   */
+  getSegmentPattern(): string {
+    return join(this._recordingsDir, 'rec_%s.ts');
+  }
+
+  /** Create the recordings/clips directories if missing. */
+  ensureDirs(): void {
+    for (const dir of [this._recordingsDir, this._clipsDir]) {
+      if (!existsSync(dir)) {
+        mkdirSync(dir, { recursive: true });
+      }
+    }
+  }
+
+  /**
+   * Extract an MP4 clip covering [start, start + durationSec].
+   * Returns null when no recorded segments overlap the window.
+   *
+   * The clip is built from whole segments, so it may start up to one
+   * segment before `start` and end up to one segment after — fine for
+   * event playback, and avoids broken keyframe-less cuts.
+   */
+  async extractClip(
+    start: Date,
+    durationSec: number
+  ): Promise<{ path: string; filename: string } | null> {
+    if (!this._enabled) return null;
+    this.ensureDirs();
+    this._pruneClips();
+
+    const startEpoch = Math.floor(start.getTime() / 1000);
+    const endEpoch = startEpoch + Math.ceil(durationSec);
+    const nowEpoch = Math.floor(Date.now() / 1000);
+
+    // Skip segments that may still be written by FFmpeg
+    const completed = this._listSegments().filter(
+      (s) => s.epoch + this._segmentSeconds + 3 <= nowEpoch
+    );
+
+    const inWindow = completed.filter(
+      (s) => s.epoch >= startEpoch && s.epoch < endEpoch
+    );
+    // Include the segment that was already running at `start` (covers
+    // the head of the window). Copy-mode segments can exceed the target
+    // duration slightly, hence the 2x slack.
+    const before = completed
+      .filter(
+        (s) =>
+          s.epoch < startEpoch && s.epoch + this._segmentSeconds * 2 > startEpoch
+      )
+      .pop();
+    const segments = before ? [before, ...inWindow] : inWindow;
+
+    if (segments.length === 0) return null;
+
+    const clipFilename = `clip_${startEpoch}_${Math.ceil(durationSec)}.mp4`;
+    const clipPath = join(this._clipsDir, clipFilename);
+    if (existsSync(clipPath)) {
+      return { path: clipPath, filename: clipFilename };
+    }
+
+    const inFlight = this._inFlight.get(clipFilename);
+    if (inFlight) return inFlight;
+
+    const promise = this._concatSegments(segments, clipPath, clipFilename);
+    this._inFlight.set(clipFilename, promise);
+    try {
+      return await promise;
+    } finally {
+      this._inFlight.delete(clipFilename);
+    }
+  }
+
+  /**
+   * Delete recording segments older than the cutoff (and stale clips).
+   * Returns the number of segment files removed.
+   */
+  pruneOlderThan(cutoff: Date): number {
+    const cutoffEpoch = Math.floor(cutoff.getTime() / 1000);
+    let deleted = 0;
+    for (const segment of this._listSegments()) {
+      if (segment.epoch >= cutoffEpoch) continue;
+      try {
+        unlinkSync(join(this._recordingsDir, segment.filename));
+        deleted++;
+      } catch {
+        // ignore individual failures
+      }
+    }
+    this._pruneClips();
+    return deleted;
+  }
+
+  /** Current recording storage usage for status/cleanup reporting. */
+  getStorageStats(): { segmentCount: number; sizeMB: number } {
+    const segments = this._listSegments();
+    const bytes = segments.reduce((sum, s) => sum + s.size, 0);
+    return {
+      segmentCount: segments.length,
+      sizeMB: Math.round(bytes / 1024 / 1024),
+    };
+  }
+
+  getStatus(): RecordingStatus {
+    const segments = this._listSegments();
+    const totalBytes = segments.reduce((sum, s) => sum + s.size, 0);
+    const oldest = segments[0];
+    const newest = segments[segments.length - 1];
+
+    // Estimate the daily write rate once we have ≥10 minutes of footage
+    let estimatedDailyGB: number | null = null;
+    if (oldest && newest) {
+      const spanSec = newest.epoch + this._segmentSeconds - oldest.epoch;
+      if (spanSec >= 600) {
+        estimatedDailyGB =
+          Math.round(((totalBytes / spanSec) * 86_400) / 1e7) / 100;
+      }
+    }
+
+    return {
+      enabled: this._enabled,
+      segmentCount: segments.length,
+      totalSizeMB: Math.round(totalBytes / 1024 / 1024),
+      oldestTimestamp: oldest
+        ? new Date(oldest.epoch * 1000).toISOString()
+        : null,
+      newestTimestamp: newest
+        ? new Date((newest.epoch + this._segmentSeconds) * 1000).toISOString()
+        : null,
+      retentionDays: this._retentionDays,
+      segmentSeconds: this._segmentSeconds,
+      estimatedDailyGB,
+    };
+  }
+
+  /** List segments on disk, sorted oldest → newest. */
+  private _listSegments(): SegmentInfo[] {
+    if (!existsSync(this._recordingsDir)) return [];
+
+    const segments: SegmentInfo[] = [];
+    try {
+      for (const filename of readdirSync(this._recordingsDir)) {
+        const match = filename.match(/^rec_(\d+)\.ts$/);
+        if (!match) continue;
+        try {
+          const { size } = statSync(join(this._recordingsDir, filename));
+          segments.push({ filename, epoch: parseInt(match[1], 10), size });
+        } catch {
+          // file may have been pruned mid-listing
+        }
+      }
+    } catch {
+      return [];
+    }
+
+    return segments.sort((a, b) => a.epoch - b.epoch);
+  }
+
+  /**
+   * Concatenate segments into a single MP4 with stream copy.
+   * Uses the concat demuxer; `-reset_timestamps 1` on the segment output
+   * means each segment starts at t=0, so concat re-offsets them cleanly.
+   */
+  private _concatSegments(
+    segments: SegmentInfo[],
+    clipPath: string,
+    clipFilename: string
+  ): Promise<{ path: string; filename: string } | null> {
+    const listPath = `${clipPath}.txt`;
+    const listContent = segments
+      .map((s) => `file '${join(this._recordingsDir, s.filename)}'`)
+      .join('\n');
+
+    return new Promise((resolve) => {
+      try {
+        writeFileSync(listPath, listContent);
+      } catch (err) {
+        console.error('❌ Failed to write concat list:', err);
+        resolve(null);
+        return;
+      }
+
+      const args = [
+        '-y',
+        '-f',
+        'concat',
+        '-safe',
+        '0',
+        '-i',
+        listPath,
+        '-c',
+        'copy',
+        '-movflags',
+        '+faststart',
+        clipPath,
+      ];
+
+      const proc = spawn('ffmpeg', args, {
+        stdio: ['ignore', 'ignore', 'pipe'],
+      });
+
+      let stderr = '';
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      const timeout = setTimeout(() => {
+        proc.kill('SIGKILL');
+      }, 30_000);
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        try {
+          unlinkSync(listPath);
+        } catch {
+          // ignore
+        }
+      };
+
+      proc.on('close', (code) => {
+        cleanup();
+        if (code === 0 && existsSync(clipPath)) {
+          resolve({ path: clipPath, filename: clipFilename });
+        } else {
+          console.error(
+            `❌ Clip extraction failed (code ${code}): ${stderr.slice(-500)}`
+          );
+          try {
+            unlinkSync(clipPath);
+          } catch {
+            // ignore
+          }
+          resolve(null);
+        }
+      });
+
+      proc.on('error', (err) => {
+        cleanup();
+        console.error('❌ FFmpeg clip spawn error:', err);
+        resolve(null);
+      });
+    });
+  }
+
+  /** Remove cached clips older than the max age. */
+  private _pruneClips(): void {
+    if (!existsSync(this._clipsDir)) return;
+    const cutoff = Date.now() - this._clipMaxAgeMs;
+    try {
+      for (const filename of readdirSync(this._clipsDir)) {
+        if (!filename.endsWith('.mp4') && !filename.endsWith('.txt')) continue;
+        const filePath = join(this._clipsDir, filename);
+        try {
+          if (statSync(filePath).mtimeMs < cutoff) {
+            unlinkSync(filePath);
+          }
+        } catch {
+          // ignore
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/apps/camera/src/app/stream/stream.service.ts
+++ b/apps/camera/src/app/stream/stream.service.ts
@@ -10,6 +10,7 @@ import {
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { CameraService } from '../camera/camera.service';
+import { RecordingService } from '../recording/recording.service';
 
 /**
  * StreamService manages the FFmpeg process that converts
@@ -17,6 +18,7 @@ import { CameraService } from '../camera/camera.service';
  */
 export class StreamService {
   private readonly _cameraService = inject(CameraService);
+  private readonly _recordingService = inject(RecordingService);
   private _ffmpegProcess: ChildProcess | null = null;
   private _isRunning = false;
   private _restartAttempts = 0;
@@ -70,6 +72,11 @@ export class StreamService {
     // Ensure HLS directory exists
     if (!existsSync(this._hlsDir)) {
       mkdirSync(this._hlsDir, { recursive: true });
+    }
+
+    // Ensure recording directories exist (segments persist across restarts)
+    if (this._recordingService.isEnabled()) {
+      this._recordingService.ensureDirs();
     }
 
     // Purge stale HLS files from previous runs so the player doesn't
@@ -239,6 +246,30 @@ export class StreamService {
       '-an',
       this._detectionFramePath,
     ];
+
+    // ── Output #2: continuous rolling recording for event playback ──
+    // Fixed-length MPEG-TS segments named by their start epoch so the
+    // RecordingService can assemble clips around detection timestamps.
+    if (this._recordingService.isEnabled()) {
+      args.push(
+        '-map',
+        '0:v',
+        '-an',
+        '-c:v',
+        'copy',
+        '-f',
+        'segment',
+        '-segment_time',
+        String(this._recordingService.getSegmentSeconds()),
+        '-segment_format',
+        'mpegts',
+        '-reset_timestamps',
+        '1',
+        '-strftime',
+        '1',
+        this._recordingService.getSegmentPattern()
+      );
+    }
 
     console.log('🎬 Starting FFmpeg with args:', args.join(' '));
 

--- a/deployments/camera/values.yaml
+++ b/deployments/camera/values.yaml
@@ -45,6 +45,9 @@ env:
   CLEANUP_INTERVAL_MINUTES: '30'
   MAX_SNAPSHOTS: '5000'
   DISK_THRESHOLD_PCT: '85'
+  RECORDING_ENABLED: 'true'
+  RECORDING_SEGMENT_SECONDS: '10'
+  VIDEO_RETENTION_DAYS: '3'
 
 # Camera credentials from Kubernetes Secret
 secretEnv:


### PR DESCRIPTION
Add continuous rolling video recording and event clip playback:

Backend:
- StreamService: third FFmpeg output writing 10s MPEG-TS segments
  (stream copy, no re-encode) named rec_<epoch>.ts
- RecordingService: assembles MP4 clips from segments overlapping a
  time window via concat demuxer + faststart, with clip caching and
  in-flight dedupe
- /recordings/status and /recordings/clip endpoints (Range support
  for video seeking)
- CleanupService: separate VIDEO_RETENTION_DAYS (default 3) age-off,
  emergency halving when disk crosses threshold, recording stats in
  cleanup status

Frontend:
- ClipPlayerComponent: modal video player opening a 10s-before /
  20s-after window around an event
- Play buttons in the events table and dashboard event feed, shown
  when the recording window covers the event
- Recording size/retention shown in the storage status card

Deployment: RECORDING_ENABLED, RECORDING_SEGMENT_SECONDS and
VIDEO_RETENTION_DAYS env vars in the camera Helm values.

https://claude.ai/code/session_01U4NbJTvMtckLKCokjKgWjx