### PR TITLE
feat(split): Split expense-sharing app (backend + frontend)

### DIFF
--- a/apps/split-frontend/Dockerfile
+++ b/apps/split-frontend/Dockerfile
@@ -1,0 +1,12 @@
+# Production build using the pre-built Angular app from CI
+FROM docker.io/nginx:alpine
+
+# Copy pre-built app to nginx html directory
+COPY dist/apps/split-frontend/browser /usr/share/nginx/html
+
+# Copy nginx configuration
+COPY apps/split-frontend/nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/apps/split-frontend/nginx.conf
+++ b/apps/split-frontend/nginx.conf
@@ -1,0 +1,34 @@
+server {
+    listen 80;
+    server_name localhost split.elliott.haus;
+
+    # Redirect HTTP to HTTPS in production
+    if ($host = "split.elliott.haus") {
+        return 301 https://$host$request_uri;
+    }
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Handle Angular routing - serve index.html for all routes
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Security headers
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # Gzip compression
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+
+    # Cache static assets
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, no-transform";
+    }
+}

--- a/apps/split-frontend/project.json
+++ b/apps/split-frontend/project.json
@@ -1,0 +1,97 @@
+{
+  "name": "split-frontend",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "projectType": "application",
+  "prefix": "app",
+  "sourceRoot": "apps/split-frontend/src",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@angular-devkit/build-angular:application",
+      "outputs": ["{options.outputPath}"],
+      "options": {
+        "outputPath": "dist/apps/split-frontend",
+        "index": "apps/split-frontend/src/index.html",
+        "browser": "apps/split-frontend/src/main.ts",
+        "polyfills": [],
+        "tsConfig": "apps/split-frontend/tsconfig.app.json",
+        "inlineStyleLanguage": "scss",
+        "assets": [
+          {
+            "glob": "**/*",
+            "input": "apps/split-frontend/public"
+          }
+        ],
+        "styles": ["apps/split-frontend/src/styles.scss"],
+        "stylePreprocessorOptions": {
+          "includePaths": ["apps/split-frontend/src"]
+        },
+        "scripts": []
+      },
+      "configurations": {
+        "production": {
+          "budgets": [
+            {
+              "type": "initial",
+              "maximumWarning": "1mb",
+              "maximumError": "2mb"
+            },
+            {
+              "type": "anyComponentStyle",
+              "maximumWarning": "500kb",
+              "maximumError": "1mb"
+            }
+          ],
+          "optimization": {
+            "scripts": true,
+            "styles": {
+              "minify": true,
+              "inlineCritical": false
+            },
+            "fonts": true
+          },
+          "outputHashing": "all",
+          "fileReplacements": [
+            {
+              "replace": "apps/split-frontend/src/environments/environment.ts",
+              "with": "apps/split-frontend/src/environments/environment.prod.ts"
+            }
+          ]
+        },
+        "development": {
+          "optimization": false,
+          "extractLicenses": false,
+          "sourceMap": true
+        }
+      },
+      "defaultConfiguration": "production"
+    },
+    "serve": {
+      "executor": "@angular-devkit/build-angular:dev-server",
+      "configurations": {
+        "production": {
+          "buildTarget": "split-frontend:build:production"
+        },
+        "development": {
+          "buildTarget": "split-frontend:build:development"
+        }
+      },
+      "defaultConfiguration": "development"
+    },
+    "extract-i18n": {
+      "executor": "@angular-devkit/build-angular:extract-i18n"
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    },
+    "container": {
+      "dependsOn": ["build"],
+      "executor": "./tools/executors/deploy:container",
+      "options": {
+        "image": "ethanelliottio/split-frontend",
+        "dockerfile": "apps/split-frontend/Dockerfile",
+        "deployment": "split-frontend"
+      }
+    }
+  }
+}

--- a/apps/split-frontend/src/app/app.component.ts
+++ b/apps/split-frontend/src/app/app.component.ts
@@ -1,0 +1,15 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { Toast } from 'primeng/toast';
+
+@Component({
+  selector: 'app-root',
+  standalone: true,
+  imports: [RouterModule, Toast],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <p-toast position="top-center" />
+    <router-outlet />
+  `,
+})
+export class AppComponent {}

--- a/apps/split-frontend/src/app/app.config.ts
+++ b/apps/split-frontend/src/app/app.config.ts
@@ -1,0 +1,51 @@
+import { provideHttpClient, withInterceptors } from '@angular/common/http';
+import {
+  ApplicationConfig,
+  provideZonelessChangeDetection,
+} from '@angular/core';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { provideRouter, withComponentInputBinding } from '@angular/router';
+import { providePrimeNG } from 'primeng/config';
+import { MessageService } from 'primeng/api';
+import Aura from '@primeuix/themes/aura';
+import { definePreset } from '@primeuix/themes';
+import { appRoutes } from './app.routes';
+import { authInterceptor } from './core/auth.interceptor';
+
+// Split-style green primary palette
+const SplitPreset = definePreset(Aura, {
+  semantic: {
+    primary: {
+      50: '#e7f6f1',
+      100: '#c3e9dc',
+      200: '#9bdbc5',
+      300: '#6fccac',
+      400: '#48c098',
+      500: '#1b9e77',
+      600: '#178a68',
+      700: '#137457',
+      800: '#0f5d46',
+      900: '#0b4634',
+      950: '#06241b',
+    },
+  },
+});
+
+export const appConfig: ApplicationConfig = {
+  providers: [
+    provideZonelessChangeDetection(),
+    provideRouter(appRoutes, withComponentInputBinding()),
+    provideHttpClient(withInterceptors([authInterceptor])),
+    provideAnimationsAsync(),
+    MessageService,
+    providePrimeNG({
+      theme: {
+        preset: SplitPreset,
+        options: {
+          darkModeSelector: '.dark-mode',
+          cssLayer: false,
+        },
+      },
+    }),
+  ],
+};

--- a/apps/split-frontend/src/app/app.routes.ts
+++ b/apps/split-frontend/src/app/app.routes.ts
@@ -1,0 +1,55 @@
+import { Route } from '@angular/router';
+import { authGuard } from './core/auth.guard';
+import { MainLayoutComponent } from './layout/main-layout.component';
+
+export const appRoutes: Route[] = [
+  {
+    path: 'login',
+    loadComponent: () =>
+      import('./pages/login/login.component').then((m) => m.LoginComponent),
+  },
+  {
+    path: 'register',
+    loadComponent: () =>
+      import('./pages/register/register.component').then(
+        (m) => m.RegisterComponent
+      ),
+  },
+  {
+    path: '',
+    component: MainLayoutComponent,
+    canActivate: [authGuard],
+    children: [
+      { path: '', redirectTo: 'groups', pathMatch: 'full' },
+      {
+        path: 'groups',
+        loadComponent: () =>
+          import('./pages/groups/groups.component').then(
+            (m) => m.GroupsComponent
+          ),
+      },
+      {
+        path: 'groups/:id',
+        loadComponent: () =>
+          import('./pages/group-detail/group-detail.component').then(
+            (m) => m.GroupDetailComponent
+          ),
+      },
+      {
+        path: 'activity',
+        loadComponent: () =>
+          import('./pages/activity/activity.component').then(
+            (m) => m.ActivityComponent
+          ),
+      },
+      {
+        path: 'profile',
+        loadComponent: () =>
+          import('./pages/profile/profile.component').then(
+            (m) => m.ProfileComponent
+          ),
+      },
+    ],
+  },
+  { path: '**', redirectTo: '' },
+];

--- a/apps/split-frontend/src/app/core/api.service.ts
+++ b/apps/split-frontend/src/app/core/api.service.ts
@@ -1,0 +1,136 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import {
+  ActivityItem,
+  CreateExpenseRequest,
+  CreateSettlementRequest,
+  Expense,
+  Group,
+  GroupBalances,
+  GroupSummary,
+  Overview,
+  PublicUser,
+  Settlement,
+} from './models';
+
+@Injectable({ providedIn: 'root' })
+export class ApiService {
+  private readonly http = inject(HttpClient);
+  private readonly base = `${environment.apiUrl}/split`;
+  private readonly usersBase = `${environment.apiUrl}/users`;
+
+  // ── Overview & activity ──
+  getOverview(): Observable<Overview> {
+    return this.http.get<Overview>(`${this.base}/overview`);
+  }
+
+  getActivity(): Observable<ActivityItem[]> {
+    return this.http.get<ActivityItem[]>(`${this.base}/activity`);
+  }
+
+  // ── Users ──
+  searchUsers(q: string): Observable<PublicUser[]> {
+    return this.http.get<PublicUser[]>(`${this.usersBase}/search`, {
+      params: { q },
+    });
+  }
+
+  // ── Groups ──
+  getGroups(): Observable<GroupSummary[]> {
+    return this.http.get<GroupSummary[]>(`${this.base}/groups`);
+  }
+
+  getGroup(id: string): Observable<Group> {
+    return this.http.get<Group>(`${this.base}/groups/${id}`);
+  }
+
+  createGroup(body: {
+    name: string;
+    description?: string;
+    type?: string;
+    currency?: string;
+    memberUsernames?: string[];
+  }): Observable<Group> {
+    return this.http.post<Group>(`${this.base}/groups`, body);
+  }
+
+  updateGroup(
+    id: string,
+    body: { name?: string; description?: string; type?: string; currency?: string }
+  ): Observable<Group> {
+    return this.http.put<Group>(`${this.base}/groups/${id}`, body);
+  }
+
+  deleteGroup(id: string): Observable<{ success: boolean }> {
+    return this.http.delete<{ success: boolean }>(`${this.base}/groups/${id}`);
+  }
+
+  getBalances(id: string): Observable<GroupBalances> {
+    return this.http.get<GroupBalances>(`${this.base}/groups/${id}/balances`);
+  }
+
+  addMember(id: string, username: string): Observable<Group> {
+    return this.http.post<Group>(`${this.base}/groups/${id}/members`, {
+      username,
+    });
+  }
+
+  removeMember(id: string, userId: string): Observable<Group> {
+    return this.http.delete<Group>(
+      `${this.base}/groups/${id}/members/${userId}`
+    );
+  }
+
+  // ── Expenses ──
+  getExpenses(groupId: string): Observable<Expense[]> {
+    return this.http.get<Expense[]>(`${this.base}/groups/${groupId}/expenses`);
+  }
+
+  createExpense(
+    groupId: string,
+    body: CreateExpenseRequest
+  ): Observable<Expense> {
+    return this.http.post<Expense>(
+      `${this.base}/groups/${groupId}/expenses`,
+      body
+    );
+  }
+
+  updateExpense(
+    expenseId: string,
+    body: CreateExpenseRequest
+  ): Observable<Expense> {
+    return this.http.put<Expense>(`${this.base}/expenses/${expenseId}`, body);
+  }
+
+  deleteExpense(expenseId: string): Observable<{ success: boolean }> {
+    return this.http.delete<{ success: boolean }>(
+      `${this.base}/expenses/${expenseId}`
+    );
+  }
+
+  // ── Settlements ──
+  getSettlements(groupId: string): Observable<Settlement[]> {
+    return this.http.get<Settlement[]>(
+      `${this.base}/groups/${groupId}/settlements`
+    );
+  }
+
+  createSettlement(
+    groupId: string,
+    body: CreateSettlementRequest
+  ): Observable<Settlement> {
+    return this.http.post<Settlement>(
+      `${this.base}/groups/${groupId}/settlements`,
+      body
+    );
+  }
+
+  deleteSettlement(id: string): Observable<{ success: boolean }> {
+    return this.http.delete<{ success: boolean }>(
+      `${this.base}/settlements/${id}`
+    );
+  }
+}

--- a/apps/split-frontend/src/app/core/auth.guard.ts
+++ b/apps/split-frontend/src/app/core/auth.guard.ts
@@ -1,0 +1,13 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { AuthService } from './auth.service';
+
+export const authGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  if (auth.isAuthenticated()) {
+    return true;
+  }
+  return router.createUrlTree(['/login']);
+};

--- a/apps/split-frontend/src/app/core/auth.interceptor.ts
+++ b/apps/split-frontend/src/app/core/auth.interceptor.ts
@@ -1,0 +1,92 @@
+import {
+  HttpErrorResponse,
+  HttpInterceptorFn,
+} from '@angular/common/http';
+import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { HttpClient } from '@angular/common/http';
+import {
+  BehaviorSubject,
+  catchError,
+  filter,
+  switchMap,
+  take,
+  throwError,
+} from 'rxjs';
+import { environment } from '../../environments/environment';
+
+let isRefreshing = false;
+const refreshTokenSubject = new BehaviorSubject<string | null>(null);
+
+export const authInterceptor: HttpInterceptorFn = (req, next) => {
+  const router = inject(Router);
+  const http = inject(HttpClient);
+
+  // Don't attach/refresh tokens for the auth endpoints themselves.
+  if (
+    req.url.includes('/login') ||
+    req.url.includes('/register') ||
+    req.url.includes('/token/refresh')
+  ) {
+    return next(req);
+  }
+
+  const accessToken = localStorage.getItem('accessToken');
+  const authReq = accessToken
+    ? req.clone({ setHeaders: { Authorization: `Bearer ${accessToken}` } })
+    : req;
+
+  return next(authReq).pipe(
+    catchError((error: HttpErrorResponse) => {
+      if (error.status !== 401) {
+        return throwError(() => error);
+      }
+
+      if (isRefreshing) {
+        return refreshTokenSubject.pipe(
+          filter((token) => token !== null),
+          take(1),
+          switchMap((token) =>
+            next(req.clone({ setHeaders: { Authorization: `Bearer ${token}` } }))
+          )
+        );
+      }
+
+      const refreshToken = localStorage.getItem('refreshToken');
+      if (!refreshToken) {
+        localStorage.removeItem('accessToken');
+        router.navigate(['/login']);
+        return throwError(() => error);
+      }
+
+      isRefreshing = true;
+      refreshTokenSubject.next(null);
+
+      return http
+        .post<{ accessToken: string; refreshToken: string }>(
+          `${environment.apiUrl}/users/token/refresh`,
+          { refreshToken }
+        )
+        .pipe(
+          switchMap((res) => {
+            isRefreshing = false;
+            localStorage.setItem('accessToken', res.accessToken);
+            localStorage.setItem('refreshToken', res.refreshToken);
+            refreshTokenSubject.next(res.accessToken);
+            return next(
+              req.clone({
+                setHeaders: { Authorization: `Bearer ${res.accessToken}` },
+              })
+            );
+          }),
+          catchError((refreshError) => {
+            isRefreshing = false;
+            localStorage.removeItem('accessToken');
+            localStorage.removeItem('refreshToken');
+            router.navigate(['/login']);
+            return throwError(() => refreshError);
+          })
+        );
+    })
+  );
+};

--- a/apps/split-frontend/src/app/core/auth.service.ts
+++ b/apps/split-frontend/src/app/core/auth.service.ts
@@ -1,0 +1,113 @@
+import { HttpClient } from '@angular/common/http';
+import { Injectable, inject, signal } from '@angular/core';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import {
+  startAuthentication,
+  startRegistration,
+} from '@simplewebauthn/browser';
+import { environment } from '../../environments/environment';
+import { Profile } from './models';
+
+const ACCESS_TOKEN_KEY = 'accessToken';
+const REFRESH_TOKEN_KEY = 'refreshToken';
+
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private readonly http = inject(HttpClient);
+  private readonly router = inject(Router);
+  private readonly baseUrl = environment.apiUrl;
+
+  /** Current signed-in user profile (loaded lazily). */
+  readonly profile = signal<Profile | null>(null);
+
+  isAuthenticated(): boolean {
+    return !!localStorage.getItem(ACCESS_TOKEN_KEY);
+  }
+
+  private storeTokens(accessToken: string, refreshToken: string) {
+    localStorage.setItem(ACCESS_TOKEN_KEY, accessToken);
+    localStorage.setItem(REFRESH_TOKEN_KEY, refreshToken);
+  }
+
+  /** Passwordless login with a passkey. */
+  async loginWithPasskey(username?: string): Promise<void> {
+    const start: any = await firstValueFrom(
+      this.http.post(`${this.baseUrl}/users/login`, {
+        username: username || undefined,
+      })
+    );
+
+    const assertion = await startAuthentication({ optionsJSON: start.options });
+
+    const complete: any = await firstValueFrom(
+      this.http.post(`${this.baseUrl}/users/login/complete`, {
+        sessionId: start.sessionId,
+        credential: assertion,
+      })
+    );
+
+    this.storeTokens(complete.accessToken, complete.refreshToken);
+  }
+
+  /** Account creation: create the user, then register a passkey. */
+  async register(input: {
+    name: string;
+    username: string;
+    email?: string;
+  }): Promise<void> {
+    const start: any = await firstValueFrom(
+      this.http.post(`${this.baseUrl}/users/register`, input)
+    );
+
+    const attestation = await startRegistration({
+      optionsJSON: start.registrationOptions.options,
+    });
+
+    const complete: any = await firstValueFrom(
+      this.http.post(`${this.baseUrl}/users/register/complete`, {
+        sessionId: start.sessionId,
+        credential: attestation,
+      })
+    );
+
+    this.storeTokens(complete.accessToken, complete.refreshToken);
+  }
+
+  async loadProfile(): Promise<Profile | null> {
+    try {
+      const res: any = await firstValueFrom(
+        this.http.get(`${this.baseUrl}/users/profile`)
+      );
+      this.profile.set(res.user);
+      return res.user;
+    } catch {
+      return null;
+    }
+  }
+
+  async updateProfile(updates: {
+    name?: string;
+    email?: string;
+  }): Promise<void> {
+    const res: any = await firstValueFrom(
+      this.http.put(`${this.baseUrl}/users/profile`, updates)
+    );
+    this.profile.set(res.user);
+  }
+
+  async logout(): Promise<void> {
+    const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+    try {
+      await firstValueFrom(
+        this.http.post(`${this.baseUrl}/users/logout`, { refreshToken })
+      );
+    } catch {
+      // ignore network errors on logout
+    }
+    localStorage.removeItem(ACCESS_TOKEN_KEY);
+    localStorage.removeItem(REFRESH_TOKEN_KEY);
+    this.profile.set(null);
+    this.router.navigate(['/login']);
+  }
+}

--- a/apps/split-frontend/src/app/core/auth.service.ts
+++ b/apps/split-frontend/src/app/core/auth.service.ts
@@ -50,12 +50,8 @@ export class AuthService {
     this.storeTokens(complete.accessToken, complete.refreshToken);
   }
 
-  /** Account creation: create the user, then register a passkey. */
-  async register(input: {
-    name: string;
-    username: string;
-    email?: string;
-  }): Promise<void> {
+  /** Account creation: pick a username, then register a passkey. */
+  async register(input: { username: string }): Promise<void> {
     const start: any = await firstValueFrom(
       this.http.post(`${this.baseUrl}/users/register`, input)
     );

--- a/apps/split-frontend/src/app/core/models.ts
+++ b/apps/split-frontend/src/app/core/models.ts
@@ -1,0 +1,129 @@
+export interface PublicUser {
+  id: string;
+  name: string;
+  username: string;
+}
+
+export interface Profile {
+  id: string;
+  name: string;
+  username: string;
+  email?: string | null;
+  isActive: boolean;
+  lastLoginAt?: string | null;
+  timestamp: string;
+  updatedAt: string;
+}
+
+export interface GroupMember {
+  id: string;
+  user: PublicUser;
+  joinedAt: string;
+}
+
+export interface Group {
+  id: string;
+  name: string;
+  description?: string | null;
+  type: string;
+  currency: string;
+  createdBy?: PublicUser | null;
+  members: GroupMember[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface GroupSummary {
+  id: string;
+  name: string;
+  description?: string | null;
+  type: string;
+  currency: string;
+  memberCount: number;
+  members: GroupMember[];
+  yourBalanceCents: number;
+  updatedAt: string;
+}
+
+export interface ExpenseSplit {
+  id: string;
+  user: PublicUser;
+  amountCents: number;
+}
+
+export interface Expense {
+  id: string;
+  groupId: string;
+  description: string;
+  amountCents: number;
+  currency: string;
+  category?: string | null;
+  paidBy: PublicUser;
+  splitType: string;
+  date: string;
+  splits: ExpenseSplit[];
+  createdAt: string;
+}
+
+export interface Settlement {
+  id: string;
+  groupId: string;
+  fromUser: PublicUser;
+  toUser: PublicUser;
+  amountCents: number;
+  currency: string;
+  note?: string | null;
+  date: string;
+  createdAt: string;
+}
+
+export interface MemberBalance {
+  user: PublicUser;
+  netCents: number;
+}
+
+export interface SimplifiedDebt {
+  from: PublicUser;
+  to: PublicUser;
+  amountCents: number;
+}
+
+export interface GroupBalances {
+  currency: string;
+  balances: MemberBalance[];
+  debts: SimplifiedDebt[];
+}
+
+export interface Overview {
+  currency: string;
+  youAreOwedCents: number;
+  youOweCents: number;
+  netCents: number;
+}
+
+export interface ActivityItem {
+  expense: Expense;
+  groupName: string;
+}
+
+export type SplitType = 'equal' | 'exact' | 'percentage';
+
+export interface CreateExpenseRequest {
+  description: string;
+  amount: number;
+  currency?: string;
+  category?: string;
+  paidByUserId: string;
+  date?: string;
+  splitType: SplitType;
+  splits: { userId: string; value?: number }[];
+}
+
+export interface CreateSettlementRequest {
+  fromUserId: string;
+  toUserId: string;
+  amount: number;
+  currency?: string;
+  note?: string;
+  date?: string;
+}

--- a/apps/split-frontend/src/app/core/money.pipe.ts
+++ b/apps/split-frontend/src/app/core/money.pipe.ts
@@ -1,0 +1,17 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+/** Format integer cents into a localized currency string. */
+@Pipe({ name: 'money', standalone: true })
+export class MoneyPipe implements PipeTransform {
+  transform(cents: number | null | undefined, currency = 'CAD'): string {
+    const value = (cents ?? 0) / 100;
+    try {
+      return new Intl.NumberFormat(undefined, {
+        style: 'currency',
+        currency,
+      }).format(value);
+    } catch {
+      return `$${value.toFixed(2)}`;
+    }
+  }
+}

--- a/apps/split-frontend/src/app/layout/main-layout.component.ts
+++ b/apps/split-frontend/src/app/layout/main-layout.component.ts
@@ -1,0 +1,189 @@
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import {
+  RouterLink,
+  RouterLinkActive,
+  RouterOutlet,
+} from '@angular/router';
+import { AuthService } from '../core/auth.service';
+
+interface NavItem {
+  label: string;
+  icon: string;
+  link: string;
+}
+
+@Component({
+  selector: 'app-main-layout',
+  standalone: true,
+  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="shell">
+      <header class="app-header">
+        <div class="header-inner">
+          <a class="brand" routerLink="/groups">
+            <i class="pi pi-wallet"></i>
+            <span>Split</span>
+          </a>
+
+          <nav class="desktop-nav">
+            @for (item of nav; track item.link) {
+              <a
+                [routerLink]="item.link"
+                routerLinkActive="active"
+                class="desktop-nav-link"
+              >
+                <i [class]="'pi ' + item.icon"></i>
+                {{ item.label }}
+              </a>
+            }
+          </nav>
+        </div>
+      </header>
+
+      <main class="app-content">
+        <router-outlet />
+      </main>
+
+      <nav class="bottom-nav">
+        @for (item of nav; track item.link) {
+          <a
+            [routerLink]="item.link"
+            routerLinkActive="active"
+            class="bottom-nav-link"
+          >
+            <i [class]="'pi ' + item.icon"></i>
+            <span>{{ item.label }}</span>
+          </a>
+        }
+      </nav>
+    </div>
+  `,
+  styles: `
+    .shell {
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .app-header {
+      position: sticky;
+      top: 0;
+      z-index: 40;
+      height: var(--header-height);
+      background: var(--brand);
+      color: #fff;
+      box-shadow: var(--shadow-sm);
+    }
+
+    .header-inner {
+      max-width: var(--content-max-width);
+      margin: 0 auto;
+      height: 100%;
+      padding: 0 16px;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: #fff;
+      font-weight: 700;
+      font-size: 18px;
+
+      i {
+        font-size: 20px;
+      }
+    }
+
+    .desktop-nav {
+      display: none;
+      gap: 4px;
+    }
+
+    .desktop-nav-link {
+      color: rgba(255, 255, 255, 0.85);
+      padding: 8px 14px;
+      border-radius: 999px;
+      font-size: 14px;
+      font-weight: 600;
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+
+      &.active {
+        background: rgba(255, 255, 255, 0.18);
+        color: #fff;
+      }
+    }
+
+    .app-content {
+      flex: 1;
+      padding-bottom: calc(var(--bottom-nav-height) + 16px);
+    }
+
+    .bottom-nav {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      z-index: 40;
+      height: var(--bottom-nav-height);
+      background: var(--bg-surface);
+      border-top: 1px solid var(--border);
+      display: flex;
+      padding-bottom: env(safe-area-inset-bottom);
+    }
+
+    .bottom-nav-link {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 2px;
+      color: var(--text-muted);
+      font-size: 11px;
+      font-weight: 600;
+
+      i {
+        font-size: 20px;
+      }
+
+      &.active {
+        color: var(--brand);
+      }
+    }
+
+    @media (min-width: 768px) {
+      .desktop-nav {
+        display: flex;
+      }
+      .bottom-nav {
+        display: none;
+      }
+      .app-content {
+        padding-bottom: 16px;
+      }
+    }
+  `,
+})
+export class MainLayoutComponent {
+  private readonly auth = inject(AuthService);
+
+  readonly nav: NavItem[] = [
+    { label: 'Groups', icon: 'pi-users', link: '/groups' },
+    { label: 'Activity', icon: 'pi-clock', link: '/activity' },
+    { label: 'Account', icon: 'pi-user', link: '/profile' },
+  ];
+
+  constructor() {
+    // Warm the profile cache once the shell mounts.
+    if (!this.auth.profile()) {
+      void this.auth.loadProfile();
+    }
+  }
+}

