### PR TITLE
fix(camera): clip playback blocked by helmet CORP header

### DIFF
--- a/apps/camera/src/app/recording/recording.router.ts
+++ b/apps/camera/src/app/recording/recording.router.ts
@@ -107,10 +107,14 @@ export async function RecordingRouter(fastify: FastifyInstance) {
 
       const { size } = statSync(clip.path);
 
+      // Cross-Origin-Resource-Policy must override helmet's same-origin
+      // default — without it the browser blocks the <video> element's
+      // cross-origin media request right after the headers arrive.
       reply
         .header('Content-Type', 'video/mp4')
         .header('Accept-Ranges', 'bytes')
         .header('Cache-Control', 'private, max-age=300')
+        .header('Cross-Origin-Resource-Policy', 'cross-origin')
         .header('Access-Control-Allow-Origin', '*');
 
       const range = request.headers.range;
@@ -127,7 +131,7 @@ export async function RecordingRouter(fastify: FastifyInstance) {
             .code(416)
             .header('Content-Range', `bytes */${size}`)
             .send({ error: 'Range not satisfiable' });
-          return;
+          return reply;
         }
 
         reply
@@ -135,12 +139,13 @@ export async function RecordingRouter(fastify: FastifyInstance) {
           .header('Content-Range', `bytes ${rangeStart}-${rangeEnd}/${size}`)
           .header('Content-Length', rangeEnd - rangeStart + 1)
           .send(createReadStream(clip.path, { start: rangeStart, end: rangeEnd }));
-        return;
+        return reply;
       }
 
       reply
         .header('Content-Length', size)
         .send(createReadStream(clip.path));
+      return reply;
     }
   );
 }

--- a/apps/camera/src/app/recording/recording.service.ts
+++ b/apps/camera/src/app/recording/recording.service.ts
@@ -4,6 +4,7 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  renameSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -244,12 +245,17 @@ export class RecordingService {
 
     const clipFilename = `clip_${startEpoch}_${Math.ceil(durationSec)}.mp4`;
     const clipPath = join(this._clipsDir, clipFilename);
+
+    // Browsers issue several parallel range requests for the same clip
+    // URL — join an in-flight extraction before trusting the filesystem.
+    const inFlight = this._inFlight.get(clipFilename);
+    if (inFlight) return inFlight;
+
+    // Completed clips are renamed into place atomically, so an existing
+    // file is always a fully written MP4.
     if (existsSync(clipPath)) {
       return { path: clipPath, filename: clipFilename };
     }
-
-    const inFlight = this._inFlight.get(clipFilename);
-    if (inFlight) return inFlight;
 
     const promise = this._concatSegments(segments, clipPath, clipFilename);
     this._inFlight.set(clipFilename, promise);
@@ -356,6 +362,9 @@ export class RecordingService {
     clipPath: string,
     clipFilename: string
   ): Promise<{ path: string; filename: string } | null> {
+    // Write to a temp file and rename into place on success so that
+    // concurrent requests never see a partially written MP4.
+    const partPath = `${clipPath}.part`;
     const listPath = `${clipPath}.txt`;
     const listContent = segments
       .map((s) => `file '${join(this._recordingsDir, s.filename)}'`)
@@ -382,7 +391,9 @@ export class RecordingService {
         'copy',
         '-movflags',
         '+faststart',
-        clipPath,
+        '-f',
+        'mp4',
+        partPath,
       ];
 
       const proc = spawn('ffmpeg', args, {
@@ -409,19 +420,24 @@ export class RecordingService {
 
       proc.on('close', (code) => {
         cleanup();
-        if (code === 0 && existsSync(clipPath)) {
-          resolve({ path: clipPath, filename: clipFilename });
-        } else {
-          console.error(
-            `❌ Clip extraction failed (code ${code}): ${stderr.slice(-500)}`
-          );
+        if (code === 0 && existsSync(partPath)) {
           try {
-            unlinkSync(clipPath);
-          } catch {
-            // ignore
+            renameSync(partPath, clipPath);
+            resolve({ path: clipPath, filename: clipFilename });
+            return;
+          } catch (err) {
+            console.error('❌ Failed to finalize clip:', err);
           }
-          resolve(null);
         }
+        console.error(
+          `❌ Clip extraction failed (code ${code}): ${stderr.slice(-500)}`
+        );
+        try {
+          unlinkSync(partPath);
+        } catch {
+          // ignore
+        }
+        resolve(null);
       });
 
       proc.on('error', (err) => {
@@ -438,7 +454,13 @@ export class RecordingService {
     const cutoff = Date.now() - this._clipMaxAgeMs;
     try {
       for (const filename of readdirSync(this._clipsDir)) {
-        if (!filename.endsWith('.mp4') && !filename.endsWith('.txt')) continue;
+        if (
+          !filename.endsWith('.mp4') &&
+          !filename.endsWith('.txt') &&
+          !filename.endsWith('.part')
+        ) {
+          continue;
+        }
         const filePath = join(this._clipsDir, filename);
         try {
           if (statSync(filePath).mtimeMs < cutoff) {


### PR DESCRIPTION
## Problem

Event video clips were unplayable. Every clip request logged a 206 that "completed" in ~3 ms followed by `stream closed prematurely` — the browser was aborting the connection immediately after receiving headers.

## Root cause

The 206 itself is normal (browsers fetch `<video>` sources with `Range: bytes=0-`). The real issue: the shared Fastify starter registers `@fastify/helmet` with defaults, which adds `Cross-Origin-Resource-Policy: same-origin` to every response. A `<video>` element on `camera.elliott.haus` loading media from `camera-api.elliott.haus` is a cross-origin no-CORS media request, so the browser saw the CORP header and killed the response instantly. (This is the same reason the snapshot route already carries an explicit `Cross-Origin-Resource-Policy: cross-origin` override.)

## Fixes

- Override `Cross-Origin-Resource-Policy: cross-origin` on the clip route
- `return reply` from streaming handlers per Fastify async-handler guidance
- Close a race where parallel range requests for a not-yet-cached clip could be served FFmpeg's partially written output: extraction now joins the in-flight promise **before** checking the filesystem, and clips are written to a `.part` temp file and atomically renamed when complete — an existing `.mp4` is always fully written
- Prune stale `.part` files alongside cached clips

## Verification

Ran the real `RecordingRouter` behind the actual helmet/zod/cors plugin stack with FFmpeg-generated segments:

- `Range: bytes=0-` → 206 with `cross-origin-resource-policy: cross-origin`, correct `Content-Range`, and a playable MP4
- Sub-range `bytes=100-199` → exact 100-byte slice
- No `Range` header → 200, byte-identical to the ranged download
- 3 parallel cold-cache requests → byte-identical valid MP4s (md5-matched)
- Out-of-window request → 404

https://claude.ai/code/session_01U4NbJTvMtckLKCokjKgWjx

---
_Generated by [Claude Code](https://claude.ai/code/session_01U4NbJTvMtckLKCokjKgWjx)_