### PR TITLE
feat(split-frontend): responsive desktop/mobile experience overhaul

### DIFF
--- a/apps/split-frontend/src/app/core/layout.service.ts
+++ b/apps/split-frontend/src/app/core/layout.service.ts
@@ -1,0 +1,19 @@
+import { Injectable, signal } from '@angular/core';
+
+/**
+ * Tracks the desktop/mobile breakpoint as a signal so components can
+ * branch behaviour (not just styling) between form factors.
+ * Keep the query in sync with the 768px breakpoint used in styles.
+ */
+@Injectable({ providedIn: 'root' })
+export class LayoutService {
+  private readonly query = window.matchMedia('(min-width: 768px)');
+
+  readonly isDesktop = signal(this.query.matches);
+
+  constructor() {
+    this.query.addEventListener('change', (event) =>
+      this.isDesktop.set(event.matches)
+    );
+  }
+}

--- a/apps/split-frontend/src/app/layout/main-layout.component.ts
+++ b/apps/split-frontend/src/app/layout/main-layout.component.ts
@@ -61,7 +61,10 @@ interface NavItem {
   `,
   styles: `
     .shell {
+      // dvh tracks the visible viewport as mobile browsers collapse/expand
+      // their URL bar; plain vh overshoots while the bar is visible.
       min-height: 100vh;
+      min-height: 100dvh;
       display: flex;
       flex-direction: column;
     }
@@ -122,7 +125,9 @@ interface NavItem {
 
     .app-content {
       flex: 1;
-      padding-bottom: calc(var(--bottom-nav-height) + 16px);
+      padding-bottom: calc(
+        var(--bottom-nav-height) + var(--safe-bottom) + 16px
+      );
     }
 
     .bottom-nav {
@@ -131,11 +136,14 @@ interface NavItem {
       left: 0;
       right: 0;
       z-index: 40;
-      height: var(--bottom-nav-height);
+      // The safe-area inset must grow the bar, not eat into the fixed
+      // height — otherwise the links get squished when the inset appears
+      // (e.g. when the URL bar retracts on iOS).
+      height: calc(var(--bottom-nav-height) + var(--safe-bottom));
+      padding-bottom: var(--safe-bottom);
       background: var(--bg-surface);
       border-top: 1px solid var(--border);
       display: flex;
-      padding-bottom: env(safe-area-inset-bottom);
     }
 
     .bottom-nav-link {

--- a/apps/split-frontend/src/app/pages/activity/activity.component.ts
+++ b/apps/split-frontend/src/app/pages/activity/activity.component.ts
@@ -53,6 +53,11 @@ import { MoneyPipe } from '../../core/money.pipe';
     </div>
   `,
   styles: `
+    // A feed reads better narrow, even on a wide canvas.
+    .page {
+      max-width: 720px;
+    }
+
     .rows {
       overflow: hidden;
     }

--- a/apps/split-frontend/src/app/pages/group-detail/group-detail.component.scss
+++ b/apps/split-frontend/src/app/pages/group-detail/group-detail.component.scss
@@ -57,6 +57,11 @@
   display: block;
 }
 
+// Inline "Add expense" button — desktop replacement for the mobile FAB.
+.desktop-add {
+  display: none;
+}
+
 .tabs {
   display: flex;
   gap: 8px;
@@ -80,6 +85,48 @@
   }
 }
 
+// Mobile: one pane at a time, driven by the tabs. The pane titles are
+// redundant with the tab labels, so hide them.
+.pane {
+  display: none;
+
+  &.active {
+    display: block;
+  }
+}
+
+.pane-title {
+  display: none;
+}
+
+// Desktop: no tabs — expenses and balances live side by side.
+@media (min-width: 768px) {
+  .desktop-add {
+    display: block;
+  }
+
+  .tabs {
+    display: none;
+  }
+
+  .panes {
+    display: grid;
+    grid-template-columns: 3fr 2fr;
+    gap: 0 24px;
+    align-items: start;
+  }
+
+  .pane {
+    display: block;
+    min-width: 0;
+  }
+
+  .pane-title {
+    display: block;
+    margin-top: 4px;
+  }
+}
+
 .rows {
   overflow: hidden;
 }
@@ -93,6 +140,12 @@
   border-bottom: 1px solid var(--border);
   &:last-child {
     border-bottom: none;
+  }
+
+  @media (hover: hover) {
+    &:hover {
+      background: var(--bg-subtle);
+    }
   }
 }
 
@@ -177,7 +230,7 @@
   font-weight: 600;
 }
 