--- a/apps/split-frontend/src/app/pages/activity/activity.component.ts
+++ b/apps/split-frontend/src/app/pages/activity/activity.component.ts
@@ -1,0 +1,164 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { ApiService } from '../../core/api.service';
+import { AuthService } from '../../core/auth.service';
+import { ActivityItem } from '../../core/models';
+import { MoneyPipe } from '../../core/money.pipe';
+
+@Component({
+  selector: 'app-activity',
+  standalone: true,
+  imports: [DatePipe, MoneyPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page">
+      <h2 class="section-title">Recent activity</h2>
+
+      @if (loading()) {
+        <div class="empty-state"><i class="pi pi-spin pi-spinner"></i></div>
+      } @else if (items().length === 0) {
+        <div class="empty-state card">
+          <i class="pi pi-clock"></i>
+          <p>No activity yet. Add an expense to get started.</p>
+        </div>
+      } @else {
+        <div class="rows card">
+          @for (item of items(); track item.expense.id) {
+            <div class="activity-row">
+              <div class="act-icon"><i class="pi pi-receipt"></i></div>
+              <div class="act-main">
+                <span class="act-desc">{{ item.expense.description }}</span>
+                <span class="act-sub">
+                  {{ item.groupName }} ·
+                  {{ payerLabel(item) }}
+                  {{ item.expense.amountCents | money: item.expense.currency }}
+                </span>
+              </div>
+              <div class="act-meta">
+                <span class="act-date">{{
+                  item.expense.date | date: 'MMM d'
+                }}</span>
+                <span [class]="shareClass(item)">{{ shareText(item) }}</span>
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  `,
+  styles: `
+    .rows {
+      overflow: hidden;
+    }
+    .activity-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 12px 14px;
+      border-bottom: 1px solid var(--border);
+      &:last-child {
+        border-bottom: none;
+      }
+    }
+    .act-icon {
+      width: 38px;
+      height: 38px;
+      border-radius: 10px;
+      background: var(--brand-light);
+      color: var(--brand);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-shrink: 0;
+    }
+    .act-main {
+      flex: 1;
+      min-width: 0;
+      display: flex;
+      flex-direction: column;
+      .act-desc {
+        font-weight: 600;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .act-sub {
+        font-size: 13px;
+        color: var(--text-secondary);
+      }
+    }
+    .act-meta {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      font-size: 12px;
+      .act-date {
+        color: var(--text-muted);
+      }
+    }
+  `,
+})
+export class ActivityComponent {
+  private readonly api = inject(ApiService);
+  private readonly auth = inject(AuthService);
+
+  readonly items = signal<ActivityItem[]>([]);
+  readonly loading = signal(true);
+  readonly myId = computed(() => this.auth.profile()?.id ?? '');
+
+  constructor() {
+    if (!this.auth.profile()) {
+      void this.auth.loadProfile();
+    }
+    this.api.getActivity().subscribe({
+      next: (items) => {
+        this.items.set(items);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  payerLabel(item: ActivityItem): string {
+    return item.expense.paidBy.id === this.myId()
+      ? 'you paid'
+      : `${item.expense.paidBy.name} paid`;
+  }
+
+  private myShareCents(item: ActivityItem): number {
+    return (
+      item.expense.splits.find((s) => s.user.id === this.myId())?.amountCents ??
+      0
+    );
+  }
+
+  shareText(item: ActivityItem): string {
+    const e = item.expense;
+    if (e.paidBy.id === this.myId()) {
+      const lent = e.amountCents - this.myShareCents(item);
+      return lent > 0 ? this.fmt(lent, e.currency, 'you lent') : '';
+    }
+    const owe = this.myShareCents(item);
+    return owe > 0 ? this.fmt(owe, e.currency, 'you owe') : '';
+  }
+
+  shareClass(item: ActivityItem): string {
+    return item.expense.paidBy.id === this.myId()
+      ? 'amount-positive'
+      : 'amount-negative';
+  }
+
+  private fmt(cents: number, currency: string, prefix: string): string {
+    const value = (cents / 100).toLocaleString(undefined, {
+      style: 'currency',
+      currency,
+    });
+    return `${prefix} ${value}`;
+  }
+}

--- a/apps/split-frontend/src/app/pages/group-detail/group-detail.component.scss
+++ b/apps/split-frontend/src/app/pages/group-detail/group-detail.component.scss
@@ -1,0 +1,280 @@
+:host {
+  display: block;
+}
+
+.detail-header {
+  position: sticky;
+  top: var(--header-height);
+  z-index: 30;
+  background: var(--bg-surface);
+  border-bottom: 1px solid var(--border);
+}
+
+.detail-header-inner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding-top: 12px;
+  padding-bottom: 12px;
+}
+
+.back-btn,
+.icon-btn {
+  width: 38px;
+  height: 38px;
+  border-radius: 10px;
+  border: none;
+  background: var(--bg-subtle);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+  i {
+    font-size: 17px;
+  }
+}
+
+.title-block {
+  flex: 1;
+  min-width: 0;
+  h1 {
+    font-size: 19px;
+    font-weight: 700;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.members-line {
+  font-size: 13px;
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: block;
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  padding-bottom: 10px;
+
+  button {
+    flex: 1;
+    border: none;
+    background: transparent;
+    padding: 8px 0;
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text-secondary);
+    border-bottom: 2px solid transparent;
+    cursor: pointer;
+
+    &.active {
+      color: var(--brand);
+      border-bottom-color: var(--brand);
+    }
+  }
+}
+
+.rows {
+  overflow: hidden;
+}
+
+.expense-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border);
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.exp-date {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 38px;
+  flex-shrink: 0;
+  .mon {
+    font-size: 11px;
+    text-transform: uppercase;
+    color: var(--owe);
+    font-weight: 600;
+  }
+  .day {
+    font-size: 17px;
+    font-weight: 700;
+  }
+}
+
+.exp-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  .exp-desc {
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .exp-sub {
+    font-size: 13px;
+    color: var(--text-secondary);
+  }
+}
+
+.exp-share {
+  font-size: 12px;
+  color: var(--text-muted);
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.debt-row,
+.balance-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  &:last-child {
+    border-bottom: none;
+  }
+}
+
+.debt-row {
+  justify-content: space-between;
+}
+.debt-text {
+  font-size: 14px;
+}
+.debt-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+}
+
+.balance-row {
+  .bal-name {
+    flex: 1;
+    font-weight: 500;
+  }
+}
+
+::ng-deep .member-avatar,
+::ng-deep .p-avatar {
+  background: var(--brand-light) !important;
+  color: var(--brand) !important;
+  font-weight: 600;
+}
+
+// ── Dialog internals ──
+.dialog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  label {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-secondary);
+  }
+  input,
+  ::ng-deep .p-inputnumber,
+  ::ng-deep .p-select {
+    width: 100%;
+  }
+  small {
+    color: var(--text-muted);
+    font-size: 12px;
+  }
+}
+
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.splits {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.split-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 6px 0;
+  &.off {
+    opacity: 0.5;
+  }
+}
+
+.split-check {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 500;
+  cursor: pointer;
+  input {
+    width: 18px;
+    height: 18px;
+    accent-color: var(--brand);
+  }
+}
+
+::ng-deep .split-input {
+  max-width: 130px;
+}
+
+.split-hint {
+  color: var(--text-muted);
+  font-size: 12px;
+  margin-top: 2px;
+}
+
+.member-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.member-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  .member-meta {
+    display: flex;
+    flex-direction: column;
+    span {
+      font-weight: 600;
+    }
+    small {
+      color: var(--text-muted);
+    }
+  }
+}
+
+.add-member-row {
+  display: flex;
+  gap: 8px;
+  input {
+    flex: 1;
+  }
+}

--- a/apps/split-frontend/src/app/pages/group-detail/group-detail.component.ts
+++ b/apps/split-frontend/src/app/pages/group-detail/group-detail.component.ts
@@ -1,0 +1,653 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Button } from 'primeng/button';
+import { Dialog } from 'primeng/dialog';
+import { InputText } from 'primeng/inputtext';
+import { InputNumber } from 'primeng/inputnumber';
+import { Select } from 'primeng/select';
+import { SelectButton } from 'primeng/selectbutton';
+import { Avatar } from 'primeng/avatar';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { ApiService } from '../../core/api.service';
+import { AuthService } from '../../core/auth.service';
+import {
+  Expense,
+  Group,
+  GroupBalances,
+  Settlement,
+  SplitType,
+} from '../../core/models';
+import { MoneyPipe } from '../../core/money.pipe';
+
+interface SplitRow {
+  userId: string;
+  name: string;
+  included: boolean;
+  value: number | null; // dollars for exact, percent for percentage
+}
+
+@Component({
+  selector: 'app-group-detail',
+  standalone: true,
+  imports: [
+    FormsModule,
+    DatePipe,
+    Button,
+    Dialog,
+    InputText,
+    InputNumber,
+    Select,
+    SelectButton,
+    Avatar,
+    MoneyPipe,
+  ],
+  providers: [ConfirmationService],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    @if (group(); as g) {
+      <div class="detail-header">
+        <div class="page detail-header-inner">
+          <button class="back-btn" (click)="back()">
+            <i class="pi pi-arrow-left"></i>
+          </button>
+          <div class="title-block">
+            <h1>{{ g.name }}</h1>
+            <span class="members-line">{{ memberNames() }}</span>
+          </div>
+          <button class="icon-btn" (click)="openMembers()">
+            <i class="pi pi-user-plus"></i>
+          </button>
+        </div>
+
+        <div class="page tabs">
+          <button
+            [class.active]="tab() === 'expenses'"
+            (click)="tab.set('expenses')"
+          >
+            Expenses
+          </button>
+          <button
+            [class.active]="tab() === 'balances'"
+            (click)="tab.set('balances')"
+          >
+            Balances
+          </button>
+        </div>
+      </div>
+
+      <div class="page">
+        @if (tab() === 'expenses') {
+          @if (expenses().length === 0) {
+            <div class="empty-state card">
+              <i class="pi pi-receipt"></i>
+              <p>No expenses yet. Add the first one.</p>
+            </div>
+          } @else {
+            <div class="rows card">
+              @for (e of expenses(); track e.id) {
+                <div class="expense-row" (click)="editExpense(e)">
+                  <div class="exp-date">
+                    <span class="mon">{{ e.date | date: 'MMM' }}</span>
+                    <span class="day">{{ e.date | date: 'd' }}</span>
+                  </div>
+                  <div class="exp-main">
+                    <span class="exp-desc">{{ e.description }}</span>
+                    <span class="exp-sub"
+                      >{{ e.paidBy.name }} paid
+                      {{ e.amountCents | money: e.currency }}</span
+                    >
+                  </div>
+                  <div class="exp-share">{{ shareLabel(e) }}</div>
+                </div>
+              }
+            </div>
+          }
+        } @else {
+          <!-- Balances tab -->
+          @if (balances(); as b) {
+            @if (b.debts.length === 0) {
+              <div class="empty-state card">
+                <i class="pi pi-check-circle" style="color: var(--brand)"></i>
+                <p>Everyone is settled up!</p>
+              </div>
+            } @else {
+              <div class="rows card">
+                @for (d of b.debts; track d.from.id + d.to.id) {
+                  <div class="debt-row">
+                    <span class="debt-text">
+                      <strong>{{ youOrName(d.from) }}</strong> owe{{
+                        d.from.id === myId() ? '' : 's'
+                      }}
+                      <strong>{{ youOrName(d.to) }}</strong>
+                    </span>
+                    <span class="debt-actions">
+                      <span class="amount-negative">{{
+                        d.amountCents | money: b.currency
+                      }}</span>
+                      <p-button
+                        label="Settle"
+                        size="small"
+                        [text]="true"
+                        (onClick)="openSettle(d.from.id, d.to.id, d.amountCents)"
+                      />
+                    </span>
+                  </div>
+                }
+              </div>
+            }
+
+            <h2 class="section-title">Member balances</h2>
+            <div class="rows card">
+              @for (m of b.balances; track m.user.id) {
+                <div class="balance-row">
+                  <p-avatar
+                    [label]="initial(m.user.name)"
+                    shape="circle"
+                    styleClass="member-avatar"
+                  />
+                  <span class="bal-name">{{ youOrName(m.user) }}</span>
+                  @if (m.netCents === 0) {
+                    <span class="muted">settled</span>
+                  } @else if (m.netCents > 0) {
+                    <span class="amount-positive"
+                      >gets back {{ m.netCents | money: b.currency }}</span
+                    >
+                  } @else {
+                    <span class="amount-negative"
+                      >owes {{ -m.netCents | money: b.currency }}</span
+                    >
+                  }
+                </div>
+              }
+            </div>
+          }
+        }
+      </div>
+
+      <!-- FAB add expense -->
+      <p-button
+        class="fab"
+        icon="pi pi-plus"
+        [rounded]="true"
+        size="large"
+        (onClick)="openExpense()"
+      />
+    } @else {
+      <div class="empty-state"><i class="pi pi-spin pi-spinner"></i></div>
+    }
+
+    <!-- Add / edit expense dialog -->
+    <p-dialog
+      [header]="editingId() ? 'Edit expense' : 'Add expense'"
+      [(visible)]="showExpense"
+      [modal]="true"
+      [draggable]="false"
+      [style]="{ width: '94vw', maxWidth: '460px' }"
+    >
+      <div class="dialog-body">
+        <div class="field">
+          <label>Description</label>
+          <input pInputText [(ngModel)]="expDesc" placeholder="Dinner, groceries…" />
+        </div>
+        <div class="two-col">
+          <div class="field">
+            <label>Amount</label>
+            <p-inputNumber
+              [(ngModel)]="expAmount"
+              mode="currency"
+              [currency]="group()?.currency || 'CAD'"
+              [min]="0"
+            />
+          </div>
+          <div class="field">
+            <label>Paid by</label>
+            <p-select
+              [options]="memberOptions()"
+              [(ngModel)]="expPaidBy"
+              optionLabel="name"
+              optionValue="userId"
+              appendTo="body"
+            />
+          </div>
+        </div>
+
+        <div class="field">
+          <label>Split</label>
+          <p-selectButton
+            [options]="splitOptions"
+            [(ngModel)]="expSplitType"
+            optionLabel="label"
+            optionValue="value"
+            [allowEmpty]="false"
+          />
+        </div>
+
+        <div class="splits">
+          @for (row of splitRows(); track row.userId) {
+            <div class="split-row" [class.off]="!row.included">
+              <label class="split-check">
+                <input type="checkbox" [(ngModel)]="row.included" />
+                <span>{{ row.name }}</span>
+              </label>
+              @if (expSplitType !== 'equal' && row.included) {
+                <p-inputNumber
+                  [(ngModel)]="row.value"
+                  [min]="0"
+                  [suffix]="expSplitType === 'percentage' ? ' %' : ''"
+                  [mode]="expSplitType === 'exact' ? 'currency' : 'decimal'"
+                  [currency]="group()?.currency || 'CAD'"
+                  styleClass="split-input"
+                />
+              }
+            </div>
+          }
+          <small class="split-hint">{{ splitHint() }}</small>
+        </div>
+      </div>
+      <ng-template #footer>
+        @if (editingId()) {
+          <p-button
+            label="Delete"
+            severity="danger"
+            [text]="true"
+            (onClick)="deleteExpense()"
+          />
+        }
+        <p-button label="Cancel" [text]="true" (onClick)="showExpense.set(false)" />
+        <p-button label="Save" [loading]="savingExpense()" (onClick)="saveExpense()" />
+      </ng-template>
+    </p-dialog>
+
+    <!-- Settle up dialog -->
+    <p-dialog
+      header="Record a payment"
+      [(visible)]="showSettle"
+      [modal]="true"
+      [draggable]="false"
+      [style]="{ width: '92vw', maxWidth: '420px' }"
+    >
+      <div class="dialog-body">
+        <div class="two-col">
+          <div class="field">
+            <label>From</label>
+            <p-select
+              [options]="memberOptions()"
+              [(ngModel)]="settleFrom"
+              optionLabel="name"
+              optionValue="userId"
+              appendTo="body"
+            />
+          </div>
+          <div class="field">
+            <label>To</label>
+            <p-select
+              [options]="memberOptions()"
+              [(ngModel)]="settleTo"
+              optionLabel="name"
+              optionValue="userId"
+              appendTo="body"
+            />
+          </div>
+        </div>
+        <div class="field">
+          <label>Amount</label>
+          <p-inputNumber
+            [(ngModel)]="settleAmount"
+            mode="currency"
+            [currency]="group()?.currency || 'CAD'"
+            [min]="0"
+          />
+        </div>
+      </div>
+      <ng-template #footer>
+        <p-button label="Cancel" [text]="true" (onClick)="showSettle.set(false)" />
+        <p-button label="Save payment" [loading]="savingSettle()" (onClick)="saveSettle()" />
+      </ng-template>
+    </p-dialog>
+
+    <!-- Members dialog -->
+    <p-dialog
+      header="Members"
+      [(visible)]="showMembers"
+      [modal]="true"
+      [draggable]="false"
+      [style]="{ width: '92vw', maxWidth: '420px' }"
+    >
+      <div class="dialog-body">
+        <div class="member-list">
+          @for (m of group()?.members || []; track m.id) {
+            <div class="member-item">
+              <p-avatar [label]="initial(m.user.name)" shape="circle" />
+              <div class="member-meta">
+                <span>{{ m.user.name }}</span>
+                <small>{{ '@' + m.user.username }}</small>
+              </div>
+            </div>
+          }
+        </div>
+        <div class="field">
+          <label>Add by username</label>
+          <div class="add-member-row">
+            <input pInputText [(ngModel)]="newMemberUsername" placeholder="username" autocapitalize="none" />
+            <p-button icon="pi pi-plus" [loading]="addingMember()" (onClick)="addMember()" />
+          </div>
+        </div>
+        <p-button
+          label="Delete group"
+          severity="danger"
+          [text]="true"
+          icon="pi pi-trash"
+          (onClick)="deleteGroup()"
+        />
+      </div>
+    </p-dialog>
+  `,
+  styleUrl: './group-detail.component.scss',
+})
+export class GroupDetailComponent implements OnInit {
+  private readonly api = inject(ApiService);
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly messages = inject(MessageService);
+
+  // Bound from the route param via withComponentInputBinding.
+  readonly id = input.required<string>();
+
+  readonly group = signal<Group | null>(null);
+  readonly expenses = signal<Expense[]>([]);
+  readonly settlements = signal<Settlement[]>([]);
+  readonly balances = signal<GroupBalances | null>(null);
+  readonly tab = signal<'expenses' | 'balances'>('expenses');
+
+  readonly myId = computed(() => this.auth.profile()?.id ?? '');
+
+  // Expense dialog state
+  readonly showExpense = signal(false);
+  readonly savingExpense = signal(false);
+  readonly editingId = signal<string | null>(null);
+  expDesc = '';
+  expAmount: number | null = null;
+  expPaidBy = '';
+  expSplitType: SplitType = 'equal';
+  readonly splitRows = signal<SplitRow[]>([]);
+  readonly splitOptions = [
+    { label: 'Equally', value: 'equal' },
+    { label: 'Exact', value: 'exact' },
+    { label: 'Percent', value: 'percentage' },
+  ];
+
+  // Settle dialog state
+  readonly showSettle = signal(false);
+  readonly savingSettle = signal(false);
+  settleFrom = '';
+  settleTo = '';
+  settleAmount: number | null = null;
+
+  // Members dialog state
+  readonly showMembers = signal(false);
+  readonly addingMember = signal(false);
+  newMemberUsername = '';
+
+  readonly memberOptions = computed(() =>
+    (this.group()?.members ?? []).map((m) => ({
+      userId: m.user.id,
+      name: m.user.name,
+    }))
+  );
+
+  constructor() {
+    if (!this.auth.profile()) {
+      void this.auth.loadProfile();
+    }
+  }
+
+  ngOnInit(): void {
+    // Route param inputs are bound by the time ngOnInit runs.
+    this.reload();
+  }
+
+  reload(): void {
+    const id = this.id();
+    this.api.getGroup(id).subscribe((g) => this.group.set(g));
+    this.api.getExpenses(id).subscribe((e) => this.expenses.set(e));
+    this.api.getBalances(id).subscribe((b) => this.balances.set(b));
+  }
+
+  back(): void {
+    this.router.navigate(['/groups']);
+  }
+
+  initial(name: string): string {
+    return (name?.charAt(0) || '?').toUpperCase();
+  }
+
+  memberNames(): string {
+    return (this.group()?.members ?? []).map((m) => m.user.name).join(', ');
+  }
+
+  youOrName(user: { id: string; name: string }): string {
+    return user.id === this.myId() ? 'You' : user.name;
+  }
+
+  /** A short label for what the current user owes/lent on a given expense. */
+  shareLabel(e: Expense): string {
+    const mine = e.splits.find((s) => s.user.id === this.myId());
+    if (e.paidBy.id === this.myId()) {
+      const lent = e.amountCents - (mine?.amountCents ?? 0);
+      return lent > 0 ? 'you lent' : '';
+    }
+    return mine ? 'you owe' : '';
+  }
+
+  // ── Expense dialog ──
+  private buildSplitRows(selected?: Expense): void {
+    const members = this.group()?.members ?? [];
+    const selectedIds = selected
+      ? new Set(selected.splits.map((s) => s.user.id))
+      : new Set(members.map((m) => m.user.id));
+    this.splitRows.set(
+      members.map((m) => {
+        const existing = selected?.splits.find((s) => s.user.id === m.user.id);
+        let value: number | null = null;
+        if (selected && existing) {
+          value =
+            selected.splitType === 'percentage'
+              ? Math.round(
+                  (existing.amountCents / selected.amountCents) * 100
+                )
+              : existing.amountCents / 100;
+        }
+        return {
+          userId: m.user.id,
+          name: m.user.name,
+          included: selectedIds.has(m.user.id),
+          value,
+        };
+      })
+    );
+  }
+
+  openExpense(): void {
+    this.editingId.set(null);
+    this.expDesc = '';
+    this.expAmount = null;
+    this.expPaidBy = this.myId() || this.memberOptions()[0]?.userId || '';
+    this.expSplitType = 'equal';
+    this.buildSplitRows();
+    this.showExpense.set(true);
+  }
+
+  editExpense(e: Expense): void {
+    this.editingId.set(e.id);
+    this.expDesc = e.description;
+    this.expAmount = e.amountCents / 100;
+    this.expPaidBy = e.paidBy.id;
+    this.expSplitType = (e.splitType as SplitType) ?? 'equal';
+    this.buildSplitRows(e);
+    this.showExpense.set(true);
+  }
+
+  splitHint(): string {
+    const included = this.splitRows().filter((r) => r.included);
+    if (this.expSplitType === 'equal') {
+      return `Split equally between ${included.length} member${
+        included.length === 1 ? '' : 's'
+      }.`;
+    }
+    if (this.expSplitType === 'percentage') {
+      const total = included.reduce((acc, r) => acc + (r.value ?? 0), 0);
+      return `Percentages add up to ${total}% (must be 100%).`;
+    }
+    const total = included.reduce((acc, r) => acc + (r.value ?? 0), 0);
+    return `Shares add up to ${total.toFixed(2)} (must equal the amount).`;
+  }
+
+  saveExpense(): void {
+    const desc = this.expDesc.trim();
+    const amount = this.expAmount ?? 0;
+    const included = this.splitRows().filter((r) => r.included);
+    if (!desc || amount <= 0 || included.length === 0 || !this.expPaidBy) {
+      this.messages.add({
+        severity: 'warn',
+        summary: 'Incomplete',
+        detail: 'Enter a description, amount, payer and at least one member.',
+      });
+      return;
+    }
+
+    const body = {
+      description: desc,
+      amount,
+      currency: this.group()?.currency || 'CAD',
+      paidByUserId: this.expPaidBy,
+      splitType: this.expSplitType,
+      splits: included.map((r) => ({
+        userId: r.userId,
+        value: this.expSplitType === 'equal' ? undefined : r.value ?? 0,
+      })),
+    };
+
+    this.savingExpense.set(true);
+    const editId = this.editingId();
+    const request$ = editId
+      ? this.api.updateExpense(editId, body)
+      : this.api.createExpense(this.id(), body);
+
+    request$.subscribe({
+      next: () => {
+        this.savingExpense.set(false);
+        this.showExpense.set(false);
+        this.reload();
+      },
+      error: (error) => {
+        this.savingExpense.set(false);
+        this.messages.add({
+          severity: 'error',
+          summary: 'Could not save',
+          detail: error?.error?.message || 'Check the split amounts.',
+        });
+      },
+    });
+  }
+
+  deleteExpense(): void {
+    const editId = this.editingId();
+    if (!editId) return;
+    this.api.deleteExpense(editId).subscribe(() => {
+      this.showExpense.set(false);
+      this.reload();
+    });
+  }
+
+  // ── Settle ──
+  openSettle(fromId?: string, toId?: string, amountCents?: number): void {
+    this.settleFrom = fromId || this.myId();
+    this.settleTo = toId || '';
+    this.settleAmount = amountCents ? amountCents / 100 : null;
+    this.showSettle.set(true);
+  }
+
+  saveSettle(): void {
+    if (
+      !this.settleFrom ||
+      !this.settleTo ||
+      this.settleFrom === this.settleTo ||
+      !this.settleAmount
+    ) {
+      this.messages.add({
+        severity: 'warn',
+        summary: 'Incomplete',
+        detail: 'Pick two different members and an amount.',
+      });
+      return;
+    }
+    this.savingSettle.set(true);
+    this.api
+      .createSettlement(this.id(), {
+        fromUserId: this.settleFrom,
+        toUserId: this.settleTo,
+        amount: this.settleAmount,
+        currency: this.group()?.currency || 'CAD',
+      })
+      .subscribe({
+        next: () => {
+          this.savingSettle.set(false);
+          this.showSettle.set(false);
+          this.reload();
+        },
+        error: (error) => {
+          this.savingSettle.set(false);
+          this.messages.add({
+            severity: 'error',
+            summary: 'Could not save payment',
+            detail: error?.error?.message || 'Something went wrong.',
+          });
+        },
+      });
+  }
+
+  // ── Members ──
+  openMembers(): void {
+    this.newMemberUsername = '';
+    this.showMembers.set(true);
+  }
+
+  addMember(): void {
+    const username = this.newMemberUsername.trim();
+    if (!username) return;
+    this.addingMember.set(true);
+    this.api.addMember(this.id(), username).subscribe({
+      next: (group) => {
+        this.addingMember.set(false);
+        this.newMemberUsername = '';
+        this.group.set(group);
+        this.reload();
+      },
+      error: (error) => {
+        this.addingMember.set(false);
+        this.messages.add({
+          severity: 'error',
+          summary: 'Could not add member',
+          detail: error?.error?.message || `No user "${username}".`,
+        });
+      },
+    });
+  }
+
+  deleteGroup(): void {
+    this.api.deleteGroup(this.id()).subscribe(() => {
+      this.showMembers.set(false);
+      this.router.navigate(['/groups']);
+    });
+  }
+}

--- a/apps/split-frontend/src/app/pages/groups/groups.component.ts
+++ b/apps/split-frontend/src/app/pages/groups/groups.component.ts
@@ -1,0 +1,390 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { Button } from 'primeng/button';
+import { Dialog } from 'primeng/dialog';
+import { InputText } from 'primeng/inputtext';
+import { SelectButton } from 'primeng/selectbutton';
+import { MessageService } from 'primeng/api';
+import { ApiService } from '../../core/api.service';
+import { GroupSummary, Overview } from '../../core/models';
+import { MoneyPipe } from '../../core/money.pipe';
+
+@Component({
+  selector: 'app-groups',
+  standalone: true,
+  imports: [FormsModule, Button, Dialog, InputText, SelectButton, MoneyPipe],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page">
+      <!-- Overview hero -->
+      <section class="overview card">
+        @if (overview(); as o) {
+          <div class="overview-row">
+            <div class="overview-item">
+              <span class="label">you are owed</span>
+              <span class="value amount-positive">{{
+                o.youAreOwedCents | money: o.currency
+              }}</span>
+            </div>
+            <div class="overview-item">
+              <span class="label">you owe</span>
+              <span class="value amount-negative">{{
+                o.youOweCents | money: o.currency
+              }}</span>
+            </div>
+            <div class="overview-item">
+              <span class="label">total balance</span>
+              <span
+                class="value"
+                [class.amount-positive]="o.netCents >= 0"
+                [class.amount-negative]="o.netCents < 0"
+                >{{ o.netCents | money: o.currency }}</span
+              >
+            </div>
+          </div>
+        } @else {
+          <div class="overview-row skeleton">Loading…</div>
+        }
+      </section>
+
+      <div class="list-header">
+        <h2 class="section-title" style="margin:0">Your groups</h2>
+        <p-button
+          label="New"
+          icon="pi pi-plus"
+          size="small"
+          (onClick)="openCreate()"
+        />
+      </div>
+
+      @if (loading()) {
+        <div class="empty-state"><i class="pi pi-spin pi-spinner"></i></div>
+      } @else if (groups().length === 0) {
+        <div class="empty-state card">
+          <i class="pi pi-users"></i>
+          <p>No groups yet.</p>
+          <p-button
+            label="Create your first group"
+            (onClick)="openCreate()"
+          />
+        </div>
+      } @else {
+        <div class="group-list">
+          @for (g of groups(); track g.id) {
+            <button class="group-card card" (click)="open(g)">
+              <div class="group-avatar" [attr.data-type]="g.type">
+                <i [class]="'pi ' + typeIcon(g.type)"></i>
+              </div>
+              <div class="group-info">
+                <span class="group-name">{{ g.name }}</span>
+                <span class="group-meta"
+                  >{{ g.memberCount }} member{{
+                    g.memberCount === 1 ? '' : 's'
+                  }}</span
+                >
+              </div>
+              <div class="group-balance">
+                @if (g.yourBalanceCents === 0) {
+                  <span class="settled">settled up</span>
+                } @else if (g.yourBalanceCents > 0) {
+                  <span class="label">you are owed</span>
+                  <span class="amount-positive">{{
+                    g.yourBalanceCents | money: g.currency
+                  }}</span>
+                } @else {
+                  <span class="label">you owe</span>
+                  <span class="amount-negative">{{
+                    -g.yourBalanceCents | money: g.currency
+                  }}</span>
+                }
+              </div>
+            </button>
+          }
+        </div>
+      }
+    </div>
+
+    <!-- Create group dialog -->
+    <p-dialog
+      header="New group"
+      [(visible)]="showCreate"
+      [modal]="true"
+      [draggable]="false"
+      [style]="{ width: '92vw', maxWidth: '440px' }"
+    >
+      <div class="dialog-body">
+        <div class="field">
+          <label>Group name</label>
+          <input pInputText [(ngModel)]="newName" placeholder="Apartment, Trip to Italy…" />
+        </div>
+        <div class="field">
+          <label>Type</label>
+          <p-selectButton
+            [options]="typeOptions"
+            [(ngModel)]="newType"
+            optionLabel="label"
+            optionValue="value"
+          />
+        </div>
+        <div class="field">
+          <label>Add members (usernames, comma separated)</label>
+          <input
+            pInputText
+            [(ngModel)]="newMembers"
+            placeholder="alex, sam"
+            autocapitalize="none"
+          />
+          <small>You're added automatically. Others must already have an account.</small>
+        </div>
+      </div>
+      <ng-template #footer>
+        <p-button label="Cancel" [text]="true" (onClick)="showCreate.set(false)" />
+        <p-button
+          label="Create"
+          [loading]="creating()"
+          (onClick)="create()"
+        />
+      </ng-template>
+    </p-dialog>
+  `,
+  styles: `
+    .overview {
+      padding: 16px;
+      margin-bottom: 8px;
+    }
+    .overview-row {
+      display: flex;
+      justify-content: space-between;
+      gap: 8px;
+    }
+    .overview-item {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      flex: 1;
+      text-align: center;
+    }
+    .overview-item .label {
+      font-size: 11px;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-muted);
+    }
+    .overview-item .value {
+      font-size: 17px;
+      font-weight: 700;
+    }
+    .skeleton {
+      color: var(--text-muted);
+      justify-content: center;
+      padding: 8px;
+    }
+
+    .list-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin: 18px 4px 10px;
+    }
+
+    .group-list {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .group-card {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      padding: 14px;
+      text-align: left;
+      cursor: pointer;
+      width: 100%;
+      background: var(--bg-surface);
+      transition: transform 0.06s ease, box-shadow 0.12s ease;
+    }
+    .group-card:active {
+      transform: scale(0.99);
+    }
+
+    .group-avatar {
+      width: 46px;
+      height: 46px;
+      border-radius: 12px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--brand-light);
+      color: var(--brand);
+      flex-shrink: 0;
+      i {
+        font-size: 20px;
+      }
+    }
+
+    .group-info {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+    .group-name {
+      font-weight: 600;
+      font-size: 16px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    .group-meta {
+      font-size: 13px;
+      color: var(--text-secondary);
+    }
+
+    .group-balance {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-end;
+      font-weight: 600;
+      font-size: 15px;
+      text-align: right;
+    }
+    .group-balance .label {
+      font-size: 11px;
+      font-weight: 500;
+      color: var(--text-muted);
+      text-transform: uppercase;
+    }
+    .group-balance .settled {
+      font-size: 13px;
+      color: var(--text-muted);
+      font-weight: 500;
+    }
+
+    .dialog-body {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      label {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-secondary);
+      }
+      input {
+        width: 100%;
+      }
+      small {
+        color: var(--text-muted);
+        font-size: 12px;
+      }
+    }
+  `,
+})
+export class GroupsComponent {
+  private readonly api = inject(ApiService);
+  private readonly router = inject(Router);
+  private readonly messages = inject(MessageService);
+
+  readonly groups = signal<GroupSummary[]>([]);
+  readonly overview = signal<Overview | null>(null);
+  readonly loading = signal(true);
+
+  readonly showCreate = signal(false);
+  readonly creating = signal(false);
+  newName = '';
+  newType = 'other';
+  newMembers = '';
+
+  readonly typeOptions = [
+    { label: 'Trip', value: 'trip' },
+    { label: 'Home', value: 'home' },
+    { label: 'Couple', value: 'couple' },
+    { label: 'Other', value: 'other' },
+  ];
+
+  constructor() {
+    this.reload();
+  }
+
+  reload(): void {
+    this.loading.set(true);
+    this.api.getGroups().subscribe({
+      next: (groups) => {
+        this.groups.set(groups);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+    this.api.getOverview().subscribe((o) => this.overview.set(o));
+  }
+
+  typeIcon(type: string): string {
+    switch (type) {
+      case 'trip':
+        return 'pi-send';
+      case 'home':
+        return 'pi-home';
+      case 'couple':
+        return 'pi-heart';
+      default:
+        return 'pi-users';
+    }
+  }
+
+  open(g: GroupSummary): void {
+    this.router.navigate(['/groups', g.id]);
+  }
+
+  openCreate(): void {
+    this.newName = '';
+    this.newType = 'other';
+    this.newMembers = '';
+    this.showCreate.set(true);
+  }
+
+  create(): void {
+    const name = this.newName.trim();
+    if (!name) {
+      this.messages.add({
+        severity: 'warn',
+        summary: 'Name required',
+        detail: 'Give your group a name.',
+      });
+      return;
+    }
+    const memberUsernames = this.newMembers
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean);
+
+    this.creating.set(true);
+    this.api
+      .createGroup({ name, type: this.newType, memberUsernames })
+      .subscribe({
+        next: (group) => {
+          this.creating.set(false);
+          this.showCreate.set(false);
+          this.router.navigate(['/groups', group.id]);
+        },
+        error: (error) => {
+          this.creating.set(false);
+          this.messages.add({
+            severity: 'error',
+            summary: 'Could not create group',
+            detail: error?.error?.message || 'Something went wrong.',
+          });
+        },
+      });
+  }
+}

--- a/apps/split-frontend/src/app/pages/login/login.component.ts
+++ b/apps/split-frontend/src/app/pages/login/login.component.ts
@@ -1,0 +1,167 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { Button } from 'primeng/button';
+import { InputText } from 'primeng/inputtext';
+import { MessageService } from 'primeng/api';
+import { AuthService } from '../../core/auth.service';
+
+@Component({
+  selector: 'app-login',
+  standalone: true,
+  imports: [FormsModule, RouterLink, Button, InputText],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="auth-screen">
+      <div class="auth-card card">
+        <div class="logo">
+          <i class="pi pi-wallet"></i>
+        </div>
+        <h1>Welcome back</h1>
+        <p class="subtitle">Sign in with your passkey — no password needed.</p>
+
+        <div class="field">
+          <label for="username">Username (optional)</label>
+          <input
+            pInputText
+            id="username"
+            [(ngModel)]="username"
+            placeholder="your_username"
+            autocapitalize="none"
+            autocomplete="username webauthn"
+          />
+        </div>
+
+        <p-button
+          [loading]="loading()"
+          (onClick)="login()"
+          styleClass="w-full"
+          label="Sign in with passkey"
+          icon="pi pi-key"
+        />
+
+        <div class="divider"><span>new here?</span></div>
+
+        <a routerLink="/register" class="create-account">
+          Create an account
+        </a>
+      </div>
+    </div>
+  `,
+  styles: `
+    .auth-screen {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      background: linear-gradient(160deg, var(--brand) 0%, #0f5d46 100%);
+    }
+
+    .auth-card {
+      width: 100%;
+      max-width: 380px;
+      padding: 32px 24px;
+      text-align: center;
+    }
+
+    .logo {
+      width: 64px;
+      height: 64px;
+      border-radius: 18px;
+      background: var(--brand-light);
+      color: var(--brand);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 16px;
+      i {
+        font-size: 30px;
+      }
+    }
+
+    h1 {
+      font-size: 22px;
+      margin-bottom: 6px;
+    }
+
+    .subtitle {
+      color: var(--text-secondary);
+      font-size: 14px;
+      margin-bottom: 22px;
+    }
+
+    .field {
+      text-align: left;
+      margin-bottom: 18px;
+      label {
+        display: block;
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 6px;
+        color: var(--text-secondary);
+      }
+      input {
+        width: 100%;
+      }
+    }
+
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin: 22px 0 14px;
+      color: var(--text-muted);
+      font-size: 12px;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      &::before,
+      &::after {
+        content: '';
+        flex: 1;
+        height: 1px;
+        background: var(--border);
+      }
+    }
+
+    .create-account {
+      font-weight: 600;
+    }
+
+    :host ::ng-deep .w-full {
+      width: 100%;
+    }
+  `,
+})
+export class LoginComponent {
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly messages = inject(MessageService);
+
+  username = '';
+  readonly loading = signal(false);
+
+  async login(): Promise<void> {
+    this.loading.set(true);
+    try {
+      await this.auth.loginWithPasskey(this.username.trim() || undefined);
+      await this.router.navigate(['/groups']);
+    } catch (error: any) {
+      this.messages.add({
+        severity: 'error',
+        summary: 'Login failed',
+        detail:
+          error?.error?.message ||
+          error?.message ||
+          'Could not authenticate with a passkey.',
+      });
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/apps/split-frontend/src/app/pages/profile/profile.component.ts
+++ b/apps/split-frontend/src/app/pages/profile/profile.component.ts
@@ -1,0 +1,180 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Button } from 'primeng/button';
+import { InputText } from 'primeng/inputtext';
+import { Avatar } from 'primeng/avatar';
+import { MessageService } from 'primeng/api';
+import { AuthService } from '../../core/auth.service';
+
+@Component({
+  selector: 'app-profile',
+  standalone: true,
+  imports: [FormsModule, Button, InputText, Avatar],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="page">
+      <div class="profile-head card">
+        <p-avatar
+          [label]="initial()"
+          size="xlarge"
+          shape="circle"
+          styleClass="profile-avatar"
+        />
+        <h1>{{ auth.profile()?.name }}</h1>
+        <span class="username">{{ '@' + (auth.profile()?.username || '') }}</span>
+      </div>
+
+      <h2 class="section-title">Account details</h2>
+      <div class="card form-card">
+        <div class="field">
+          <label>Display name</label>
+          <input pInputText [(ngModel)]="name" />
+        </div>
+        <div class="field">
+          <label>Email</label>
+          <input pInputText type="email" [(ngModel)]="email" placeholder="optional" />
+        </div>
+        <p-button
+          label="Save changes"
+          [loading]="saving()"
+          (onClick)="save()"
+        />
+      </div>
+
+      <h2 class="section-title">Security</h2>
+      <div class="card info-card">
+        <div class="info-row">
+          <i class="pi pi-key"></i>
+          <span>Signed in with a passkey on this device.</span>
+        </div>
+      </div>
+
+      <div class="logout-wrap">
+        <p-button
+          label="Log out"
+          severity="danger"
+          [outlined]="true"
+          icon="pi pi-sign-out"
+          styleClass="w-full"
+          (onClick)="logout()"
+        />
+      </div>
+    </div>
+  `,
+  styles: `
+    .profile-head {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      padding: 28px 16px;
+      margin-bottom: 8px;
+      h1 {
+        font-size: 20px;
+      }
+      .username {
+        color: var(--text-secondary);
+      }
+    }
+    ::ng-deep .profile-avatar {
+      background: var(--brand-light) !important;
+      color: var(--brand) !important;
+      width: 76px !important;
+      height: 76px !important;
+      font-size: 30px !important;
+      font-weight: 700;
+    }
+    .form-card,
+    .info-card {
+      padding: 16px;
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+    }
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+      label {
+        font-size: 13px;
+        font-weight: 600;
+        color: var(--text-secondary);
+      }
+      input {
+        width: 100%;
+      }
+    }
+    .info-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      color: var(--text-secondary);
+      i {
+        color: var(--brand);
+      }
+    }
+    .logout-wrap {
+      margin-top: 24px;
+    }
+    :host ::ng-deep .w-full {
+      width: 100%;
+    }
+  `,
+})
+export class ProfileComponent {
+  readonly auth = inject(AuthService);
+  private readonly messages = inject(MessageService);
+
+  name = '';
+  email = '';
+  readonly saving = signal(false);
+
+  constructor() {
+    const apply = () => {
+      const p = this.auth.profile();
+      if (p) {
+        this.name = p.name;
+        this.email = p.email ?? '';
+      }
+    };
+    if (this.auth.profile()) {
+      apply();
+    } else {
+      void this.auth.loadProfile().then(apply);
+    }
+  }
+
+  initial(): string {
+    return (this.auth.profile()?.name?.charAt(0) || '?').toUpperCase();
+  }
+
+  save(): void {
+    this.saving.set(true);
+    this.auth
+      .updateProfile({ name: this.name.trim(), email: this.email.trim() || undefined })
+      .then(() => {
+        this.messages.add({
+          severity: 'success',
+          summary: 'Saved',
+          detail: 'Your profile has been updated.',
+        });
+      })
+      .catch(() => {
+        this.messages.add({
+          severity: 'error',
+          summary: 'Could not save',
+          detail: 'Please try again.',
+        });
+      })
+      .finally(() => this.saving.set(false));
+  }
+
+  logout(): void {
+    void this.auth.logout();
+  }
+}

--- a/apps/split-frontend/src/app/pages/register/register.component.ts
+++ b/apps/split-frontend/src/app/pages/register/register.component.ts
@@ -1,0 +1,201 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterLink } from '@angular/router';
+import { Button } from 'primeng/button';
+import { InputText } from 'primeng/inputtext';
+import { MessageService } from 'primeng/api';
+import { AuthService } from '../../core/auth.service';
+
+@Component({
+  selector: 'app-register',
+  standalone: true,
+  imports: [FormsModule, RouterLink, Button, InputText],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="auth-screen">
+      <div class="auth-card card">
+        <div class="logo"><i class="pi pi-user-plus"></i></div>
+        <h1>Create your account</h1>
+        <p class="subtitle">
+          Set up your profile and secure it with a passkey.
+        </p>
+
+        <div class="field">
+          <label for="name">Full name</label>
+          <input
+            pInputText
+            id="name"
+            [(ngModel)]="name"
+            placeholder="Jane Doe"
+            autocomplete="name"
+          />
+        </div>
+
+        <div class="field">
+          <label for="username">Username</label>
+          <input
+            pInputText
+            id="username"
+            [(ngModel)]="username"
+            placeholder="jane_doe"
+            autocapitalize="none"
+            autocomplete="username"
+          />
+          <small>Letters, numbers and underscores. Min 3 characters.</small>
+        </div>
+
+        <div class="field">
+          <label for="email">Email (optional)</label>
+          <input
+            pInputText
+            id="email"
+            type="email"
+            [(ngModel)]="email"
+            placeholder="jane@example.com"
+            autocomplete="email"
+          />
+        </div>
+
+        <p-button
+          [loading]="loading()"
+          (onClick)="register()"
+          styleClass="w-full"
+          label="Create account & add passkey"
+          icon="pi pi-shield"
+        />
+
+        <div class="divider"><span>already have an account?</span></div>
+        <a routerLink="/login" class="signin-link">Sign in instead</a>
+      </div>
+    </div>
+  `,
+  styles: `
+    .auth-screen {
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      background: linear-gradient(160deg, var(--brand) 0%, #0f5d46 100%);
+    }
+    .auth-card {
+      width: 100%;
+      max-width: 400px;
+      padding: 32px 24px;
+      text-align: center;
+    }
+    .logo {
+      width: 64px;
+      height: 64px;
+      border-radius: 18px;
+      background: var(--brand-light);
+      color: var(--brand);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      margin: 0 auto 16px;
+      i {
+        font-size: 30px;
+      }
+    }
+    h1 {
+      font-size: 22px;
+      margin-bottom: 6px;
+    }
+    .subtitle {
+      color: var(--text-secondary);
+      font-size: 14px;
+      margin-bottom: 22px;
+    }
+    .field {
+      text-align: left;
+      margin-bottom: 16px;
+      label {
+        display: block;
+        font-size: 13px;
+        font-weight: 600;
+        margin-bottom: 6px;
+        color: var(--text-secondary);
+      }
+      input {
+        width: 100%;
+      }
+      small {
+        display: block;
+        margin-top: 4px;
+        color: var(--text-muted);
+        font-size: 12px;
+      }
+    }
+    .divider {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin: 22px 0 14px;
+      color: var(--text-muted);
+      font-size: 12px;
+      &::before,
+      &::after {
+        content: '';
+        flex: 1;
+        height: 1px;
+        background: var(--border);
+      }
+    }
+    .signin-link {
+      font-weight: 600;
+    }
+    :host ::ng-deep .w-full {
+      width: 100%;
+    }
+  `,
+})
+export class RegisterComponent {
+  private readonly auth = inject(AuthService);
+  private readonly router = inject(Router);
+  private readonly messages = inject(MessageService);
+
+  name = '';
+  username = '';
+  email = '';
+  readonly loading = signal(false);
+
+  async register(): Promise<void> {
+    const name = this.name.trim();
+    const username = this.username.trim();
+    if (name.length < 1 || username.length < 3) {
+      this.messages.add({
+        severity: 'warn',
+        summary: 'Missing details',
+        detail: 'Enter your name and a username of at least 3 characters.',
+      });
+      return;
+    }
+
+    this.loading.set(true);
+    try {
+      await this.auth.register({
+        name,
+        username,
+        email: this.email.trim() || undefined,
+      });
+      await this.router.navigate(['/groups']);
+    } catch (error: any) {
+      this.messages.add({
+        severity: 'error',
+        summary: 'Could not create account',
+        detail:
+          error?.error?.message ||
+          error?.message ||
+          'Registration failed. The username may already be taken.',
+      });
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/apps/split-frontend/src/app/pages/register/register.component.ts
+++ b/apps/split-frontend/src/app/pages/register/register.component.ts
@@ -20,21 +20,11 @@ import { AuthService } from '../../core/auth.service';
     <div class="auth-screen">
       <div class="auth-card card">
         <div class="logo"><i class="pi pi-user-plus"></i></div>
-        <h1>Create your account</h1>
+        <h1>Choose a username</h1>
         <p class="subtitle">
-          Set up your profile and secure it with a passkey.
+          That's it — secure your account with a passkey. You can add a display
+          name later.
         </p>
-
-        <div class="field">
-          <label for="name">Full name</label>
-          <input
-            pInputText
-            id="name"
-            [(ngModel)]="name"
-            placeholder="Jane Doe"
-            autocomplete="name"
-          />
-        </div>
 
         <div class="field">
           <label for="username">Username</label>
@@ -45,20 +35,9 @@ import { AuthService } from '../../core/auth.service';
             placeholder="jane_doe"
             autocapitalize="none"
             autocomplete="username"
+            (keyup.enter)="register()"
           />
           <small>Letters, numbers and underscores. Min 3 characters.</small>
-        </div>
-
-        <div class="field">
-          <label for="email">Email (optional)</label>
-          <input
-            pInputText
-            id="email"
-            type="email"
-            [(ngModel)]="email"
-            placeholder="jane@example.com"
-            autocomplete="email"
-          />
         </div>
 
         <p-button
@@ -160,30 +139,23 @@ export class RegisterComponent {
   private readonly router = inject(Router);
   private readonly messages = inject(MessageService);
 
-  name = '';
   username = '';
-  email = '';
   readonly loading = signal(false);
 
   async register(): Promise<void> {
-    const name = this.name.trim();
     const username = this.username.trim();
-    if (name.length < 1 || username.length < 3) {
+    if (username.length < 3) {
       this.messages.add({
         severity: 'warn',
-        summary: 'Missing details',
-        detail: 'Enter your name and a username of at least 3 characters.',
+        summary: 'Username too short',
+        detail: 'Pick a username of at least 3 characters.',
       });
       return;
     }
 
     this.loading.set(true);
     try {
-      await this.auth.register({
-        name,
-        username,
-        email: this.email.trim() || undefined,
-      });
+      await this.auth.register({ username });
       await this.router.navigate(['/groups']);
     } catch (error: any) {
       this.messages.add({

--- a/apps/split-frontend/src/environments/environment.prod.ts
+++ b/apps/split-frontend/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: 'https://split-api.elliott.haus',
+};

--- a/apps/split-frontend/src/environments/environment.ts
+++ b/apps/split-frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: 'http://localhost:3000',
+};

--- a/apps/split-frontend/src/index.html
+++ b/apps/split-frontend/src/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Split</title>
+    <base href="/" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#1b9e77" />
+    <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <app-root></app-root>
+  </body>
+</html>

--- a/apps/split-frontend/src/main.ts
+++ b/apps/split-frontend/src/main.ts
@@ -1,0 +1,7 @@
+import { bootstrapApplication } from '@angular/platform-browser';
+import { appConfig } from './app/app.config';
+import { AppComponent } from './app/app.component';
+
+bootstrapApplication(AppComponent, appConfig).catch((err) =>
+  console.error(err)
+);

--- a/apps/split-frontend/src/styles.scss
+++ b/apps/split-frontend/src/styles.scss
@@ -1,0 +1,140 @@
+// ── PrimeIcons ──
+@import 'primeicons/primeicons.css';
+
+// ── Design tokens ──
+:root {
+  --brand: #1b9e77;
+  --brand-dark: #157a5c;
+  --brand-light: #e7f6f1;
+  --owed: #1b9e77; // you are owed (green/positive)
+  --owe: #e8643c; // you owe (orange/negative)
+
+  --bg-page: #f5f6f8;
+  --bg-surface: #ffffff;
+  --bg-subtle: #f0f1f4;
+  --text-primary: #1f2430;
+  --text-secondary: #6b7280;
+  --text-muted: #9aa1ad;
+  --border: #e6e8ec;
+
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 18px;
+  --shadow-sm: 0 1px 2px rgba(16, 24, 40, 0.06);
+  --shadow-md: 0 4px 16px rgba(16, 24, 40, 0.08);
+
+  --header-height: 56px;
+  --bottom-nav-height: 60px;
+  --content-max-width: 720px;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  background: var(--bg-page);
+  color: var(--text-primary);
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-size: 15px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: var(--brand);
+  text-decoration: none;
+}
+
+// ── Scrollbars ──
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-thumb {
+  background: #d3d7df;
+  border-radius: 4px;
+}
+
+// ── Shared utility classes ──
+.amount-positive {
+  color: var(--owed);
+}
+.amount-negative {
+  color: var(--owe);
+}
+
+.muted {
+  color: var(--text-secondary);
+}
+
+.page {
+  padding: 16px;
+  max-width: var(--content-max-width);
+  margin: 0 auto;
+  width: 100%;
+}
+
+.section-title {
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-muted);
+  margin: 18px 4px 8px;
+}
+
+.card {
+  background: var(--bg-surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 48px 24px;
+  color: var(--text-secondary);
+
+  i {
+    font-size: 40px;
+    color: var(--text-muted);
+    margin-bottom: 12px;
+    display: block;
+  }
+}
+
+// ── PrimeNG overrides to match the brand ──
+:root {
+  --p-primary-color: var(--brand);
+  --p-primary-500: var(--brand);
+  --p-primary-600: var(--brand-dark);
+}
+
+.p-button {
+  font-weight: 600;
+}
+
+// Floating action button used to add expenses
+.fab {
+  position: fixed;
+  right: 18px;
+  bottom: calc(var(--bottom-nav-height) + 18px);
+  z-index: 50;
+}
+
+@media (min-width: 768px) {
+  .fab {
+    bottom: 28px;
+    right: calc(50% - var(--content-max-width) / 2 + 18px);
+  }
+}

--- a/apps/split-frontend/tsconfig.app.json
+++ b/apps/split-frontend/tsconfig.app.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "types": [],
+    "moduleResolution": "bundler"
+  },
+  "files": ["src/main.ts"],
+  "include": ["src/**/*.d.ts"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/apps/split-frontend/tsconfig.json
+++ b/apps/split-frontend/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": false,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/apps/split/Dockerfile
+++ b/apps/split/Dockerfile
@@ -1,0 +1,27 @@
+# Runtime-only Docker image for the pre-built split backend
+FROM docker.io/node:lts-alpine
+
+ENV HOST=0.0.0.0
+ENV PORT=3000
+ENV CI=true
+
+WORKDIR /app
+
+# Build tooling for any native modules (e.g. pg native bindings)
+RUN apk add --no-cache python3 make g++ libc6-compat
+
+# Create non-root user
+RUN addgroup --system server && \
+    adduser --system -G server server
+
+# Copy the pre-built application
+COPY --chown=server:server dist/apps/split ./
+
+# Install runtime dependencies
+RUN npm install --omit=dev
+
+USER server
+
+EXPOSE 3000
+
+CMD ["node", "main.js"]

--- a/apps/split/project.json
+++ b/apps/split/project.json
@@ -1,0 +1,73 @@
+{
+  "name": "split",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "apps/split/src",
+  "projectType": "application",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/esbuild:esbuild",
+      "outputs": ["{options.outputPath}"],
+      "defaultConfiguration": "production",
+      "options": {
+        "platform": "node",
+        "outputPath": "dist/apps/split",
+        "format": ["esm"],
+        "bundle": true,
+        "main": "apps/split/src/main.ts",
+        "tsConfig": "apps/split/tsconfig.app.json",
+        "assets": ["apps/split/src/assets"],
+        "generatePackageJson": true,
+        "esbuildOptions": {
+          "sourcemap": true,
+          "outExtension": {
+            ".js": ".js"
+          }
+        }
+      },
+      "configurations": {
+        "development": {
+          "thirdParty": false
+        },
+        "production": {
+          "generateLockfile": true,
+          "thirdParty": false,
+          "esbuildOptions": {
+            "sourcemap": false,
+            "bundle": true,
+            "outExtension": {
+              ".js": ".js"
+            }
+          }
+        }
+      }
+    },
+    "serve": {
+      "continuous": true,
+      "executor": "@nx/js:node",
+      "defaultConfiguration": "development",
+      "dependsOn": ["build"],
+      "options": {
+        "buildTarget": "split:build",
+        "runBuildTargetDependencies": false
+      },
+      "configurations": {
+        "development": {
+          "buildTarget": "split:build:development"
+        },
+        "production": {
+          "buildTarget": "split:build:production"
+        }
+      }
+    },
+    "container": {
+      "dependsOn": ["build"],
+      "executor": "./tools/executors/deploy:container",
+      "options": {
+        "image": "ethanelliottio/split",
+        "dockerfile": "apps/split/Dockerfile",
+        "deployment": "split"
+      }
+    }
+  }
+}

--- a/apps/split/src/app/app.config.ts
+++ b/apps/split/src/app/app.config.ts
@@ -1,0 +1,5 @@
+import { AppConfig } from '@ee/starter';
+
+export const appConfig: AppConfig = {
+  providers: [],
+};

--- a/apps/split/src/app/app.ts
+++ b/apps/split/src/app/app.ts
@@ -1,0 +1,18 @@
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { UsersRouter } from './users/users.router';
+import { SplitRouter } from './split/split.router';
+
+// Import entity registrations so TypeORM knows about them.
+import './users/user';
+import './split';
+
+export async function Application(fastify: FastifyInstance) {
+  fastify
+    .withTypeProvider<ZodTypeProvider>()
+    .register(UsersRouter, { prefix: '/users' });
+
+  fastify
+    .withTypeProvider<ZodTypeProvider>()
+    .register(SplitRouter, { prefix: '/split' });
+}

--- a/apps/split/src/app/data-source.ts
+++ b/apps/split/src/app/data-source.ts
@@ -1,0 +1,52 @@
+import { createToken, inject, Class } from '@ee/di';
+import { DataSource, ObjectLiteral } from 'typeorm';
+// Ensure the native postgres driver is bundled in the build output
+import 'pg';
+
+export const ENTITIES = createToken<Class<any>>('entities', {
+  multi: true,
+});
+
+export class Database {
+  private readonly _entities = inject(ENTITIES);
+
+  dataSource = new DataSource({
+    type: 'postgres',
+    host: process.env.DB_HOST || 'localhost',
+    port: parseInt(process.env.DB_PORT || '5432', 10),
+    username: process.env.DB_USER || 'split',
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME || 'split',
+    synchronize: true,
+    entities: this._entities,
+  });
+
+  constructor() {
+    this.dataSource
+      .initialize()
+      .then(() => {
+        console.log(
+          `📊 Registered entities: ${this._entities
+            .map((e) => e.name)
+            .join(', ')}`
+        );
+      })
+      .catch((error) => {
+        console.error('❌ Database initialization failed:', error);
+        process.exit(1);
+      });
+  }
+
+  repositoryFor<T extends ObjectLiteral>(entity: Class<T>) {
+    return this.dataSource.getRepository(entity);
+  }
+
+  async healthCheck(): Promise<boolean> {
+    try {
+      await this.dataSource.query('SELECT 1');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/apps/split/src/app/split/balances.service.ts
+++ b/apps/split/src/app/split/balances.service.ts
@@ -1,0 +1,135 @@
+import { inject } from '@ee/di';
+import { Database } from '../data-source';
+import { User } from '../users/user';
+import { Expense } from './expense.entity';
+import { Group, GroupMember } from './group.entity';
+import { Settlement } from './settlement.entity';
+import { toPublicUser } from './mappers';
+import { GroupBalancesOut } from './split.types';
+
+export class BalancesService {
+  private readonly _expenseRepository = inject(Database).repositoryFor(Expense);
+  private readonly _settlementRepository =
+    inject(Database).repositoryFor(Settlement);
+  private readonly _memberRepository =
+    inject(Database).repositoryFor(GroupMember);
+
+  /**
+   * Compute each member's net balance (in cents) for a group.
+   * Positive => the group owes them; negative => they owe the group.
+   */
+  async computeNet(groupId: string): Promise<Map<string, number>> {
+    const net = new Map<string, number>();
+
+    const add = (userId: string, delta: number) => {
+      net.set(userId, (net.get(userId) ?? 0) + delta);
+    };
+
+    // Ensure every current member appears, even with a zero balance.
+    const members = await this._memberRepository.find({
+      where: { group: { id: groupId } },
+    });
+    for (const member of members) {
+      net.set(member.user.id, 0);
+    }
+
+    const expenses = await this._expenseRepository.find({
+      where: { group: { id: groupId } },
+    });
+    for (const expense of expenses) {
+      add(expense.paidBy.id, expense.amountCents);
+      for (const split of expense.splits ?? []) {
+        add(split.user.id, -split.amountCents);
+      }
+    }
+
+    const settlements = await this._settlementRepository.find({
+      where: { group: { id: groupId } },
+    });
+    for (const settlement of settlements) {
+      add(settlement.fromUser.id, settlement.amountCents);
+      add(settlement.toUser.id, -settlement.amountCents);
+    }
+
+    return net;
+  }
+
+  /**
+   * Greedily reduce a set of net balances into a minimal list of
+   * "who pays whom" transactions.
+   */
+  simplifyDebts(
+    net: Map<string, number>
+  ): Array<{ fromUserId: string; toUserId: string; amountCents: number }> {
+    const debtors: Array<{ id: string; amount: number }> = [];
+    const creditors: Array<{ id: string; amount: number }> = [];
+
+    for (const [id, amount] of net.entries()) {
+      if (amount < 0) debtors.push({ id, amount: -amount });
+      else if (amount > 0) creditors.push({ id, amount });
+    }
+
+    debtors.sort((a, b) => b.amount - a.amount);
+    creditors.sort((a, b) => b.amount - a.amount);
+
+    const result: Array<{
+      fromUserId: string;
+      toUserId: string;
+      amountCents: number;
+    }> = [];
+
+    let i = 0;
+    let j = 0;
+    while (i < debtors.length && j < creditors.length) {
+      const debtor = debtors[i];
+      const creditor = creditors[j];
+      const amount = Math.min(debtor.amount, creditor.amount);
+
+      if (amount > 0) {
+        result.push({
+          fromUserId: debtor.id,
+          toUserId: creditor.id,
+          amountCents: amount,
+        });
+      }
+
+      debtor.amount -= amount;
+      creditor.amount -= amount;
+
+      if (debtor.amount === 0) i++;
+      if (creditor.amount === 0) j++;
+    }
+
+    return result;
+  }
+
+  async getGroupBalances(group: Group): Promise<GroupBalancesOut> {
+    const net = await this.computeNet(group.id);
+
+    const members = await this._memberRepository.find({
+      where: { group: { id: group.id } },
+    });
+    const userById = new Map<string, User>();
+    for (const member of members) {
+      userById.set(member.user.id, member.user);
+    }
+
+    const balances = [...net.entries()]
+      .filter(([id]) => userById.has(id))
+      .map(([id, netCents]) => ({
+        user: toPublicUser(userById.get(id)!),
+        netCents,
+      }))
+      .sort((a, b) => b.netCents - a.netCents);
+
+    const debts = this.simplifyDebts(net)
+      .filter((debt) => userById.has(debt.fromUserId) && userById.has(debt.toUserId))
+      .map((debt) => ({
+        from: toPublicUser(userById.get(debt.fromUserId)!),
+        to: toPublicUser(userById.get(debt.toUserId)!),
+        amountCents: debt.amountCents,
+      }));
+
+    return { currency: group.currency, balances, debts };
+  }
+}

--- a/apps/split/src/app/split/expense.entity.ts
+++ b/apps/split/src/app/split/expense.entity.ts
@@ -1,0 +1,87 @@
+import { provide } from '@ee/di';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ENTITIES } from '../data-source';
+import { User } from '../users/user';
+import { Group } from './group.entity';
+
+export type SplitType = 'equal' | 'exact' | 'percentage';
+
+/**
+ * An expense within a group. All monetary values are stored as integer cents
+ * to avoid floating-point rounding issues.
+ */
+@Entity()
+export class Expense {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Group, { onDelete: 'CASCADE', eager: true })
+  group!: Group;
+
+  @Column('text')
+  description!: string;
+
+  @Column('integer')
+  amountCents!: number;
+
+  @Column('text', { default: 'CAD' })
+  currency!: string;
+
+  @Column('text', { nullable: true })
+  category?: string;
+
+  // The member who paid for the expense
+  @ManyToOne(() => User, { onDelete: 'CASCADE', eager: true })
+  paidBy!: User;
+
+  @ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true })
+  createdBy?: User;
+
+  @Column('text', { default: 'equal' })
+  splitType!: SplitType;
+
+  @Column('timestamp')
+  date!: Date;
+
+  @OneToMany(() => ExpenseSplit, (s) => s.expense, {
+    cascade: true,
+    eager: true,
+    orphanedRowAction: 'delete',
+  })
+  splits!: ExpenseSplit[];
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}
+
+/**
+ * How much a single member owes for a given expense (their share).
+ */
+@Entity()
+export class ExpenseSplit {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Expense, (e) => e.splits, { onDelete: 'CASCADE' })
+  expense!: Expense;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE', eager: true })
+  user!: User;
+
+  @Column('integer')
+  amountCents!: number;
+}
+
+provide(ENTITIES, Expense);
+provide(ENTITIES, ExpenseSplit);

--- a/apps/split/src/app/split/expenses.service.ts
+++ b/apps/split/src/app/split/expenses.service.ts
@@ -1,0 +1,239 @@
+import { inject } from '@ee/di';
+import HttpErrors from 'http-errors';
+import { Database } from '../data-source';
+import { UsersService } from '../users/users.service';
+import { Expense, ExpenseSplit, SplitType } from './expense.entity';
+import { GroupMember } from './group.entity';
+import { GroupsService } from './groups.service';
+import { toExpenseDto } from './mappers';
+import {
+  CreateExpenseInput,
+  ExpenseOut,
+  ExpenseSplitInputSchema,
+} from './split.types';
+import { z } from 'zod';
+
+type SplitInput = z.infer<typeof ExpenseSplitInputSchema>;
+
+export class ExpensesService {
+  private readonly _expenseRepository = inject(Database).repositoryFor(Expense);
+  private readonly _memberRepository =
+    inject(Database).repositoryFor(GroupMember);
+  private readonly _groupsService = inject(GroupsService);
+  private readonly _usersService = inject(UsersService);
+
+  /**
+   * Turn the requested split into a concrete list of integer-cent shares that
+   * sums exactly to `totalCents`. Any rounding remainder is distributed one
+   * cent at a time across the participants.
+   */
+  private computeShares(
+    totalCents: number,
+    splitType: SplitType,
+    splits: SplitInput[]
+  ): Array<{ userId: string; amountCents: number }> {
+    if (splits.length === 0) {
+      throw new HttpErrors.BadRequest('At least one participant is required');
+    }
+
+    const shares: Array<{ userId: string; amountCents: number }> = [];
+
+    if (splitType === 'equal') {
+      const base = Math.floor(totalCents / splits.length);
+      let remainder = totalCents - base * splits.length;
+      for (const split of splits) {
+        const extra = remainder > 0 ? 1 : 0;
+        remainder -= extra;
+        shares.push({ userId: split.userId, amountCents: base + extra });
+      }
+      return shares;
+    }
+
+    if (splitType === 'exact') {
+      let sum = 0;
+      for (const split of splits) {
+        const cents = Math.round((split.value ?? 0) * 100);
+        sum += cents;
+        shares.push({ userId: split.userId, amountCents: cents });
+      }
+      if (sum !== totalCents) {
+        throw new HttpErrors.BadRequest(
+          `Exact split shares (${sum} cents) must sum to the total (${totalCents} cents)`
+        );
+      }
+      return shares;
+    }
+
+    // percentage
+    const totalPct = splits.reduce((acc, s) => acc + (s.value ?? 0), 0);
+    if (Math.round(totalPct) !== 100) {
+      throw new HttpErrors.BadRequest('Percentages must add up to 100');
+    }
+    let allocated = 0;
+    splits.forEach((split, index) => {
+      const isLast = index === splits.length - 1;
+      const cents = isLast
+        ? totalCents - allocated
+        : Math.round(((split.value ?? 0) / 100) * totalCents);
+      allocated += cents;
+      shares.push({ userId: split.userId, amountCents: cents });
+    });
+    return shares;
+  }
+
+  private async assertUsersAreMembers(groupId: string, userIds: string[]) {
+    const members = await this._memberRepository.find({
+      where: { group: { id: groupId } },
+    });
+    const memberIds = new Set(members.map((m) => m.user.id));
+    for (const id of userIds) {
+      if (!memberIds.has(id)) {
+        throw new HttpErrors.BadRequest(
+          'All participants and the payer must be members of the group'
+        );
+      }
+    }
+  }
+
+  async list(groupId: string, userId: string): Promise<ExpenseOut[]> {
+    await this._groupsService.assertMember(groupId, userId);
+    const expenses = await this._expenseRepository.find({
+      where: { group: { id: groupId } },
+      order: { date: 'DESC', createdAt: 'DESC' },
+    });
+    return expenses.map(toExpenseDto);
+  }
+
+  async getById(expenseId: string, userId: string): Promise<ExpenseOut> {
+    const expense = await this._expenseRepository.findOne({
+      where: { id: expenseId },
+    });
+    if (!expense) {
+      throw new HttpErrors.NotFound('Expense not found');
+    }
+    await this._groupsService.assertMember(expense.group.id, userId);
+    return toExpenseDto(expense);
+  }
+
+  async create(
+    groupId: string,
+    userId: string,
+    input: CreateExpenseInput
+  ): Promise<ExpenseOut> {
+    const group = await this._groupsService.assertMember(groupId, userId);
+
+    const totalCents = Math.round(input.amount * 100);
+    const participantIds = input.splits.map((s) => s.userId);
+    await this.assertUsersAreMembers(groupId, [
+      input.paidByUserId,
+      ...participantIds,
+    ]);
+
+    const shares = this.computeShares(totalCents, input.splitType, input.splits);
+
+    const creator = await this._usersService.findEntityById(userId);
+
+    const expense = this._expenseRepository.create({
+      group,
+      description: input.description,
+      amountCents: totalCents,
+      currency: input.currency || group.currency,
+      category: input.category,
+      paidBy: { id: input.paidByUserId } as any,
+      createdBy: creator ?? undefined,
+      splitType: input.splitType,
+      date: input.date ? new Date(input.date) : new Date(),
+      splits: shares.map(
+        (share) =>
+          ({
+            user: { id: share.userId } as any,
+            amountCents: share.amountCents,
+          } as ExpenseSplit)
+      ),
+    });
+
+    const saved = await this._expenseRepository.save(expense);
+    return this.getById(saved.id, userId);
+  }
+
+  async update(
+    expenseId: string,
+    userId: string,
+    input: CreateExpenseInput
+  ): Promise<ExpenseOut> {
+    const existing = await this._expenseRepository.findOne({
+      where: { id: expenseId },
+    });
+    if (!existing) {
+      throw new HttpErrors.NotFound('Expense not found');
+    }
+    const groupId = existing.group.id;
+    await this._groupsService.assertMember(groupId, userId);
+
+    const totalCents = Math.round(input.amount * 100);
+    const participantIds = input.splits.map((s) => s.userId);
+    await this.assertUsersAreMembers(groupId, [
+      input.paidByUserId,
+      ...participantIds,
+    ]);
+    const shares = this.computeShares(totalCents, input.splitType, input.splits);
+
+    existing.description = input.description;
+    existing.amountCents = totalCents;
+    existing.currency = input.currency || existing.currency;
+    existing.category = input.category;
+    existing.paidBy = { id: input.paidByUserId } as any;
+    existing.splitType = input.splitType;
+    existing.date = input.date ? new Date(input.date) : existing.date;
+    // Replacing splits: orphaned rows are removed via cascade + orphan handling.
+    existing.splits = shares.map(
+      (share) =>
+        ({
+          user: { id: share.userId } as any,
+          amountCents: share.amountCents,
+        } as ExpenseSplit)
+    );
+
+    const saved = await this._expenseRepository.save(existing);
+    return this.getById(saved.id, userId);
+  }
+
+  async remove(expenseId: string, userId: string) {
+    const expense = await this._expenseRepository.findOne({
+      where: { id: expenseId },
+    });
+    if (!expense) {
+      throw new HttpErrors.NotFound('Expense not found');
+    }
+    await this._groupsService.assertMember(expense.group.id, userId);
+    await this._expenseRepository.delete(expenseId);
+    return { success: true };
+  }
+
+  /** Recent expenses across all of the user's groups. */
+  async activityForUser(userId: string, limit = 30) {
+    const memberships = await this._memberRepository.find({
+      where: { user: { id: userId } },
+      relations: { group: true },
+    });
+    const groupIds = memberships.map((m) => m.group.id);
+    if (groupIds.length === 0) return [];
+
+    const expenses = await this._expenseRepository
+      .createQueryBuilder('expense')
+      .leftJoinAndSelect('expense.group', 'group')
+      .leftJoinAndSelect('expense.paidBy', 'paidBy')
+      .leftJoinAndSelect('expense.splits', 'splits')
+      .leftJoinAndSelect('splits.user', 'splitUser')
+      .where('group.id IN (:...groupIds)', { groupIds })
+      .orderBy('expense.date', 'DESC')
+      .addOrderBy('expense.createdAt', 'DESC')
+      .take(limit)
+      .getMany();
+
+    return expenses.map((expense) => ({
+      expense: toExpenseDto(expense),
+      groupName: expense.group.name,
+    }));
+  }
+}

--- a/apps/split/src/app/split/group.entity.ts
+++ b/apps/split/src/app/split/group.entity.ts
@@ -1,0 +1,63 @@
+import { provide } from '@ee/di';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { ENTITIES } from '../data-source';
+import { User } from '../users/user';
+
+@Entity()
+export class Group {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column('text')
+  name!: string;
+
+  @Column('text', { nullable: true })
+  description?: string;
+
+  // Free-form group type / emoji like Split (trip, home, couple, other)
+  @Column('text', { default: 'other' })
+  type!: string;
+
+  @Column('text', { default: 'CAD' })
+  currency!: string;
+
+  @ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true, eager: true })
+  createdBy?: User;
+
+  @OneToMany(() => GroupMember, (m) => m.group)
+  members!: GroupMember[];
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}
+
+@Entity()
+@Index(['group', 'user'], { unique: true })
+export class GroupMember {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Group, (g) => g.members, { onDelete: 'CASCADE' })
+  group!: Group;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE', eager: true })
+  user!: User;
+
+  @CreateDateColumn()
+  joinedAt!: Date;
+}
+
+provide(ENTITIES, Group);
+provide(ENTITIES, GroupMember);

--- a/apps/split/src/app/split/groups.service.ts
+++ b/apps/split/src/app/split/groups.service.ts
@@ -1,0 +1,177 @@
+import { inject } from '@ee/di';
+import HttpErrors from 'http-errors';
+import { Database } from '../data-source';
+import { UsersService } from '../users/users.service';
+import { BalancesService } from './balances.service';
+import { Group, GroupMember } from './group.entity';
+import { toGroupDto, toGroupMemberDto } from './mappers';
+import {
+  CreateGroupInput,
+  GroupSummaryOut,
+  UpdateGroupInput,
+} from './split.types';
+
+export class GroupsService {
+  private readonly _groupRepository = inject(Database).repositoryFor(Group);
+  private readonly _memberRepository =
+    inject(Database).repositoryFor(GroupMember);
+  private readonly _usersService = inject(UsersService);
+  private readonly _balancesService = inject(BalancesService);
+
+  /** Throw unless the user is a member of the group; returns the group. */
+  async assertMember(groupId: string, userId: string): Promise<Group> {
+    const group = await this._groupRepository.findOne({
+      where: { id: groupId },
+    });
+    if (!group) {
+      throw new HttpErrors.NotFound('Group not found');
+    }
+    const membership = await this._memberRepository.findOne({
+      where: { group: { id: groupId }, user: { id: userId } },
+    });
+    if (!membership) {
+      throw new HttpErrors.Forbidden('You are not a member of this group');
+    }
+    return group;
+  }
+
+  private async loadMembers(groupId: string): Promise<GroupMember[]> {
+    return this._memberRepository.find({
+      where: { group: { id: groupId } },
+      order: { joinedAt: 'ASC' },
+    });
+  }
+
+  async listForUser(userId: string): Promise<GroupSummaryOut[]> {
+    const memberships = await this._memberRepository.find({
+      where: { user: { id: userId } },
+      relations: { group: true },
+    });
+
+    const summaries: GroupSummaryOut[] = [];
+    for (const membership of memberships) {
+      const group = await this._groupRepository.findOne({
+        where: { id: membership.group.id },
+      });
+      if (!group) continue;
+
+      const members = await this.loadMembers(group.id);
+      const net = await this._balancesService.computeNet(group.id);
+
+      summaries.push({
+        id: group.id,
+        name: group.name,
+        description: group.description ?? null,
+        type: group.type,
+        currency: group.currency,
+        memberCount: members.length,
+        members: members.map(toGroupMemberDto),
+        yourBalanceCents: net.get(userId) ?? 0,
+        updatedAt: group.updatedAt,
+      });
+    }
+
+    summaries.sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime());
+    return summaries;
+  }
+
+  async getById(groupId: string, userId: string) {
+    const group = await this.assertMember(groupId, userId);
+    const members = await this.loadMembers(groupId);
+    return toGroupDto(group, members);
+  }
+
+  async create(userId: string, input: CreateGroupInput) {
+    const creator = await this._usersService.findEntityById(userId);
+    if (!creator) {
+      throw new HttpErrors.Unauthorized('User not found');
+    }
+
+    const group = await this._groupRepository.save(
+      this._groupRepository.create({
+        name: input.name,
+        description: input.description,
+        type: input.type,
+        currency: input.currency,
+        createdBy: creator,
+      })
+    );
+
+    // Always add the creator as a member.
+    await this.addMemberEntity(group, creator.id);
+
+    // Add any requested members by username (ignore unknown/duplicate).
+    for (const username of input.memberUsernames ?? []) {
+      const user = await this._usersService.findEntityByUsername(username);
+      if (user && user.id !== creator.id) {
+        await this.addMemberEntity(group, user.id);
+      }
+    }
+
+    const members = await this.loadMembers(group.id);
+    return toGroupDto(group, members);
+  }
+
+  async update(groupId: string, userId: string, input: UpdateGroupInput) {
+    await this.assertMember(groupId, userId);
+    await this._groupRepository.update(groupId, input);
+    const group = await this._groupRepository.findOneByOrFail({ id: groupId });
+    const members = await this.loadMembers(groupId);
+    return toGroupDto(group, members);
+  }
+
+  async remove(groupId: string, userId: string) {
+    await this.assertMember(groupId, userId);
+    await this._groupRepository.delete(groupId);
+    return { success: true };
+  }
+
+  private async addMemberEntity(group: Group, userId: string) {
+    const existing = await this._memberRepository.findOne({
+      where: { group: { id: group.id }, user: { id: userId } },
+    });
+    if (existing) return existing;
+    return this._memberRepository.save(
+      this._memberRepository.create({
+        group,
+        user: { id: userId } as any,
+      })
+    );
+  }
+
+  async addMember(groupId: string, userId: string, username: string) {
+    const group = await this.assertMember(groupId, userId);
+    const user = await this._usersService.findEntityByUsername(username);
+    if (!user) {
+      throw new HttpErrors.NotFound(`No user with username "${username}"`);
+    }
+    await this.addMemberEntity(group, user.id);
+    const members = await this.loadMembers(groupId);
+    return toGroupDto(group, members);
+  }
+
+  async removeMember(groupId: string, userId: string, memberUserId: string) {
+    await this.assertMember(groupId, userId);
+
+    const net = await this._balancesService.computeNet(groupId);
+    if ((net.get(memberUserId) ?? 0) !== 0) {
+      throw new HttpErrors.BadRequest(
+        'Cannot remove a member who still has a non-zero balance'
+      );
+    }
+
+    await this._memberRepository.delete({
+      group: { id: groupId },
+      user: { id: memberUserId },
+    });
+
+    const group = await this._groupRepository.findOneByOrFail({ id: groupId });
+    const members = await this.loadMembers(groupId);
+    return toGroupDto(group, members);
+  }
+
+  async getBalances(groupId: string, userId: string) {
+    const group = await this.assertMember(groupId, userId);
+    return this._balancesService.getGroupBalances(group);
+  }
+}

--- a/apps/split/src/app/split/index.ts
+++ b/apps/split/src/app/split/index.ts
@@ -1,0 +1,4 @@
+// Importing this module registers all Split entities with TypeORM.
+import './group.entity';
+import './expense.entity';
+import './settlement.entity';

--- a/apps/split/src/app/split/mappers.ts
+++ b/apps/split/src/app/split/mappers.ts
@@ -1,0 +1,65 @@
+import { PublicUser, User } from '../users/user';
+import { Expense } from './expense.entity';
+import { Group, GroupMember } from './group.entity';
+import { Settlement } from './settlement.entity';
+import { ExpenseOut, SettlementOut } from './split.types';
+
+export function toPublicUser(user: User): PublicUser {
+  return { id: user.id, name: user.name, username: user.username };
+}
+
+export function toGroupMemberDto(member: GroupMember) {
+  return {
+    id: member.id,
+    user: toPublicUser(member.user),
+    joinedAt: member.joinedAt,
+  };
+}
+
+export function toGroupDto(group: Group, members: GroupMember[]) {
+  return {
+    id: group.id,
+    name: group.name,
+    description: group.description ?? null,
+    type: group.type,
+    currency: group.currency,
+    createdBy: group.createdBy ? toPublicUser(group.createdBy) : null,
+    members: members.map(toGroupMemberDto),
+    createdAt: group.createdAt,
+    updatedAt: group.updatedAt,
+  };
+}
+
+export function toExpenseDto(expense: Expense): ExpenseOut {
+  return {
+    id: expense.id,
+    groupId: expense.group.id,
+    description: expense.description,
+    amountCents: expense.amountCents,
+    currency: expense.currency,
+    category: expense.category ?? null,
+    paidBy: toPublicUser(expense.paidBy),
+    splitType: expense.splitType,
+    date: expense.date,
+    splits: (expense.splits ?? []).map((s) => ({
+      id: s.id,
+      user: toPublicUser(s.user),
+      amountCents: s.amountCents,
+    })),
+    createdAt: expense.createdAt,
+  };
+}
+
+export function toSettlementDto(settlement: Settlement): SettlementOut {
+  return {
+    id: settlement.id,
+    groupId: settlement.group.id,
+    fromUser: toPublicUser(settlement.fromUser),
+    toUser: toPublicUser(settlement.toUser),
+    amountCents: settlement.amountCents,
+    currency: settlement.currency,
+    note: settlement.note ?? null,
+    date: settlement.date,
+    createdAt: settlement.createdAt,
+  };
+}

--- a/apps/split/src/app/split/overview.service.ts
+++ b/apps/split/src/app/split/overview.service.ts
@@ -1,0 +1,35 @@
+import { inject } from '@ee/di';
+import { Database } from '../data-source';
+import { BalancesService } from './balances.service';
+import { GroupMember } from './group.entity';
+import { OverviewOut } from './split.types';
+
+export class OverviewService {
+  private readonly _memberRepository =
+    inject(Database).repositoryFor(GroupMember);
+  private readonly _balancesService = inject(BalancesService);
+
+  async forUser(userId: string): Promise<OverviewOut> {
+    const memberships = await this._memberRepository.find({
+      where: { user: { id: userId } },
+      relations: { group: true },
+    });
+
+    let youAreOwedCents = 0;
+    let youOweCents = 0;
+
+    for (const membership of memberships) {
+      const net = await this._balancesService.computeNet(membership.group.id);
+      const balance = net.get(userId) ?? 0;
+      if (balance > 0) youAreOwedCents += balance;
+      else if (balance < 0) youOweCents += -balance;
+    }
+
+    return {
+      currency: 'CAD',
+      youAreOwedCents,
+      youOweCents,
+      netCents: youAreOwedCents - youOweCents,
+    };
+  }
+}

--- a/apps/split/src/app/split/settlement.entity.ts
+++ b/apps/split/src/app/split/settlement.entity.ts
@@ -1,0 +1,50 @@
+import { provide } from '@ee/di';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ENTITIES } from '../data-source';
+import { User } from '../users/user';
+import { Group } from './group.entity';
+
+/**
+ * A payment from one member to another to settle up a debt.
+ * Amount stored as integer cents.
+ */
+@Entity()
+export class Settlement {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Group, { onDelete: 'CASCADE', eager: true })
+  group!: Group;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE', eager: true })
+  fromUser!: User;
+
+  @ManyToOne(() => User, { onDelete: 'CASCADE', eager: true })
+  toUser!: User;
+
+  @Column('integer')
+  amountCents!: number;
+
+  @Column('text', { default: 'CAD' })
+  currency!: string;
+
+  @Column('text', { nullable: true })
+  note?: string;
+
+  @Column('timestamp')
+  date!: Date;
+
+  @ManyToOne(() => User, { onDelete: 'SET NULL', nullable: true })
+  createdBy?: User;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}
+
+provide(ENTITIES, Settlement);

