### PR TITLE
fix(split-frontend): prevent split amount inputs from overflowing the modal

### DIFF
--- a/apps/split-frontend/src/app/pages/group-detail/group-detail.component.scss
+++ b/apps/split-frontend/src/app/pages/group-detail/group-detail.component.scss
@@ -272,7 +272,6 @@
 .split-row {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 10px;
   padding: 6px 0;
   &.off {
@@ -281,12 +280,21 @@
 }
 
 .split-check {
+  flex: 1;
+  min-width: 0;
   display: flex;
   align-items: center;
   gap: 8px;
   font-weight: 500;
   cursor: pointer;
+  // Clip long names rather than pushing the input off-screen.
+  span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   input {
+    flex-shrink: 0;
     width: 18px;
     height: 18px;
     accent-color: var(--brand);
@@ -294,7 +302,16 @@
 }
 
 ::ng-deep .split-input {
-  max-width: 80px;
+  flex-shrink: 0;
+  width: 100px;
+  min-width: 0;
+
+  // The inner input must respect the container width regardless of currency
+  // prefix width — without this PrimeNG lets it grow beyond 100px.
+  .p-inputnumber-input {
+    width: 100%;
+    min-width: 0;
+  }
 }
 
 .split-hint {

--- a/apps/split-frontend/src/styles.scss
+++ b/apps/split-frontend/src/styles.scss
@@ -224,6 +224,9 @@ a {
 
 .responsive-modal .modal-body {
   flex: 1;
+  // overflow-x must be hidden (not auto) to prevent horizontal scroll;
+  // using hidden+auto on the same element is fine in modern browsers.
+  overflow-x: hidden;
   overflow-y: auto;
   padding: 18px 20px;
   -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
## Summary

Fixes the Exact/Percent per-member inputs escaping off the right edge of the expense modal.

**Root cause:** `.split-row` used `justify-content: space-between` but the label side had no flex growth constraint. PrimeNG's InputNumber expands to its intrinsic min-content width (driven by the inner `p-inputnumber-input`), so the row's total width exceeded the modal body, pushing the input off-screen.

**Fixes applied:**
- `.split-check` gets `flex: 1; min-width: 0` — the name side now absorbs available space and truncates long names instead of pushing the input out of bounds.
- `.split-input` (the component host) and its inner `.p-inputnumber-input` are both capped at 100px with `min-width: 0` so neither can grow past the row.
- `.modal-body` gets `overflow-x: hidden` as a belt-and-suspenders guard so no child can escape the modal container regardless.

## Test plan
- [ ] Open a group, tap Add expense, switch to Exact — inputs should sit flush inside the modal on both mobile (full-page) and desktop (dialog)
- [ ] Switch to Percent — same
- [ ] Long member names should truncate with ellipsis rather than pushing the input off-screen

https://claude.ai/code/session_01PgcUxscJF32ARxGaX11sh7

---
_Generated by [Claude Code](https://claude.ai/code/session_01PgcUxscJF32ARxGaX11sh7)_