-// ── Dialog internals ──
+// ── Modal internals (content projected into app-modal) ──
 .dialog-body {
   display: flex;
   flex-direction: column;

--- a/apps/split-frontend/src/app/pages/group-detail/group-detail.component.ts
+++ b/apps/split-frontend/src/app/pages/group-detail/group-detail.component.ts
@@ -11,12 +11,12 @@ import { DatePipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Button } from 'primeng/button';
-import { Dialog } from 'primeng/dialog';
 import { InputText } from 'primeng/inputtext';
 import { InputNumber } from 'primeng/inputnumber';
 import { Select } from 'primeng/select';
 import { SelectButton } from 'primeng/selectbutton';
 import { Avatar } from 'primeng/avatar';
+import { ConfirmDialog } from 'primeng/confirmdialog';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ApiService } from '../../core/api.service';
 import { AuthService } from '../../core/auth.service';
@@ -28,6 +28,7 @@ import {
   SplitType,
 } from '../../core/models';
 import { MoneyPipe } from '../../core/money.pipe';
+import { ResponsiveModalComponent } from '../../shared/responsive-modal.component';
 
 interface SplitRow {
   userId: string;
@@ -43,13 +44,14 @@ interface SplitRow {
     FormsModule,
     DatePipe,
     Button,
-    Dialog,
     InputText,
     InputNumber,
     Select,
     SelectButton,
     Avatar,
+    ConfirmDialog,
     MoneyPipe,
+    ResponsiveModalComponent,
   ],
   providers: [ConfirmationService],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -64,11 +66,19 @@ interface SplitRow {
           <h1>{{ g.name }}</h1>
           <span class="members-line">{{ memberNames() }}</span>
         </div>
+        <p-button
+          class="desktop-add"
+          label="Add expense"
+          icon="pi pi-plus"
+          size="small"
+          (onClick)="openExpense()"
+        />
         <button class="icon-btn" (click)="openMembers()">
           <i class="pi pi-user-plus"></i>
         </button>
       </div>
 
+      <!-- Tabs only exist on mobile; desktop shows both panes side by side -->
       <div class="page tabs">
         <button
           [class.active]="tab() === 'expenses'"
@@ -85,92 +95,98 @@ interface SplitRow {
       </div>
     </div>
 
-    <div class="page">
-      @if (tab() === 'expenses') { @if (expenses().length === 0) {
-      <div class="empty-state card">
-        <i class="pi pi-receipt"></i>
-        <p>No expenses yet. Add the first one.</p>
-      </div>
-      } @else {
-      <div class="rows card">
-        @for (e of expenses(); track e.id) {
-        <div class="expense-row" (click)="editExpense(e)">
-          <div class="exp-date">
-            <span class="mon">{{ e.date | date : 'MMM' }}</span>
-            <span class="day">{{ e.date | date : 'd' }}</span>
-          </div>
-          <div class="exp-main">
-            <span class="exp-desc">{{ e.description }}</span>
-            <span class="exp-sub"
-              >{{ e.paidBy.name }} paid
-              {{ e.amountCents | money : e.currency }}</span
-            >
-          </div>
-          <div class="exp-share">{{ shareLabel(e) }}</div>
+    <div class="page panes">
+      <section class="pane" [class.active]="tab() === 'expenses'">
+        <h2 class="section-title pane-title">Expenses</h2>
+        @if (expenses().length === 0) {
+        <div class="empty-state card">
+          <i class="pi pi-receipt"></i>
+          <p>No expenses yet. Add the first one.</p>
         </div>
-        }
-      </div>
-      } } @else {
-      <!-- Balances tab -->
-      @if (balances(); as b) { @if (b.debts.length === 0) {
-      <div class="empty-state card">
-        <i class="pi pi-check-circle" style="color: var(--brand)"></i>
-        <p>Everyone is settled up!</p>
-      </div>
-      } @else {
-      <div class="rows card">
-        @for (d of b.debts; track d.from.id + d.to.id) {
-        <div class="debt-row">
-          <span class="debt-text">
-            <strong>{{ youOrName(d.from) }}</strong> owe{{
-              d.from.id === myId() ? '' : 's'
-            }}
-            <strong>{{ youOrName(d.to) }}</strong>
-          </span>
-          <span class="debt-actions">
-            <span class="amount-negative">{{
-              d.amountCents | money : b.currency
-            }}</span>
-            <p-button
-              label="Settle"
-              size="small"
-              [text]="true"
-              (onClick)="openSettle(d.from.id, d.to.id, d.amountCents)"
-            />
-          </span>
-        </div>
-        }
-      </div>
-      }
-
-      <h2 class="section-title">Member balances</h2>
-      <div class="rows card">
-        @for (m of b.balances; track m.user.id) {
-        <div class="balance-row">
-          <p-avatar
-            [label]="initial(m.user.name)"
-            shape="circle"
-            styleClass="member-avatar"
-          />
-          <span class="bal-name">{{ youOrName(m.user) }}</span>
-          @if (m.netCents === 0) {
-          <span class="muted">settled</span>
-          } @else if (m.netCents > 0) {
-          <span class="amount-positive"
-            >gets back {{ m.netCents | money : b.currency }}</span
-          >
-          } @else {
-          <span class="amount-negative"
-            >owes {{ -m.netCents | money : b.currency }}</span
-          >
+        } @else {
+        <div class="rows card">
+          @for (e of expenses(); track e.id) {
+          <div class="expense-row" (click)="editExpense(e)">
+            <div class="exp-date">
+              <span class="mon">{{ e.date | date : 'MMM' }}</span>
+              <span class="day">{{ e.date | date : 'd' }}</span>
+            </div>
+            <div class="exp-main">
+              <span class="exp-desc">{{ e.description }}</span>
+              <span class="exp-sub"
+                >{{ e.paidBy.name }} paid
+                {{ e.amountCents | money : e.currency }}</span
+              >
+            </div>
+            <div class="exp-share">{{ shareLabel(e) }}</div>
+          </div>
           }
         </div>
         }
-      </div>
-      } }
+      </section>
+
+      <section class="pane" [class.active]="tab() === 'balances'">
+        <h2 class="section-title pane-title">Balances</h2>
+        @if (balances(); as b) { @if (b.debts.length === 0) {
+        <div class="empty-state card">
+          <i class="pi pi-check-circle" style="color: var(--brand)"></i>
+          <p>Everyone is settled up!</p>
+        </div>
+        } @else {
+        <div class="rows card">
+          @for (d of b.debts; track d.from.id + d.to.id) {
+          <div class="debt-row">
+            <span class="debt-text">
+              <strong>{{ youOrName(d.from) }}</strong> owe{{
+                d.from.id === myId() ? '' : 's'
+              }}
+              <strong>{{ youOrName(d.to) }}</strong>
+            </span>
+            <span class="debt-actions">
+              <span class="amount-negative">{{
+                d.amountCents | money : b.currency
+              }}</span>
+              <p-button
+                label="Settle"
+                size="small"
+                [text]="true"
+                (onClick)="openSettle(d.from.id, d.to.id, d.amountCents)"
+              />
+            </span>
+          </div>
+          }
+        </div>
+        }
+
+        <h2 class="section-title">Member balances</h2>
+        <div class="rows card">
+          @for (m of b.balances; track m.user.id) {
+          <div class="balance-row">
+            <p-avatar
+              [label]="initial(m.user.name)"
+              shape="circle"
+              styleClass="member-avatar"
+            />
+            <span class="bal-name">{{ youOrName(m.user) }}</span>
+            @if (m.netCents === 0) {
+            <span class="muted">settled</span>
+            } @else if (m.netCents > 0) {
+            <span class="amount-positive"
+              >gets back {{ m.netCents | money : b.currency }}</span
+            >
+            } @else {
+            <span class="amount-negative"
+              >owes {{ -m.netCents | money : b.currency }}</span
+            >
+            }
+          </div>
+          }
+        </div>
+        }
+      </section>
     </div>
 
-    <!-- FAB add expense -->
+    <!-- FAB add expense (mobile only) -->
     <p-button
       class="fab"
       icon="pi pi-plus"
@@ -182,13 +198,11 @@ interface SplitRow {
     <div class="empty-state"><i class="pi pi-spin pi-spinner"></i></div>
     }
 
-    <!-- Add / edit expense dialog -->
-    <p-dialog
+    <!-- Add / edit expense: dialog on desktop, full page on mobile -->
+    <app-modal
       [header]="editingId() ? 'Edit expense' : 'Add expense'"
+      [wide]="true"
       [(visible)]="showExpense"
-      [modal]="true"
-      [draggable]="false"
-      [style]="{ width: '94vw', maxWidth: '600px' }"
     >
       <div class="dialog-body">
         <div class="field">
@@ -252,7 +266,8 @@ interface SplitRow {
           <small class="split-hint">{{ splitHint() }}</small>
         </div>
       </div>
-      <ng-template #footer>
+      <!-- ngProjectAs: conditional content needs an explicit slot -->
+      <ng-container ngProjectAs="[modal-footer]">
         @if (editingId()) {
         <p-button
           label="Delete"
@@ -261,27 +276,23 @@ interface SplitRow {
           (onClick)="deleteExpense()"
         />
         }
-        <p-button
-          label="Cancel"
-          [text]="true"
-          (onClick)="showExpense.set(false)"
-        />
-        <p-button
-          label="Save"
-          [loading]="savingExpense()"
-          (onClick)="saveExpense()"
-        />
-      </ng-template>
-    </p-dialog>
+      </ng-container>
+      <p-button
+        modal-footer
+        label="Cancel"
+        [text]="true"
+        (onClick)="showExpense.set(false)"
+      />
+      <p-button
+        modal-footer
+        label="Save"
+        [loading]="savingExpense()"
+        (onClick)="saveExpense()"
+      />
+    </app-modal>
 
-    <!-- Settle up dialog -->
-    <p-dialog
-      header="Record a payment"
-      [(visible)]="showSettle"
-      [modal]="true"
-      [draggable]="false"
-      [style]="{ width: '92vw', maxWidth: '500px' }"
-    >
+    <!-- Settle up: dialog on desktop, full page on mobile -->
+    <app-modal header="Record a payment" [(visible)]="showSettle">
       <div class="dialog-body">
         <div class="two-col">
           <div class="field">
@@ -315,28 +326,22 @@ interface SplitRow {
           />
         </div>
       </div>
-      <ng-template #footer>
-        <p-button
-          label="Cancel"
-          [text]="true"
-          (onClick)="showSettle.set(false)"
-        />
-        <p-button
-          label="Save payment"
-          [loading]="savingSettle()"
-          (onClick)="saveSettle()"
-        />
-      </ng-template>
-    </p-dialog>
+      <p-button
+        modal-footer
+        label="Cancel"
+        [text]="true"
+        (onClick)="showSettle.set(false)"
+      />
+      <p-button
+        modal-footer
+        label="Save payment"
+        [loading]="savingSettle()"
+        (onClick)="saveSettle()"
+      />
+    </app-modal>
 
-    <!-- Members dialog -->
-    <p-dialog
-      header="Members"
-      [(visible)]="showMembers"
-      [modal]="true"
-      [draggable]="false"
-      [style]="{ width: '92vw', maxWidth: '500px' }"
-    >
+    <!-- Members: dialog on desktop, full page on mobile -->
+    <app-modal header="Members" [(visible)]="showMembers">
       <div class="dialog-body">
         <div class="member-list">
           @for (m of group()?.members || []; track m.id) {
@@ -365,15 +370,23 @@ interface SplitRow {
             />
           </div>
         </div>
-        <p-button
-          label="Delete group"
-          severity="danger"
-          [text]="true"
-          icon="pi pi-trash"
-          (onClick)="deleteGroup()"
-        />
       </div>
-    </p-dialog>
+      <p-button
+        modal-footer
+        label="Delete group"
+        severity="danger"
+        [text]="true"
+        icon="pi pi-trash"
+        (onClick)="deleteGroup()"
+      />
+      <p-button
+        modal-footer
+        label="Done"
+        (onClick)="showMembers.set(false)"
+      />
+    </app-modal>
+
+    <p-confirmdialog [style]="{ width: '90vw', maxWidth: '420px' }" />
   `,
   styleUrl: './group-detail.component.scss',
 })
@@ -382,6 +395,7 @@ export class GroupDetailComponent implements OnInit {
   private readonly auth = inject(AuthService);
   private readonly router = inject(Router);
   private readonly messages = inject(MessageService);
+  private readonly confirm = inject(ConfirmationService);
 
   // Bound from the route param via withComponentInputBinding.
   readonly id = input.required<string>();
@@ -584,9 +598,18 @@ export class GroupDetailComponent implements OnInit {
   deleteExpense(): void {
     const editId = this.editingId();
     if (!editId) return;
-    this.api.deleteExpense(editId).subscribe(() => {
-      this.showExpense.set(false);
-      this.reload();
+    this.confirm.confirm({
+      header: 'Delete expense',
+      message: 'Delete this expense? This cannot be undone.',
+      icon: 'pi pi-trash',
+      acceptButtonProps: { label: 'Delete', severity: 'danger' },
+      rejectButtonProps: { label: 'Cancel', text: true },
+      accept: () => {
+        this.api.deleteExpense(editId).subscribe(() => {
+          this.showExpense.set(false);
+          this.reload();
+        });
+      },
     });
   }
 
@@ -666,9 +689,19 @@ export class GroupDetailComponent implements OnInit {
   }
 
   deleteGroup(): void {
-    this.api.deleteGroup(this.id()).subscribe(() => {
-      this.showMembers.set(false);
-      this.router.navigate(['/groups']);
+    this.confirm.confirm({
+      header: 'Delete group',
+      message:
+        'Delete this group and all of its expenses? This cannot be undone.',
+      icon: 'pi pi-trash',
+      acceptButtonProps: { label: 'Delete group', severity: 'danger' },
+      rejectButtonProps: { label: 'Cancel', text: true },
+      accept: () => {
+        this.api.deleteGroup(this.id()).subscribe(() => {
+          this.showMembers.set(false);
+          this.router.navigate(['/groups']);
+        });
+      },
     });
   }
 }

--- a/apps/split-frontend/src/app/pages/groups/groups.component.ts
+++ b/apps/split-frontend/src/app/pages/groups/groups.component.ts
@@ -7,18 +7,25 @@ import {
 import { FormsModule } from '@angular/forms';
 import { Router } from '@angular/router';
 import { Button } from 'primeng/button';
-import { Dialog } from 'primeng/dialog';
 import { InputText } from 'primeng/inputtext';
 import { SelectButton } from 'primeng/selectbutton';
 import { MessageService } from 'primeng/api';
 import { ApiService } from '../../core/api.service';
 import { GroupSummary, Overview } from '../../core/models';
 import { MoneyPipe } from '../../core/money.pipe';
+import { ResponsiveModalComponent } from '../../shared/responsive-modal.component';
 
 @Component({
   selector: 'app-groups',
   standalone: true,
-  imports: [FormsModule, Button, Dialog, InputText, SelectButton, MoneyPipe],
+  imports: [
+    FormsModule,
+    Button,
+    InputText,
+    SelectButton,
+    MoneyPipe,
+    ResponsiveModalComponent,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="page">
@@ -110,14 +117,8 @@ import { MoneyPipe } from '../../core/money.pipe';
       }
     </div>
 
-    <!-- Create group dialog -->
-    <p-dialog
-      header="New group"
-      [(visible)]="showCreate"
-      [modal]="true"
-      [draggable]="false"
-      [style]="{ width: '92vw', maxWidth: '440px' }"
-    >
+    <!-- Create group: dialog on desktop, full page on mobile -->
+    <app-modal header="New group" [(visible)]="showCreate">
       <div class="dialog-body">
         <div class="field">
           <label>Group name</label>
@@ -143,15 +144,19 @@ import { MoneyPipe } from '../../core/money.pipe';
           <small>You're added automatically. Others must already have an account.</small>
         </div>
       </div>
-      <ng-template #footer>
-        <p-button label="Cancel" [text]="true" (onClick)="showCreate.set(false)" />
-        <p-button
-          label="Create"
-          [loading]="creating()"
-          (onClick)="create()"
-        />
-      </ng-template>
-    </p-dialog>
+      <p-button
+        modal-footer
+        label="Cancel"
+        [text]="true"
+        (onClick)="showCreate.set(false)"
+      />
+      <p-button
+        modal-footer
+        label="Create"
+        [loading]="creating()"
+        (onClick)="create()"
+      />
+    </app-modal>
   `,
   styles: `
     .overview {
@@ -199,6 +204,15 @@ import { MoneyPipe } from '../../core/money.pipe';
       gap: 10px;
     }
 
+    // Desktop: lay the groups out as a card grid instead of a list.
+    @media (min-width: 768px) {
+      .group-list {
+        display: grid;
+        grid-template-columns: repeat(2, 1fr);
+        gap: 12px;
+      }
+    }
+
     .group-card {
       display: flex;
       align-items: center;
@@ -208,10 +222,18 @@ import { MoneyPipe } from '../../core/money.pipe';
       cursor: pointer;
       width: 100%;
       background: var(--bg-surface);
-      transition: transform 0.06s ease, box-shadow 0.12s ease;
+      transition: transform 0.06s ease, box-shadow 0.12s ease,
+        border-color 0.12s ease;
     }
     .group-card:active {
       transform: scale(0.99);
+    }
+
+    @media (hover: hover) {
+      .group-card:hover {
+        box-shadow: var(--shadow-md);
+        border-color: #d6dae1;
+      }
     }
 
     .group-avatar {

--- a/apps/split-frontend/src/app/pages/login/login.component.ts
+++ b/apps/split-frontend/src/app/pages/login/login.component.ts
@@ -7,14 +7,13 @@ import {
 import { FormsModule } from '@angular/forms';
 import { Router, RouterLink } from '@angular/router';
 import { Button } from 'primeng/button';
-import { InputText } from 'primeng/inputtext';
 import { MessageService } from 'primeng/api';
 import { AuthService } from '../../core/auth.service';
 
 @Component({
   selector: 'app-login',
   standalone: true,
-  imports: [FormsModule, RouterLink, Button, InputText],
+  imports: [FormsModule, RouterLink, Button],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <div class="auth-screen">
@@ -42,6 +41,7 @@ import { AuthService } from '../../core/auth.service';
   styles: `
     .auth-screen {
       min-height: 100vh;
+      min-height: 100dvh;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/apps/split-frontend/src/app/pages/profile/profile.component.ts
+++ b/apps/split-frontend/src/app/pages/profile/profile.component.ts
@@ -67,6 +67,11 @@ import { AuthService } from '../../core/auth.service';
     </div>
   `,
   styles: `
+    // Settings-style page reads better narrow, even on a wide canvas.
+    .page {
+      max-width: 560px;
+    }
+
     .profile-head {
       display: flex;
       flex-direction: column;

--- a/apps/split-frontend/src/app/pages/register/register.component.ts
+++ b/apps/split-frontend/src/app/pages/register/register.component.ts
@@ -55,6 +55,7 @@ import { AuthService } from '../../core/auth.service';
   styles: `
     .auth-screen {
       min-height: 100vh;
+      min-height: 100dvh;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/apps/split-frontend/src/app/shared/responsive-modal.component.ts
+++ b/apps/split-frontend/src/app/shared/responsive-modal.component.ts
@@ -1,0 +1,88 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  model,
+} from '@angular/core';
+import { Dialog } from 'primeng/dialog';
+import { LayoutService } from '../core/layout.service';
+
+/**
+ * Renders content as a centered dialog on desktop and as a full-screen
+ * page (slide-up, back-arrow header, pinned footer) on mobile.
+ *
+ * Usage:
+ *   <app-modal header="Add expense" [(visible)]="showExpense">
+ *     …body…
+ *     <p-button modal-footer label="Save" />
+ *   </app-modal>
+ *
+ * The shell styles live in styles.scss under `.responsive-modal`.
+ */
+@Component({
+  selector: 'app-modal',
+  standalone: true,
+  imports: [Dialog],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <p-dialog
+      [visible]="visible()"
+      (visibleChange)="visible.set($event)"
+      [modal]="true"
+      [draggable]="false"
+      [showHeader]="false"
+      [dismissableMask]="true"
+      [blockScroll]="true"
+      [focusOnShow]="false"
+      [position]="position()"
+      [styleClass]="styleClass()"
+    >
+      <div class="modal-shell">
+        <header class="modal-header">
+          <button
+            type="button"
+            class="modal-nav-btn modal-back"
+            aria-label="Back"
+            (click)="visible.set(false)"
+          >
+            <i class="pi pi-arrow-left"></i>
+          </button>
+          <h2>{{ header() }}</h2>
+          <button
+            type="button"
+            class="modal-nav-btn modal-close"
+            aria-label="Close"
+            (click)="visible.set(false)"
+          >
+            <i class="pi pi-times"></i>
+          </button>
+        </header>
+        <div class="modal-body">
+          <ng-content />
+        </div>
+        <footer class="modal-footer">
+          <ng-content select="[modal-footer]" />
+        </footer>
+      </div>
+    </p-dialog>
+  `,
+})
+export class ResponsiveModalComponent {
+  private readonly layout = inject(LayoutService);
+
+  readonly header = input('');
+  /** Wider variant for dense forms like the expense editor. */
+  readonly wide = input(false);
+  readonly visible = model(false);
+
+  // Slide up from the bottom on mobile, fade in centered on desktop.
+  readonly position = computed(() =>
+    this.layout.isDesktop() ? ('center' as const) : ('bottom' as const)
+  );
+
+  readonly styleClass = computed(
+    () => 'responsive-modal' + (this.wide() ? ' responsive-modal-wide' : '')
+  );
+}

--- a/apps/split-frontend/src/styles.scss
+++ b/apps/split-frontend/src/styles.scss
@@ -25,7 +25,15 @@
 
   --header-height: 56px;
   --bottom-nav-height: 60px;
+  --safe-bottom: env(safe-area-inset-bottom, 0px);
   --content-max-width: 720px;
+}
+
+// Wider canvas on desktop so pages can use multi-column layouts.
+@media (min-width: 1024px) {
+  :root {
+    --content-max-width: 1000px;
+  }
 }
 
 *,
@@ -48,11 +56,22 @@ body {
   font-size: 15px;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  -webkit-tap-highlight-color: transparent;
 }
 
 a {
   color: var(--brand);
   text-decoration: none;
+}
+
+// Prevent iOS Safari from zooming into focused inputs (it zooms when the
+// effective font size is below 16px).
+@media (max-width: 767px) {
+  .p-inputtext,
+  .p-select-label,
+  .p-inputnumber-input {
+    font-size: 16px;
+  }
 }
 
 // ── Scrollbars ──
@@ -124,17 +143,139 @@ a {
   font-weight: 600;
 }
 
-// Floating action button used to add expenses
+// Floating action button used to add expenses (mobile only — desktop
+// surfaces the same action as a regular button in the page header).
 .fab {
   position: fixed;
   right: 18px;
-  bottom: calc(var(--bottom-nav-height) + 18px);
+  bottom: calc(var(--bottom-nav-height) + var(--safe-bottom) + 18px);
   z-index: 50;
 }
 
 @media (min-width: 768px) {
   .fab {
-    bottom: 28px;
-    right: calc(50% - var(--content-max-width) / 2 + 18px);
+    display: none;
+  }
+}
+
+// ── Responsive modal (app-modal) ──
+// Desktop: centered dialog. Mobile: full-screen page that slides up.
+.p-dialog.responsive-modal {
+  width: 92vw;
+  max-width: 460px;
+
+  // The shell owns scrolling (so header/footer stay pinned) — the
+  // dialog's own content area must not scroll or pad.
+  .p-dialog-content {
+    padding: 0;
+    border-radius: inherit;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+  }
+}
+
+.p-dialog.responsive-modal-wide {
+  max-width: 620px;
+}
+
+.responsive-modal .modal-shell {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+
+.responsive-modal .modal-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--border);
+  flex-shrink: 0;
+
+  h2 {
+    flex: 1;
+    font-size: 17px;
+    font-weight: 700;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.responsive-modal .modal-nav-btn {
+  width: 36px;
+  height: 36px;
+  border: none;
+  border-radius: 10px;
+  background: var(--bg-subtle);
+  color: var(--text-primary);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  flex-shrink: 0;
+
+  i {
+    font-size: 16px;
+  }
+}
+
+.responsive-modal .modal-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 18px 20px;
+  -webkit-overflow-scrolling: touch;
+}
+
+.responsive-modal .modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px calc(12px + var(--safe-bottom));
+  border-top: 1px solid var(--border);
+  flex-shrink: 0;
+}
+
+// Desktop: hide the back arrow, show the X; cap dialog height.
+@media (min-width: 768px) {
+  .responsive-modal .modal-back {
+    display: none;
+  }
+
+  .p-dialog.responsive-modal {
+    max-height: 86vh;
+  }
+}
+
+// Mobile: take over the whole (dynamic) viewport as a page.
+@media (max-width: 767px) {
+  .responsive-modal .modal-close {
+    display: none;
+  }
+
+  .p-dialog.responsive-modal,
+  .p-dialog.responsive-modal-wide {
+    width: 100vw !important;
+    max-width: 100vw !important;
+    height: 100vh;
+    height: 100dvh;
+    max-height: none !important;
+    // Cancel the 1rem margin PrimeNG puts on bottom-positioned dialogs.
+    margin: 0 !important;
+    border-radius: 0;
+    border: none;
+  }
+
+  // Push the primary (last) action wide so it reads as a page CTA.
+  .responsive-modal .modal-footer > :last-child {
+    flex: 1;
+
+    .p-button {
+      width: 100%;
+      justify-content: center;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Makes the Split frontend behave like a proper app on each form factor instead of one stretched layout, and fixes the bottom-nav glitch on mobile browsers.

### Dialogs on desktop, full pages on mobile
- New shared `app-modal` (`ResponsiveModalComponent`) + `LayoutService` (signal-based `matchMedia` breakpoint).
- **Desktop:** centered dialog with an × close button.
- **Mobile:** full-screen `100dvh` page that slides up from the bottom, with a back-arrow header, scrollable body, and a pinned footer where the primary action stretches into a page-level CTA.
- All four flows migrated: create group, add/edit expense, record payment, members.

### Bottom nav collapse fix
The bar had a fixed 60px height with `padding-bottom: env(safe-area-inset-bottom)` *inside* it (border-box), so the links got squished whenever the inset appeared — e.g. when the URL bar retracts on iOS. The safe-area inset now **grows** the bar instead, and the shell/auth screens use `100dvh` (with `100vh` fallback) so the layout tracks the dynamic viewport as the URL bar moves.

### More meaningful desktop/mobile differences
- **Group detail:** tabs are now mobile-only; desktop shows Expenses and Balances side by side in a two-column layout.
- **Add expense:** FAB on mobile, inline "Add expense" button in the group header on desktop.
- **Groups:** two-column card grid on desktop with hover elevation; row list on mobile.
- Wider desktop canvas (1000px ≥1024px) so the columns have room; profile and activity stay capped narrow since forms/feeds read better that way.
- Hover states gated behind `@media (hover: hover)` so touch devices don't get sticky hovers.

### Other oddities fixed
- Deleting a group or expense now asks for confirmation (`p-confirmdialog`) — previously a single tap permanently deleted a group with all its expenses.
- Inputs are ≥16px on mobile so iOS Safari no longer zooms into focused fields.
- Removed grey tap-highlight flash; removed an unused `InputText` import that warned on every build.

## Verification
- `nx build split-frontend` and `nx lint split-frontend` pass (remaining lint warnings are pre-existing `no-explicit-any` in untouched files).
- Rendered the built app against a mocked API with Puppeteer at 390×844 and 1440×900 and visually verified: groups list/grid, group detail (tabs vs two-pane), create-group + expense modals (full page vs dialog), balances, and the bottom nav.

https://claude.ai/code/session_01PgcUxscJF32ARxGaX11sh7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgcUxscJF32ARxGaX11sh7)_