--- a/apps/split/src/app/split/settlements.service.ts
+++ b/apps/split/src/app/split/settlements.service.ts
@@ -1,0 +1,78 @@
+import { inject } from '@ee/di';
+import HttpErrors from 'http-errors';
+import { Database } from '../data-source';
+import { UsersService } from '../users/users.service';
+import { GroupMember } from './group.entity';
+import { GroupsService } from './groups.service';
+import { toSettlementDto } from './mappers';
+import { Settlement } from './settlement.entity';
+import { CreateSettlementInput, SettlementOut } from './split.types';
+
+export class SettlementsService {
+  private readonly _settlementRepository =
+    inject(Database).repositoryFor(Settlement);
+  private readonly _memberRepository =
+    inject(Database).repositoryFor(GroupMember);
+  private readonly _groupsService = inject(GroupsService);
+  private readonly _usersService = inject(UsersService);
+
+  async list(groupId: string, userId: string): Promise<SettlementOut[]> {
+    await this._groupsService.assertMember(groupId, userId);
+    const settlements = await this._settlementRepository.find({
+      where: { group: { id: groupId } },
+      order: { date: 'DESC', createdAt: 'DESC' },
+    });
+    return settlements.map(toSettlementDto);
+  }
+
+  async create(
+    groupId: string,
+    userId: string,
+    input: CreateSettlementInput
+  ): Promise<SettlementOut> {
+    const group = await this._groupsService.assertMember(groupId, userId);
+
+    if (input.fromUserId === input.toUserId) {
+      throw new HttpErrors.BadRequest('Payer and recipient must differ');
+    }
+
+    const members = await this._memberRepository.find({
+      where: { group: { id: groupId } },
+    });
+    const memberIds = new Set(members.map((m) => m.user.id));
+    if (!memberIds.has(input.fromUserId) || !memberIds.has(input.toUserId)) {
+      throw new HttpErrors.BadRequest('Both users must be members of the group');
+    }
+
+    const creator = await this._usersService.findEntityById(userId);
+
+    const settlement = this._settlementRepository.create({
+      group,
+      fromUser: { id: input.fromUserId } as any,
+      toUser: { id: input.toUserId } as any,
+      amountCents: Math.round(input.amount * 100),
+      currency: input.currency || group.currency,
+      note: input.note,
+      date: input.date ? new Date(input.date) : new Date(),
+      createdBy: creator ?? undefined,
+    });
+
+    const saved = await this._settlementRepository.save(settlement);
+    const full = await this._settlementRepository.findOneByOrFail({
+      id: saved.id,
+    });
+    return toSettlementDto(full);
+  }
+
+  async remove(settlementId: string, userId: string) {
+    const settlement = await this._settlementRepository.findOne({
+      where: { id: settlementId },
+    });
+    if (!settlement) {
+      throw new HttpErrors.NotFound('Settlement not found');
+    }
+    await this._groupsService.assertMember(settlement.group.id, userId);
+    await this._settlementRepository.delete(settlementId);
+    return { success: true };
+  }
+}

--- a/apps/split/src/app/split/split.router.ts
+++ b/apps/split/src/app/split/split.router.ts
@@ -1,0 +1,343 @@
+import { inject } from '@ee/di';
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { ExpensesService } from './expenses.service';
+import { GroupsService } from './groups.service';
+import { OverviewService } from './overview.service';
+import { SettlementsService } from './settlements.service';
+import {
+  ActivityItemSchema,
+  AddMemberSchema,
+  CreateExpenseSchema,
+  CreateGroupSchema,
+  CreateSettlementSchema,
+  ExpenseSchema,
+  GroupBalancesSchema,
+  GroupSchema,
+  GroupSummarySchema,
+  OverviewSchema,
+  SettlementSchema,
+  UpdateGroupSchema,
+} from './split.types';
+
+const IdParams = z.object({ id: z.string().uuid() });
+const SuccessSchema = z.object({ success: z.boolean() });
+
+export async function SplitRouter(fastify: FastifyInstance) {
+  const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
+
+  // Every route in this module requires authentication.
+  fastify.addHook('preHandler', fastify.authenticate());
+
+  const _groups = inject(GroupsService);
+  const _expenses = inject(ExpensesService);
+  const _settlements = inject(SettlementsService);
+  const _overview = inject(OverviewService);
+
+  // ── Overview & activity ──────────────────────────────────────
+  typedFastify.get(
+    '/overview',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Aggregate balances across all of your groups',
+        response: { 200: OverviewSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _overview.forUser(request.currentUser.id))
+  );
+
+  typedFastify.get(
+    '/activity',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Recent expenses across all of your groups',
+        response: { 200: z.array(ActivityItemSchema) },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _expenses.activityForUser(request.currentUser.id))
+  );
+
+  // ── Groups ───────────────────────────────────────────────────
+  typedFastify.get(
+    '/groups',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'List groups you belong to',
+        response: { 200: z.array(GroupSummarySchema) },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _groups.listForUser(request.currentUser.id))
+  );
+
+  typedFastify.post(
+    '/groups',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Create a new group',
+        body: CreateGroupSchema,
+        response: { 201: GroupSchema },
+      },
+    },
+    async (request, reply) => {
+      const group = await _groups.create(request.currentUser.id, request.body);
+      return reply.code(201).send(group);
+    }
+  );
+
+  typedFastify.get(
+    '/groups/:id',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Get a single group',
+        params: IdParams,
+        response: { 200: GroupSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _groups.getById(request.params.id, request.currentUser.id))
+  );
+
+  typedFastify.put(
+    '/groups/:id',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Update a group',
+        params: IdParams,
+        body: UpdateGroupSchema,
+        response: { 200: GroupSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _groups.update(
+          request.params.id,
+          request.currentUser.id,
+          request.body
+        )
+      )
+  );
+
+  typedFastify.delete(
+    '/groups/:id',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Delete a group',
+        params: IdParams,
+        response: { 200: SuccessSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _groups.remove(request.params.id, request.currentUser.id))
+  );
+
+  typedFastify.get(
+    '/groups/:id/balances',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Get member balances and simplified debts for a group',
+        params: IdParams,
+        response: { 200: GroupBalancesSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _groups.getBalances(request.params.id, request.currentUser.id)
+      )
+  );
+
+  // ── Members ──────────────────────────────────────────────────
+  typedFastify.post(
+    '/groups/:id/members',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Add a member to a group by username',
+        params: IdParams,
+        body: AddMemberSchema,
+        response: { 200: GroupSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _groups.addMember(
+          request.params.id,
+          request.currentUser.id,
+          request.body.username
+        )
+      )
+  );
+
+  typedFastify.delete(
+    '/groups/:id/members/:userId',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Remove a member from a group',
+        params: z.object({
+          id: z.string().uuid(),
+          userId: z.string().uuid(),
+        }),
+        response: { 200: GroupSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _groups.removeMember(
+          request.params.id,
+          request.currentUser.id,
+          request.params.userId
+        )
+      )
+  );
+
+  // ── Expenses ─────────────────────────────────────────────────
+  typedFastify.get(
+    '/groups/:id/expenses',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'List expenses in a group',
+        params: IdParams,
+        response: { 200: z.array(ExpenseSchema) },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _expenses.list(request.params.id, request.currentUser.id))
+  );
+
+  typedFastify.post(
+    '/groups/:id/expenses',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Add an expense to a group',
+        params: IdParams,
+        body: CreateExpenseSchema,
+        response: { 201: ExpenseSchema },
+      },
+    },
+    async (request, reply) => {
+      const expense = await _expenses.create(
+        request.params.id,
+        request.currentUser.id,
+        request.body
+      );
+      return reply.code(201).send(expense);
+    }
+  );
+
+  typedFastify.get(
+    '/expenses/:id',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Get a single expense',
+        params: IdParams,
+        response: { 200: ExpenseSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _expenses.getById(request.params.id, request.currentUser.id))
+  );
+
+  typedFastify.put(
+    '/expenses/:id',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Update an expense',
+        params: IdParams,
+        body: CreateExpenseSchema,
+        response: { 200: ExpenseSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _expenses.update(
+          request.params.id,
+          request.currentUser.id,
+          request.body
+        )
+      )
+  );
+
+  typedFastify.delete(
+    '/expenses/:id',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Delete an expense',
+        params: IdParams,
+        response: { 200: SuccessSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _expenses.remove(request.params.id, request.currentUser.id))
+  );
+
+  // ── Settlements ──────────────────────────────────────────────
+  typedFastify.get(
+    '/groups/:id/settlements',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'List settlements (payments) in a group',
+        params: IdParams,
+        response: { 200: z.array(SettlementSchema) },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _settlements.list(request.params.id, request.currentUser.id)
+      )
+  );
+
+  typedFastify.post(
+    '/groups/:id/settlements',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Record a settlement payment between two members',
+        params: IdParams,
+        body: CreateSettlementSchema,
+        response: { 201: SettlementSchema },
+      },
+    },
+    async (request, reply) => {
+      const settlement = await _settlements.create(
+        request.params.id,
+        request.currentUser.id,
+        request.body
+      );
+      return reply.code(201).send(settlement);
+    }
+  );
+
+  typedFastify.delete(
+    '/settlements/:id',
+    {
+      schema: {
+        tags: ['Split'],
+        description: 'Delete a settlement',
+        params: IdParams,
+        response: { 200: SuccessSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _settlements.remove(request.params.id, request.currentUser.id)
+      )
+  );
+}

--- a/apps/split/src/app/split/split.types.ts
+++ b/apps/split/src/app/split/split.types.ts
@@ -1,0 +1,179 @@
+import { z } from 'zod';
+import { PublicUserSchema } from '../users/user';
+
+// ─────────────────────────────────────────────────────────────
+// Groups
+// ─────────────────────────────────────────────────────────────
+
+export const GroupMemberSchema = z.object({
+  id: z.string().uuid(),
+  user: PublicUserSchema,
+  joinedAt: z.date(),
+});
+
+export const GroupSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  type: z.string(),
+  currency: z.string(),
+  createdBy: PublicUserSchema.nullable().optional(),
+  members: z.array(GroupMemberSchema),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export const GroupSummarySchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  description: z.string().nullable().optional(),
+  type: z.string(),
+  currency: z.string(),
+  memberCount: z.number(),
+  members: z.array(GroupMemberSchema),
+  // The current user's net balance in this group, in cents.
+  // Positive => the group owes you; negative => you owe.
+  yourBalanceCents: z.number(),
+  updatedAt: z.date(),
+});
+
+export const CreateGroupSchema = z.object({
+  name: z.string().min(1).max(100),
+  description: z.string().max(500).optional(),
+  type: z.enum(['trip', 'home', 'couple', 'other']).default('other'),
+  currency: z.string().min(1).max(8).default('CAD'),
+  memberUsernames: z.array(z.string()).optional(),
+});
+
+export const UpdateGroupSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  description: z.string().max(500).optional(),
+  type: z.enum(['trip', 'home', 'couple', 'other']).optional(),
+  currency: z.string().min(1).max(8).optional(),
+});
+
+export const AddMemberSchema = z.object({
+  username: z.string().min(1),
+});
+
+// ─────────────────────────────────────────────────────────────
+// Expenses
+// ─────────────────────────────────────────────────────────────
+
+export const ExpenseSplitInputSchema = z.object({
+  userId: z.string().uuid(),
+  // Used when splitType is 'exact' (dollars) or 'percentage' (0-100).
+  value: z.number().nonnegative().optional(),
+});
+
+export const CreateExpenseSchema = z.object({
+  description: z.string().min(1).max(200),
+  // Amount in major units (e.g. dollars). Converted to cents server-side.
+  amount: z.number().positive(),
+  currency: z.string().min(1).max(8).default('CAD'),
+  category: z.string().max(50).optional(),
+  paidByUserId: z.string().uuid(),
+  date: z.string().datetime().optional(),
+  splitType: z.enum(['equal', 'exact', 'percentage']).default('equal'),
+  // The members to split between. For 'equal' only userId is needed.
+  splits: z.array(ExpenseSplitInputSchema).min(1),
+});
+
+export const UpdateExpenseSchema = CreateExpenseSchema.partial();
+
+export const ExpenseSplitSchema = z.object({
+  id: z.string().uuid(),
+  user: PublicUserSchema,
+  amountCents: z.number(),
+});
+
+export const ExpenseSchema = z.object({
+  id: z.string().uuid(),
+  groupId: z.string().uuid(),
+  description: z.string(),
+  amountCents: z.number(),
+  currency: z.string(),
+  category: z.string().nullable().optional(),
+  paidBy: PublicUserSchema,
+  splitType: z.string(),
+  date: z.date(),
+  splits: z.array(ExpenseSplitSchema),
+  createdAt: z.date(),
+});
+
+// ─────────────────────────────────────────────────────────────
+// Settlements
+// ─────────────────────────────────────────────────────────────
+
+export const CreateSettlementSchema = z.object({
+  fromUserId: z.string().uuid(),
+  toUserId: z.string().uuid(),
+  amount: z.number().positive(),
+  currency: z.string().min(1).max(8).default('CAD'),
+  note: z.string().max(200).optional(),
+  date: z.string().datetime().optional(),
+});
+
+export const SettlementSchema = z.object({
+  id: z.string().uuid(),
+  groupId: z.string().uuid(),
+  fromUser: PublicUserSchema,
+  toUser: PublicUserSchema,
+  amountCents: z.number(),
+  currency: z.string(),
+  note: z.string().nullable().optional(),
+  date: z.date(),
+  createdAt: z.date(),
+});
+
+// ─────────────────────────────────────────────────────────────
+// Balances
+// ─────────────────────────────────────────────────────────────
+
+export const MemberBalanceSchema = z.object({
+  user: PublicUserSchema,
+  // Net balance in cents. Positive => owed money; negative => owes money.
+  netCents: z.number(),
+});
+
+export const SimplifiedDebtSchema = z.object({
+  from: PublicUserSchema,
+  to: PublicUserSchema,
+  amountCents: z.number(),
+});
+
+export const GroupBalancesSchema = z.object({
+  currency: z.string(),
+  balances: z.array(MemberBalanceSchema),
+  debts: z.array(SimplifiedDebtSchema),
+});
+
+// ─────────────────────────────────────────────────────────────
+// Activity / dashboard
+// ─────────────────────────────────────────────────────────────
+
+export const ActivityItemSchema = z.object({
+  expense: ExpenseSchema,
+  groupName: z.string(),
+});
+
+export const OverviewSchema = z.object({
+  currency: z.string(),
+  // Total others owe you across all groups (cents)
+  youAreOwedCents: z.number(),
+  // Total you owe across all groups (cents)
+  youOweCents: z.number(),
+  netCents: z.number(),
+});
+
+export type GroupOut = z.infer<typeof GroupSchema>;
+export type GroupSummaryOut = z.infer<typeof GroupSummarySchema>;
+export type CreateGroupInput = z.infer<typeof CreateGroupSchema>;
+export type UpdateGroupInput = z.infer<typeof UpdateGroupSchema>;
+export type CreateExpenseInput = z.infer<typeof CreateExpenseSchema>;
+export type UpdateExpenseInput = z.infer<typeof UpdateExpenseSchema>;
+export type ExpenseOut = z.infer<typeof ExpenseSchema>;
+export type CreateSettlementInput = z.infer<typeof CreateSettlementSchema>;
+export type SettlementOut = z.infer<typeof SettlementSchema>;
+export type GroupBalancesOut = z.infer<typeof GroupBalancesSchema>;
+export type OverviewOut = z.infer<typeof OverviewSchema>;

--- a/apps/split/src/app/users/auth/auth.router.ts
+++ b/apps/split/src/app/users/auth/auth.router.ts
@@ -1,0 +1,210 @@
+import { inject } from '@ee/di';
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { UserRegistrationSchema } from '../user';
+import {
+  AuthErrorResponseSchema,
+  CompleteLoginRequestSchema,
+  CompleteLoginResponseSchema,
+  CompleteRegistrationRequestSchema,
+  CompleteRegistrationResponseSchema,
+  LoginStartRequestSchema,
+  LoginStartResponseSchema,
+  LogoutRequestSchema,
+  LogoutResponseSchema,
+  RegistrationResponseSchema,
+  TokenRefreshRequestSchema,
+  TokenRefreshResponseSchema,
+} from './auth.types';
+import { LoginService } from './login.service';
+import { RegistrationService } from './registration.service';
+
+// Challenge storage - in production, use Redis or similar
+const challengeStore = new Map<
+  string,
+  { challenge: string; userId?: string; expires: number }
+>();
+
+// Clean up expired challenges every 5 minutes
+setInterval(() => {
+  const now = Date.now();
+  for (const [key, value] of challengeStore.entries()) {
+    if (value.expires < now) {
+      challengeStore.delete(key);
+    }
+  }
+}, 5 * 60 * 1000);
+
+export async function AuthRouter(fastify: FastifyInstance) {
+  const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
+  const _loginService = inject(LoginService);
+  const _registrationService = inject(RegistrationService);
+
+  /**
+   * 📝 REGISTER USER
+   */
+  typedFastify.post(
+    '/register',
+    {
+      schema: {
+        tags: ['Authentication'],
+        description: 'Register a new user - passkeys mandatory for security!',
+        body: UserRegistrationSchema,
+        response: {
+          201: RegistrationResponseSchema,
+          409: AuthErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const userData = request.body;
+      const result = await _registrationService.startRegistration(userData);
+
+      challengeStore.set(result.sessionId, {
+        challenge: result.registrationOptions.challenge,
+        userId: result.user.id,
+        expires: Date.now() + 5 * 60 * 1000,
+      });
+
+      return reply.code(201).send(result);
+    }
+  );
+
+  /**
+   * ✅ COMPLETE INITIAL PASSKEY REGISTRATION
+   */
+  typedFastify.post(
+    '/register/complete',
+    {
+      schema: {
+        tags: ['Authentication'],
+        description: 'Complete initial passkey registration for new users',
+        body: CompleteRegistrationRequestSchema,
+        response: { 200: CompleteRegistrationResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const { sessionId, credential } = request.body;
+
+      const challengeData = challengeStore.get(sessionId);
+      if (!challengeData || !challengeData.userId) {
+        throw fastify.httpErrors.badRequest('Invalid or expired session');
+      }
+
+      const result = await _registrationService.completeRegistration(
+        challengeData.userId,
+        credential,
+        challengeData.challenge,
+        fastify
+      );
+
+      challengeStore.delete(sessionId);
+      return reply.send(result);
+    }
+  );
+
+  /**
+   * 🔑 START LOGIN
+   */
+  typedFastify.post(
+    '/login',
+    {
+      schema: {
+        tags: ['Authentication'],
+        description: 'Start passkey authentication (passwordless login)',
+        body: LoginStartRequestSchema,
+        response: { 200: LoginStartResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const result = await _loginService.startLogin(request.body?.username);
+
+      challengeStore.set(result.sessionId, {
+        challenge: result.options.challenge,
+        expires: Date.now() + 5 * 60 * 1000,
+      });
+
+      return reply.send(result);
+    }
+  );
+
+  /**
+   * ✅ COMPLETE LOGIN
+   */
+  typedFastify.post(
+    '/login/complete',
+    {
+      schema: {
+        tags: ['Authentication'],
+        description: 'Complete passkey authentication',
+        body: CompleteLoginRequestSchema,
+        response: { 200: CompleteLoginResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const { sessionId, credential } = request.body;
+
+      const challengeData = challengeStore.get(sessionId);
+      if (!challengeData) {
+        throw fastify.httpErrors.badRequest('Invalid or expired session');
+      }
+
+      const result = await _loginService.completeLogin(
+        credential,
+        challengeData.challenge,
+        fastify
+      );
+
+      challengeStore.delete(sessionId);
+      return reply.send(result);
+    }
+  );
+
+  /**
+   * 🔄 REFRESH ACCESS TOKEN
+   */
+  typedFastify.post(
+    '/token/refresh',
+    {
+      schema: {
+        tags: ['Authentication'],
+        description: 'Refresh access token using refresh token',
+        body: TokenRefreshRequestSchema,
+        response: {
+          200: TokenRefreshResponseSchema,
+          401: AuthErrorResponseSchema,
+        },
+      },
+    },
+    async (request, reply) => {
+      const { refreshToken } = request.body;
+
+      if (!refreshToken) {
+        throw fastify.httpErrors.unauthorized('No refresh token provided');
+      }
+
+      const result = await _loginService.refreshTokens(refreshToken, fastify);
+      return reply.send(result);
+    }
+  );
+
+  /**
+   * 🚪 LOGOUT
+   */
+  typedFastify.post(
+    '/logout',
+    {
+      schema: {
+        tags: ['Authentication'],
+        description: 'Logout user and revoke tokens',
+        body: LogoutRequestSchema.optional(),
+        response: { 200: LogoutResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const refreshToken = request.body?.refreshToken;
+      const result = await _loginService.logout(refreshToken);
+      return reply.send(result);
+    }
+  );
+}

--- a/apps/split/src/app/users/auth/auth.service.ts
+++ b/apps/split/src/app/users/auth/auth.service.ts
@@ -266,9 +266,10 @@ export class AuthService {
     const webAuthnUserId = randomBytes(32).toString('base64url');
 
     const user = new User();
-    user.name = userData.name;
+    // Registration only collects a username; the display name defaults to it
+    // and can be changed later from the profile screen.
+    user.name = userData.username;
     user.username = userData.username;
-    user.email = userData.email;
     user.webAuthnUserId = webAuthnUserId;
     user.isActive = true;
 

--- a/apps/split/src/app/users/auth/auth.service.ts
+++ b/apps/split/src/app/users/auth/auth.service.ts
@@ -1,0 +1,390 @@
+import { inject } from '@ee/di';
+import {
+  generateAuthenticationOptions,
+  generateRegistrationOptions,
+  verifyAuthenticationResponse,
+  verifyRegistrationResponse,
+  type AuthenticationResponseJSON,
+  type AuthenticatorTransportFuture,
+  type PublicKeyCredentialCreationOptionsJSON,
+  type PublicKeyCredentialRequestOptionsJSON,
+  type RegistrationResponseJSON,
+  type VerifiedAuthenticationResponse,
+  type VerifiedRegistrationResponse,
+} from '@simplewebauthn/server';
+import { randomBytes } from 'crypto';
+import HttpErrors from 'http-errors';
+import { Database } from '../../data-source';
+import { RefreshToken, User, UserCredential, UserRegistration } from '../user';
+
+export interface JWTPayload {
+  id: string;
+  username: string;
+  iat: number;
+  exp: number;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+  user: {
+    id: string;
+    username: string;
+    name: string;
+  };
+}
+
+export interface PasskeyRegistrationOptions {
+  userId: string;
+  options: PublicKeyCredentialCreationOptionsJSON;
+  challenge: string;
+}
+
+export interface PasskeyAuthenticationOptions {
+  options: PublicKeyCredentialRequestOptionsJSON;
+  challenge: string;
+}
+
+export class AuthService {
+  private readonly _userRepository = inject(Database).repositoryFor(User);
+  private readonly _credentialRepository =
+    inject(Database).repositoryFor(UserCredential);
+  private readonly _refreshTokenRepository =
+    inject(Database).repositoryFor(RefreshToken);
+
+  // Configuration - uses environment variables for flexibility
+  private readonly RP_NAME = process.env['RP_NAME'] || 'Split';
+  private readonly RP_ID = process.env['RP_ID'] || 'localhost';
+  private readonly ORIGIN = process.env['ORIGIN'] || 'http://localhost:4200';
+  private readonly REFRESH_TOKEN_EXPIRY = 30; // days
+
+  /**
+   * 🚀 PASSKEY REGISTRATION
+   */
+  async startPasskeyRegistration(
+    userId: string
+  ): Promise<PasskeyRegistrationOptions> {
+    const user = await this._userRepository.findOne({ where: { id: userId } });
+
+    if (!user) {
+      throw new HttpErrors.NotFound('User not found');
+    }
+    const options = await generateRegistrationOptions({
+      rpName: this.RP_NAME,
+      rpID: this.RP_ID,
+      userID: new TextEncoder().encode(user.webAuthnUserId) as any,
+      userName: user.username,
+      userDisplayName: user.name,
+      attestationType: 'none',
+      authenticatorSelection: {
+        residentKey: 'preferred',
+        userVerification: 'preferred',
+        authenticatorAttachment: 'platform',
+      },
+      supportedAlgorithmIDs: [-7, -257], // ES256 and RS256
+    });
+
+    return { userId, options, challenge: options.challenge };
+  }
+
+  /**
+   * Complete passkey registration
+   */
+  async completePasskeyRegistration(
+    userId: string,
+    registrationResponse: RegistrationResponseJSON,
+    expectedChallenge: string
+  ): Promise<UserCredential> {
+    const user = await this._userRepository.findOneBy({ id: userId });
+    if (!user) {
+      throw new HttpErrors.NotFound('User not found');
+    }
+
+    let verification: VerifiedRegistrationResponse;
+    try {
+      verification = await verifyRegistrationResponse({
+        response: registrationResponse,
+        expectedChallenge,
+        expectedOrigin: this.ORIGIN,
+        expectedRPID: this.RP_ID,
+        requireUserVerification: true,
+      });
+    } catch (error: any) {
+      throw new HttpErrors.BadRequest(
+        `Passkey verification failed: ${error?.message || 'Unknown error'}`
+      );
+    }
+
+    if (!verification.verified || !verification.registrationInfo) {
+      throw new HttpErrors.BadRequest(
+        'Passkey registration verification failed'
+      );
+    }
+
+    const { credential } = verification.registrationInfo;
+
+    const userCredential = new UserCredential();
+    userCredential.credentialId = Buffer.from(credential.id).toString(
+      'base64url'
+    );
+    userCredential.publicKey = Buffer.from(credential.publicKey).toString(
+      'base64url'
+    );
+    userCredential.counter = credential.counter;
+    userCredential.userId = userId;
+    userCredential.deviceType =
+      verification.registrationInfo.credentialDeviceType;
+    userCredential.backedUp = verification.registrationInfo.credentialBackedUp;
+    userCredential.transports = JSON.stringify(
+      registrationResponse.response.transports
+    );
+
+    return await this._credentialRepository.save(userCredential);
+  }
+
+  /**
+   * 🔑 PASSKEY AUTHENTICATION
+   */
+  async startPasskeyAuthentication(
+    username?: string
+  ): Promise<PasskeyAuthenticationOptions> {
+    let allowCredentials: Array<{
+      id: string;
+      transports?: AuthenticatorTransportFuture[];
+    }> = [];
+
+    if (username) {
+      const user = await this._userRepository.findOne({
+        where: { username },
+        relations: ['credentials'],
+      });
+
+      if (user && user.credentials.length > 0) {
+        allowCredentials = user.credentials.map((cred) => ({
+          id: cred.credentialId,
+          transports: cred.transports
+            ? (JSON.parse(cred.transports) as AuthenticatorTransportFuture[])
+            : undefined,
+        }));
+      }
+    }
+
+    const options = await generateAuthenticationOptions({
+      rpID: this.RP_ID,
+      allowCredentials:
+        allowCredentials.length > 0 ? allowCredentials : undefined,
+      userVerification: 'preferred',
+    });
+
+    return { options, challenge: options.challenge };
+  }
+
+  /**
+   * Complete passkey authentication and return tokens
+   */
+  async completePasskeyAuthentication(
+    authenticationResponse: AuthenticationResponseJSON,
+    expectedChallenge: string
+  ): Promise<AuthTokens> {
+    const rawCredentialId = authenticationResponse.id;
+    const credentialId = Buffer.from(rawCredentialId).toString('base64url');
+
+    const credential = await this._credentialRepository.findOneBy({
+      credentialId,
+    });
+
+    if (!credential) {
+      throw new HttpErrors.Unauthorized('Passkey not found');
+    }
+
+    const user = await this._userRepository.findOneBy({
+      id: credential.userId as any,
+    });
+    if (!user || !user.isActive) {
+      throw new HttpErrors.Unauthorized('User not found or inactive');
+    }
+
+    let verification: VerifiedAuthenticationResponse;
+    try {
+      verification = await verifyAuthenticationResponse({
+        response: authenticationResponse,
+        expectedChallenge,
+        expectedOrigin: this.ORIGIN,
+        expectedRPID: this.RP_ID,
+        credential: {
+          id: credential.credentialId,
+          publicKey: new Uint8Array(
+            Buffer.from(credential.publicKey, 'base64url')
+          ),
+          counter: credential.counter,
+          transports: credential.transports
+            ? (JSON.parse(
+                credential.transports
+              ) as AuthenticatorTransportFuture[])
+            : undefined,
+        },
+        requireUserVerification: true,
+      });
+    } catch (error: any) {
+      await this._recordFailedLogin(user.id);
+      throw new HttpErrors.Unauthorized(
+        `Passkey authentication failed: ${error?.message || 'Unknown error'}`
+      );
+    }
+
+    if (!verification.verified) {
+      await this._recordFailedLogin(user.id);
+      throw new HttpErrors.Unauthorized(
+        'Passkey authentication verification failed'
+      );
+    }
+
+    await this._credentialRepository.update(credential.id, {
+      counter: verification.authenticationInfo.newCounter,
+      lastUsed: new Date(),
+    });
+
+    await this._updateSuccessfulLogin(user.id);
+
+    return await this._generateTokens(user);
+  }
+
+  /**
+   * 📧 REGISTER USER
+   */
+  async registerUser(
+    userData: UserRegistration
+  ): Promise<{ user: User; registrationOptions: PasskeyRegistrationOptions }> {
+    const existingUser = await this._userRepository.findOne({
+      where: [{ username: userData.username }],
+    });
+
+    if (existingUser) {
+      throw new HttpErrors.Conflict('User with this username already exists');
+    }
+
+    const webAuthnUserId = randomBytes(32).toString('base64url');
+
+    const user = new User();
+    user.name = userData.name;
+    user.username = userData.username;
+    user.email = userData.email;
+    user.webAuthnUserId = webAuthnUserId;
+    user.isActive = true;
+
+    const savedUser = await this._userRepository.save(user);
+
+    const registrationOptions = await this.startPasskeyRegistration(
+      savedUser.id
+    );
+
+    return { user: savedUser, registrationOptions };
+  }
+
+  /**
+   * 🔄 REFRESH TOKENS
+   */
+  async refreshTokens(refreshToken: string): Promise<AuthTokens> {
+    const tokenRecord = await this._refreshTokenRepository.findOneBy({
+      token: refreshToken,
+      revoked: false,
+    });
+
+    if (!tokenRecord || tokenRecord.expiresAt < new Date()) {
+      throw new HttpErrors.Unauthorized('Invalid or expired refresh token');
+    }
+
+    const user = await this._userRepository.findOneBy({
+      id: tokenRecord.userId as any,
+    });
+    if (!user || !user.isActive) {
+      throw new HttpErrors.Unauthorized('User not found or inactive');
+    }
+
+    await this._refreshTokenRepository.update(tokenRecord.id, {
+      revoked: true,
+    });
+
+    return await this._generateTokens(user);
+  }
+
+  /**
+   * 📝 GET USER PROFILE WITH SECURITY INFO
+   */
+  async getUserProfile(userId: string): Promise<{
+    user: User;
+    credentials: UserCredential[];
+  }> {
+    const user = await this._userRepository.findOne({
+      where: { id: userId },
+      relations: { credentials: true },
+    });
+
+    if (!user) {
+      throw new HttpErrors.NotFound('User not found');
+    }
+
+    return { user, credentials: user.credentials };
+  }
+
+  /**
+   * 🚫 LOGOUT
+   */
+  async logout(refreshToken: string): Promise<void> {
+    await this._refreshTokenRepository.update(
+      { token: refreshToken },
+      { revoked: true }
+    );
+  }
+
+  /**
+   * 🗑️ REVOKE ALL SESSIONS
+   */
+  async revokeAllSessions(userId: string): Promise<void> {
+    await this._refreshTokenRepository.update(
+      { userId: userId as any, revoked: false },
+      { revoked: true }
+    );
+  }
+
+  // Private helper methods
+  async _generateTokens(user: User): Promise<AuthTokens> {
+    const refreshTokenValue = randomBytes(32).toString('hex');
+    const refreshToken = new RefreshToken();
+    refreshToken.token = refreshTokenValue;
+    refreshToken.userId = user.id as any;
+    refreshToken.expiresAt = new Date(
+      Date.now() + this.REFRESH_TOKEN_EXPIRY * 24 * 60 * 60 * 1000
+    );
+
+    await this._refreshTokenRepository.save(refreshToken);
+
+    return {
+      accessToken: '', // Signed by the service layer using fastify.signToken
+      refreshToken: refreshTokenValue,
+      user: { id: user.id, username: user.username, name: user.name },
+    };
+  }
+
+  private async _recordFailedLogin(userId: string): Promise<void> {
+    const user = await this._userRepository.findOneBy({ id: userId });
+    if (!user) return;
+
+    const failedAttempts = user.failedLoginAttempts + 1;
+    const updates: Partial<User> = { failedLoginAttempts: failedAttempts };
+
+    if (failedAttempts >= 5) {
+      updates.lockedUntil = new Date(Date.now() + 30 * 60 * 1000);
+    }
+
+    await this._userRepository.update(userId, updates);
+  }
+
+  private async _updateSuccessfulLogin(userId: string): Promise<void> {
+    await this._userRepository.update(userId, {
+      lastLoginAt: new Date(),
+      failedLoginAttempts: 0,
+      lockedUntil: undefined,
+    });
+  }
+}

--- a/apps/split/src/app/users/auth/auth.types.ts
+++ b/apps/split/src/app/users/auth/auth.types.ts
@@ -1,0 +1,161 @@
+import { z } from 'zod';
+import { SafeUserSchema } from '../user';
+
+/**
+ * Schema for passkey registration options
+ */
+export const PasskeyRegistrationOptionsSchema = z.object({
+  userId: z.string(),
+  options: z.any(), // WebAuthn options are complex, keeping as any
+  challenge: z.string(),
+});
+
+/**
+ * Schema for registration start response
+ */
+export const RegistrationResponseSchema = z.object({
+  success: z.boolean(),
+  user: SafeUserSchema,
+  registrationOptions: PasskeyRegistrationOptionsSchema,
+  sessionId: z.string(),
+  message: z.string(),
+});
+
+/**
+ * Schema for complete registration request body
+ */
+export const CompleteRegistrationRequestSchema = z.object({
+  sessionId: z.string(),
+  credential: z.any(),
+});
+
+/**
+ * Schema for user credential in response
+ */
+export const UserCredentialResponseSchema = z.object({
+  id: z.string(),
+  deviceType: z.string().optional(),
+  backedUp: z.boolean(),
+  createdAt: z.date(),
+});
+
+/**
+ * Schema for auth user (lighter than SafeUser)
+ */
+export const AuthUserSchema = z.object({
+  id: z.string(),
+  username: z.string(),
+  name: z.string(),
+});
+
+/**
+ * Schema for complete registration response
+ */
+export const CompleteRegistrationResponseSchema = z.object({
+  success: z.boolean(),
+  user: AuthUserSchema,
+  credential: UserCredentialResponseSchema,
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  message: z.string(),
+});
+
+/**
+ * Schema for login start request body
+ */
+export const LoginStartRequestSchema = z
+  .object({
+    username: z.string().optional(),
+  })
+  .optional();
+
+/**
+ * Schema for login start response
+ */
+export const LoginStartResponseSchema = z.object({
+  success: z.boolean(),
+  options: z.any(),
+  sessionId: z.string(),
+});
+
+/**
+ * Schema for complete login request body
+ */
+export const CompleteLoginRequestSchema = z.object({
+  sessionId: z.string(),
+  credential: z.any(),
+});
+
+/**
+ * Schema for complete login response
+ */
+export const CompleteLoginResponseSchema = z.object({
+  success: z.boolean(),
+  user: AuthUserSchema,
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  message: z.string(),
+});
+
+/**
+ * Schema for token refresh request body
+ */
+export const TokenRefreshRequestSchema = z.object({
+  refreshToken: z.string(),
+});
+
+/**
+ * Schema for token refresh response
+ */
+export const TokenRefreshResponseSchema = z.object({
+  success: z.boolean(),
+  accessToken: z.string(),
+  refreshToken: z.string(),
+  message: z.string(),
+});
+
+/**
+ * Schema for logout request body
+ */
+export const LogoutRequestSchema = z.object({
+  refreshToken: z.string(),
+});
+
+/**
+ * Schema for logout response
+ */
+export const LogoutResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+/**
+ * Schema for error responses
+ */
+export const AuthErrorResponseSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+});
+
+export type PasskeyRegistrationOptions = z.infer<
+  typeof PasskeyRegistrationOptionsSchema
+>;
+export type RegistrationResponse = z.infer<typeof RegistrationResponseSchema>;
+export type CompleteRegistrationRequest = z.infer<
+  typeof CompleteRegistrationRequestSchema
+>;
+export type UserCredentialResponse = z.infer<
+  typeof UserCredentialResponseSchema
+>;
+export type AuthUser = z.infer<typeof AuthUserSchema>;
+export type CompleteRegistrationResponse = z.infer<
+  typeof CompleteRegistrationResponseSchema
+>;
+export type LoginStartResponse = z.infer<typeof LoginStartResponseSchema>;
+export type CompleteLoginRequest = z.infer<typeof CompleteLoginRequestSchema>;
+export type CompleteLoginResponse = z.infer<typeof CompleteLoginResponseSchema>;
+export type TokenRefreshRequest = z.infer<typeof TokenRefreshRequestSchema>;
+export type TokenRefreshResponse = z.infer<typeof TokenRefreshResponseSchema>;
+export type LogoutRequest = z.infer<typeof LogoutRequestSchema>;
+export type LogoutResponse = z.infer<typeof LogoutResponseSchema>;
+export type AuthErrorResponse = z.infer<typeof AuthErrorResponseSchema>;

--- a/apps/split/src/app/users/auth/login.service.ts
+++ b/apps/split/src/app/users/auth/login.service.ts
@@ -1,0 +1,79 @@
+import { inject } from '@ee/di';
+import type { AuthenticationResponseJSON } from '@simplewebauthn/server';
+import { AuthService } from './auth.service';
+import {
+  LoginStartResponse,
+  TokenRefreshResponse,
+  LogoutResponse,
+  CompleteLoginResponse,
+} from './auth.types';
+
+export class LoginService {
+  private readonly _authService = inject(AuthService);
+
+  async startLogin(username?: string): Promise<LoginStartResponse> {
+    const authenticationOptions =
+      await this._authService.startPasskeyAuthentication(username);
+
+    const sessionId = `auth_${Date.now()}_${Math.random()
+      .toString(36)
+      .substring(2, 11)}`;
+
+    return {
+      success: true,
+      options: authenticationOptions.options,
+      sessionId,
+    };
+  }
+
+  async completeLogin(
+    credential: AuthenticationResponseJSON,
+    challenge: string,
+    fastify: any
+  ): Promise<CompleteLoginResponse> {
+    const tokens = await this._authService.completePasskeyAuthentication(
+      credential,
+      challenge
+    );
+
+    const accessToken = fastify.signToken({
+      id: tokens.user.id,
+      username: tokens.user.username,
+    });
+
+    return {
+      success: true,
+      user: tokens.user,
+      accessToken,
+      refreshToken: tokens.refreshToken,
+      message: '🚀 Welcome back! Logged in with passkey.',
+    };
+  }
+
+  async refreshTokens(
+    refreshToken: string,
+    fastify: any
+  ): Promise<TokenRefreshResponse> {
+    const tokens = await this._authService.refreshTokens(refreshToken);
+
+    const accessToken = fastify.signToken({
+      id: tokens.user.id,
+      username: tokens.user.username,
+    });
+
+    return {
+      success: true,
+      accessToken,
+      refreshToken: tokens.refreshToken,
+      message: 'Tokens refreshed successfully',
+    };
+  }
+
+  async logout(refreshToken?: string): Promise<LogoutResponse> {
+    if (refreshToken) {
+      await this._authService.logout(refreshToken);
+    }
+
+    return { success: true, message: 'Logged out successfully' };
+  }
+}

--- a/apps/split/src/app/users/auth/registration.service.ts
+++ b/apps/split/src/app/users/auth/registration.service.ts
@@ -1,0 +1,88 @@
+import { inject } from '@ee/di';
+import type { RegistrationResponseJSON } from '@simplewebauthn/server';
+import { AuthService } from './auth.service';
+import { UsersService } from '../users.service';
+import { UserRegistration } from '../user';
+import {
+  RegistrationResponse,
+  CompleteRegistrationResponse,
+} from './auth.types';
+
+export class RegistrationService {
+  private readonly _authService = inject(AuthService);
+  private readonly _usersService = inject(UsersService);
+
+  async startRegistration(
+    userData: UserRegistration
+  ): Promise<RegistrationResponse> {
+    const { user, registrationOptions } = await this._authService.registerUser(
+      userData
+    );
+
+    return {
+      success: true,
+      user: {
+        id: user.id,
+        name: user.name,
+        username: user.username,
+        email: user.email ?? null,
+        isActive: user.isActive,
+        lastLoginAt: user.lastLoginAt || null,
+        timestamp: user.timestamp,
+        updatedAt: user.updatedAt,
+      },
+      registrationOptions: {
+        userId: registrationOptions.userId,
+        options: registrationOptions.options,
+        challenge: registrationOptions.challenge,
+      },
+      sessionId: `reg_${user.id}_${Date.now()}`,
+      message:
+        '🔑 Account created! Complete passkey setup to secure your account.',
+    };
+  }
+
+  async completeRegistration(
+    userId: string,
+    credential: RegistrationResponseJSON,
+    challenge: string,
+    fastify: any
+  ): Promise<CompleteRegistrationResponse> {
+    const userCredential = await this._authService.completePasskeyRegistration(
+      userId,
+      credential,
+      challenge
+    );
+
+    const user = await this._usersService.getById(userId);
+    if (!user) {
+      throw new Error('User not found after registration');
+    }
+
+    // Issue a real session so the user lands straight in the app after signup
+    const tokens = await this._authService._generateTokens({
+      id: user.id,
+      username: user.username,
+      name: user.name,
+    } as any);
+
+    const accessToken = fastify.signToken({
+      id: userId,
+      username: user.username,
+    });
+
+    return {
+      success: true,
+      user: { id: userId, username: user.username, name: user.name },
+      credential: {
+        id: userCredential.id,
+        deviceType: userCredential.deviceType,
+        backedUp: userCredential.backedUp,
+        createdAt: userCredential.createdAt,
+      },
+      accessToken,
+      refreshToken: tokens.refreshToken,
+      message: '🎉 Welcome! Your account is now secured with a passkey.',
+    };
+  }
+}

--- a/apps/split/src/app/users/profile/profile.router.ts
+++ b/apps/split/src/app/users/profile/profile.router.ts
@@ -1,0 +1,73 @@
+import { inject } from '@ee/di';
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { ProfileService } from './profile.service';
+import {
+  ProfileResponseSchema,
+  UpdateProfileRequestSchema,
+  UpdateProfileResponseSchema,
+  DeleteAccountResponseSchema,
+} from './profile.types';
+
+export async function ProfileRouter(fastify: FastifyInstance) {
+  const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
+  const _profileService = inject(ProfileService);
+
+  typedFastify.get(
+    '/',
+    {
+      preHandler: [fastify.authenticate()],
+      schema: {
+        tags: ['User Profile'],
+        description: 'Get current user profile with security information',
+        response: { 200: ProfileResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const userId = request.currentUser.id;
+      const result = await _profileService.getProfile(userId);
+      return reply.send(result);
+    }
+  );
+
+  typedFastify.put(
+    '/',
+    {
+      preHandler: [fastify.authenticate()],
+      schema: {
+        tags: ['User Profile'],
+        description: 'Update user profile information',
+        body: UpdateProfileRequestSchema,
+        response: { 200: UpdateProfileResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const userId = request.currentUser.id;
+      const result = await _profileService.updateProfile(userId, request.body);
+      return reply.send(result);
+    }
+  );
+
+  typedFastify.delete(
+    '/',
+    {
+      preHandler: [fastify.authenticate()],
+      schema: {
+        tags: ['User Profile'],
+        description: 'Delete user account (irreversible)',
+        response: { 200: DeleteAccountResponseSchema },
+      },
+    },
+    async (request, reply) => {
+      const userId = request.currentUser.id;
+      try {
+        const result = await _profileService.deleteAccount(userId);
+        return reply.send(result);
+      } catch (error) {
+        throw fastify.httpErrors.internalServerError(
+          error instanceof Error ? error.message : 'Failed to delete account'
+        );
+      }
+    }
+  );
+}

--- a/apps/split/src/app/users/profile/profile.service.ts
+++ b/apps/split/src/app/users/profile/profile.service.ts
@@ -1,0 +1,69 @@
+import { inject } from '@ee/di';
+import { AuthService } from '../auth/auth.service';
+import { UsersService } from '../users.service';
+import {
+  ProfileResponse,
+  UpdateProfileResponse,
+  DeleteAccountResponse,
+  UpdateProfileRequest,
+} from './profile.types';
+
+export class ProfileService {
+  private readonly _authService = inject(AuthService);
+  private readonly _usersService = inject(UsersService);
+
+  async getProfile(userId: string): Promise<ProfileResponse> {
+    const profile = await this._authService.getUserProfile(userId);
+    return {
+      success: true,
+      user: {
+        id: profile.user.id,
+        name: profile.user.name,
+        username: profile.user.username,
+        email: profile.user.email ?? null,
+        isActive: profile.user.isActive,
+        lastLoginAt: profile.user.lastLoginAt || null,
+        timestamp: profile.user.timestamp,
+        updatedAt: profile.user.updatedAt,
+      },
+      credentials: profile.credentials.map((cred) => ({
+        id: cred.id,
+        deviceType: cred.deviceType,
+        backedUp: cred.backedUp,
+        createdAt: cred.createdAt,
+        lastUsed: cred.lastUsed,
+      })),
+    };
+  }
+
+  async updateProfile(
+    userId: string,
+    updates: UpdateProfileRequest
+  ): Promise<UpdateProfileResponse> {
+    await this._usersService.updateProfile(userId, updates);
+    const profile = await this._authService.getUserProfile(userId);
+
+    return {
+      success: true,
+      user: {
+        id: profile.user.id,
+        name: profile.user.name,
+        username: profile.user.username,
+        email: profile.user.email ?? null,
+        isActive: profile.user.isActive,
+        lastLoginAt: profile.user.lastLoginAt || null,
+        timestamp: profile.user.timestamp,
+        updatedAt: profile.user.updatedAt,
+      },
+      message: 'Profile updated successfully',
+    };
+  }
+
+  async deleteAccount(userId: string): Promise<DeleteAccountResponse> {
+    const deleted = await this._usersService.deleteAccount(userId);
+    if (!deleted) {
+      throw new Error('Failed to delete account');
+    }
+    return { success: true, message: 'Account deleted successfully' };
+  }
+}

--- a/apps/split/src/app/users/profile/profile.types.ts
+++ b/apps/split/src/app/users/profile/profile.types.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { SafeUserSchema } from '../user';
+
+export const ProfileCredentialSchema = z.object({
+  id: z.string(),
+  deviceType: z.string().optional(),
+  backedUp: z.boolean(),
+  createdAt: z.date(),
+  lastUsed: z.date(),
+});
+
+export const ProfileResponseSchema = z.object({
+  success: z.boolean(),
+  user: SafeUserSchema,
+  credentials: z.array(ProfileCredentialSchema),
+});
+
+export const UpdateProfileRequestSchema = z.object({
+  name: z.string().min(1).max(100).optional(),
+  email: z.string().email().optional(),
+});
+
+export const UpdateProfileResponseSchema = z.object({
+  success: z.boolean(),
+  user: SafeUserSchema,
+  message: z.string(),
+});
+
+export const DeleteAccountResponseSchema = z.object({
+  success: z.boolean(),
+  message: z.string(),
+});
+
+export type ProfileCredential = z.infer<typeof ProfileCredentialSchema>;
+export type ProfileResponse = z.infer<typeof ProfileResponseSchema>;
+export type UpdateProfileRequest = z.infer<typeof UpdateProfileRequestSchema>;
+export type UpdateProfileResponse = z.infer<typeof UpdateProfileResponseSchema>;
+export type DeleteAccountResponse = z.infer<typeof DeleteAccountResponseSchema>;

--- a/apps/split/src/app/users/user.ts
+++ b/apps/split/src/app/users/user.ts
@@ -138,13 +138,11 @@ export const UserCredentialSchema = z.object({
 });
 
 export const UserRegistrationSchema = z.object({
-  name: z.string().min(1).max(100),
   username: z
     .string()
     .min(3)
     .max(50)
     .regex(/^[a-zA-Z0-9_]+$/),
-  email: z.string().email().optional(),
 });
 
 export const FullUserSchema = z.object({

--- a/apps/split/src/app/users/user.ts
+++ b/apps/split/src/app/users/user.ts
@@ -1,0 +1,179 @@
+import { provide } from '@ee/di';
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  Index,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { z } from 'zod';
+import { ENTITIES } from '../data-source';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    currentUser: User;
+  }
+}
+
+// Entity for storing a user's passkey credentials
+@Entity()
+export class UserCredential {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column('text', { unique: true })
+  credentialId!: string;
+
+  @Column('text')
+  publicKey!: string;
+
+  @Column('integer')
+  counter!: number;
+
+  @ManyToOne(() => User, (c) => c.id)
+  userId!: string;
+
+  @Column('text', { nullable: true })
+  deviceType?: string;
+
+  @Column('boolean', { default: false })
+  backedUp!: boolean;
+
+  @Column('text', { nullable: true })
+  transports?: string; // JSON string of transport methods
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  lastUsed!: Date;
+}
+
+// Entity for refresh tokens
+@Entity()
+export class RefreshToken {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column('text')
+  token!: string;
+
+  @ManyToOne(() => User, (c) => c.id)
+  userId!: string;
+
+  @Column('timestamp')
+  expiresAt!: Date;
+
+  @Column('text', { nullable: true })
+  deviceInfo?: string;
+
+  @Column('boolean', { default: false })
+  revoked!: boolean;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}
+
+@Entity()
+@Index(['username'], { unique: true })
+export class User {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @CreateDateColumn()
+  timestamp!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+
+  @Column('text')
+  name!: string;
+
+  @Column('text', { unique: true })
+  username!: string;
+
+  @Column('text', { nullable: true })
+  email?: string;
+
+  @Column('text', { unique: true })
+  webAuthnUserId!: string;
+
+  @Column('boolean', { default: true })
+  isActive!: boolean;
+
+  @Column('timestamp', { nullable: true })
+  lastLoginAt?: Date;
+
+  @Column('text', { nullable: true })
+  lastLoginIP?: string;
+
+  @Column('integer', { default: 0 })
+  failedLoginAttempts!: number;
+
+  @Column('timestamp', { nullable: true })
+  lockedUntil?: Date;
+
+  @OneToMany(() => UserCredential, (cred) => cred.userId)
+  credentials!: UserCredential[];
+
+  @OneToMany(() => RefreshToken, (cred) => cred.userId)
+  refreshTokens!: RefreshToken[];
+}
+
+// Zod schemas for validation
+export const UserCredentialSchema = z.object({
+  id: z.string().uuid(),
+  credentialId: z.string(),
+  publicKey: z.string(),
+  counter: z.number(),
+  userId: z.string().uuid(),
+  deviceType: z.string().optional(),
+  backedUp: z.boolean(),
+  transports: z.string().optional(),
+  createdAt: z.date(),
+  lastUsed: z.date(),
+});
+
+export const UserRegistrationSchema = z.object({
+  name: z.string().min(1).max(100),
+  username: z
+    .string()
+    .min(3)
+    .max(50)
+    .regex(/^[a-zA-Z0-9_]+$/),
+  email: z.string().email().optional(),
+});
+
+export const FullUserSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  username: z.string(),
+  email: z.string().nullable().optional(),
+  isActive: z.boolean(),
+  lastLoginAt: z.date().nullable(),
+  timestamp: z.date(),
+  updatedAt: z.date(),
+});
+
+export const SafeUserSchema = FullUserSchema;
+
+// Lightweight public representation of a user, safe to share with group members
+export const PublicUserSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  username: z.string(),
+});
+
+export type UserCredentialType = z.infer<typeof UserCredentialSchema>;
+export type UserRegistration = z.infer<typeof UserRegistrationSchema>;
+export type FullUser = z.infer<typeof FullUserSchema>;
+export type SafeUser = z.infer<typeof SafeUserSchema>;
+export type PublicUser = z.infer<typeof PublicUserSchema>;
+
+// Register entities with TypeORM
+provide(ENTITIES, User);
+provide(ENTITIES, UserCredential);
+provide(ENTITIES, RefreshToken);

--- a/apps/split/src/app/users/users.router.ts
+++ b/apps/split/src/app/users/users.router.ts
@@ -1,0 +1,39 @@
+import { inject } from '@ee/di';
+import { FastifyInstance } from 'fastify';
+import { ZodTypeProvider } from 'fastify-type-provider-zod';
+import { z } from 'zod';
+import { AuthRouter } from './auth/auth.router';
+import { ProfileRouter } from './profile/profile.router';
+import { PublicUserSchema } from './user';
+import { UsersService } from './users.service';
+
+export async function UsersRouter(fastify: FastifyInstance) {
+  const typedFastify = fastify.withTypeProvider<ZodTypeProvider>();
+  const _usersService = inject(UsersService);
+
+  await fastify.register(AuthRouter);
+  await fastify.register(ProfileRouter, { prefix: '/profile' });
+
+  /**
+   * 🔎 SEARCH USERS - find people to add to a group
+   */
+  typedFastify.get(
+    '/search',
+    {
+      preHandler: [fastify.authenticate()],
+      schema: {
+        tags: ['Users'],
+        description: 'Search users by username or name',
+        querystring: z.object({ q: z.string().min(1) }),
+        response: { 200: z.array(PublicUserSchema) },
+      },
+    },
+    async (request, reply) => {
+      const result = await _usersService.search(
+        request.query.q,
+        request.currentUser.id
+      );
+      return reply.send(result);
+    }
+  );
+}

--- a/apps/split/src/app/users/users.service.ts
+++ b/apps/split/src/app/users/users.service.ts
@@ -1,0 +1,74 @@
+import { inject } from '@ee/di';
+import { Like } from 'typeorm';
+import { Database } from '../data-source';
+import { AuthService } from './auth/auth.service';
+import { PublicUser, User } from './user';
+
+export class UsersService {
+  private readonly _repository = inject(Database).repositoryFor(User);
+  private readonly _authService = inject(AuthService);
+
+  async getById(id: string) {
+    const user = await this._repository.findOne({
+      where: { id },
+      relations: { credentials: true },
+    });
+
+    if (!user) {
+      return null;
+    }
+
+    return {
+      id: user.id,
+      name: user.name,
+      username: user.username,
+      email: user.email ?? null,
+      isActive: user.isActive,
+      lastLoginAt: user.lastLoginAt,
+      timestamp: user.timestamp,
+      updatedAt: user.updatedAt,
+      credentialsCount: user.credentials.length,
+    };
+  }
+
+  async getByUsername(username: string) {
+    const user = await this._repository.findOneBy({ username });
+    return user ? this.getById(user.id) : null;
+  }
+
+  /** Find the underlying entity for a username (used when adding members). */
+  async findEntityByUsername(username: string): Promise<User | null> {
+    return this._repository.findOneBy({ username });
+  }
+
+  /** Find the underlying entity by id. */
+  async findEntityById(id: string): Promise<User | null> {
+    return this._repository.findOneBy({ id });
+  }
+
+  /** Search users by username or name, excluding the requester. */
+  async search(query: string, excludeUserId: string): Promise<PublicUser[]> {
+    const q = query.trim();
+    if (!q) return [];
+
+    const users = await this._repository.find({
+      where: [{ username: Like(`%${q}%`) }, { name: Like(`%${q}%`) }],
+      take: 10,
+    });
+
+    return users
+      .filter((u) => u.id !== excludeUserId)
+      .map((u) => ({ id: u.id, name: u.name, username: u.username }));
+  }
+
+  async updateProfile(userId: string, updates: { name?: string; email?: string }) {
+    await this._repository.update(userId, updates);
+    return this.getById(userId);
+  }
+
+  async deleteAccount(userId: string) {
+    await this._authService.revokeAllSessions(userId);
+    const result = await this._repository.delete(userId);
+    return result.affected !== 0;
+  }
+}

--- a/apps/split/src/main.ts
+++ b/apps/split/src/main.ts
@@ -1,0 +1,7 @@
+import 'dotenv/config';
+import 'reflect-metadata';
+import { Application } from './app/app';
+import { starter } from '@ee/starter';
+import { appConfig } from './app/app.config';
+
+starter(Application, appConfig).catch((error) => console.error(error));

--- a/apps/split/tsconfig.app.json
+++ b/apps/split/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "esnext",
+    "types": ["node"],
+    "target": "esnext"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/split/tsconfig.json
+++ b/apps/split/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}


### PR DESCRIPTION
## Split — a Splitwise-style shared-expenses app

A new full-stack app (separate backend + frontend) following the existing camera/finances patterns. **Deployment manifests are in a separate PR.**

### Backend — `apps/split` (Fastify + Postgres)
- **PostgreSQL** via the same data-source pattern as `ip-monitor` (`DB_*` env vars, `synchronize: true`).
- **Passkey/WebAuthn auth lifted from finances** — register, login, token refresh, profile — with JWT access tokens + persisted refresh tokens.
- **Domain**: groups & members, expenses with **equal / exact / percentage** splits (integer-cent math with remainder distribution so shares sum exactly), settlements, per-group balances with **greedy debt simplification**, plus cross-group overview + activity feed. Every group resource is member-scoped.
- Default currency: **CAD**.

### Frontend — `apps/split-frontend` (Angular + PrimeNG)
- PrimeNG Aura preset with a branded green theme, **mobile-first** (bottom tab bar on phones, top nav on desktop, safe-area insets).
- **Account-creation flow** + passkey login (`@simplewebauthn/browser`), auth interceptor with silent token refresh, route guard.
- Pages: groups list with balance overview, group detail (expenses / balances, add-expense with split editor, settle-up, member management), activity feed, profile.

### Verified
- Both apps **build (dev + prod) and lint** clean.
- Backend validated **end-to-end against a real PostgreSQL**: schema sync (8 tables), create-group → add-member → expense → balances → settle-up → overview → activity, plus odd-cent split correctness, exact-split validation (`400`), and authorization (`403` non-member, `401` no token).

### Notes
- WebAuthn `RP_ID`/`ORIGIN` are configured (in the deployment PR) to the frontend domain `split.elliott.haus`, where passkeys are created/used.
- Local dev: backend reads `DB_HOST/DB_PORT/DB_USER/DB_PASSWORD/DB_NAME`, `JWT_SECRET`, `RP_ID`, `ORIGIN`; frontend dev server points at `http://localhost:3000`.

https://claude.ai/code/session_01NCVgFuzYN5oCbhaWBiyQUb

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCVgFuzYN5oCbhaWBiyQUb)_