### PR TITLE
Recipe system: responsive polish, AI tagging, better import, grocery fix

### DIFF
--- a/apps/recipes-frontend/src/app/components/ai-suggest/ai-suggest.component.ts
+++ b/apps/recipes-frontend/src/app/components/ai-suggest/ai-suggest.component.ts
@@ -1,0 +1,355 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { ButtonModule } from 'primeng/button';
+import {
+  Category,
+  RecipesApiService,
+  SuggestionContent,
+  SuggestionItem,
+  Tag,
+} from '../../services/recipes-api.service';
+
+/**
+ * Reusable "suggest categories & tags with AI" panel.
+ *
+ * Works from raw recipe content so it can be used before a recipe is saved
+ * (create form, AI import preview) as well as on the detail page. The AI may
+ * propose brand-new categories/tags; selecting one of those creates it via the
+ * API and emits `categoryCreated` / `tagCreated` so the host can add it to its
+ * own option list. Selection itself is delegated to the host through the
+ * apply/remove outputs, keeping this component compatible with both reactive
+ * forms and signal-based state.
+ */
+@Component({
+  selector: 'app-ai-suggest',
+  standalone: true,
+  imports: [ButtonModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="ai-suggest">
+      <div class="ai-suggest-bar">
+        <p-button
+          [label]="hasRun() ? 'Re-suggest' : 'Suggest with AI'"
+          icon="pi pi-sparkles"
+          severity="secondary"
+          [outlined]="true"
+          size="small"
+          (click)="suggest()"
+          [loading]="loading()"
+          [disabled]="loading() || !canSuggest()"
+        />
+        @if (!canSuggest() && !hasRun()) {
+        <span class="ai-suggest-hint">Add a title first</span>
+        }
+      </div>
+
+      @if (error()) {
+      <div class="ai-suggest-error">
+        <i class="pi pi-exclamation-circle"></i> {{ error() }}
+      </div>
+      } @if (categorySuggestions().length > 0) {
+      <div class="ai-suggest-group">
+        <span class="ai-suggest-label">Categories</span>
+        <div class="ai-suggest-chips">
+          @for (item of categorySuggestions(); track item.name) {
+          <button
+            type="button"
+            class="suggest-chip"
+            [class.applied]="isApplied(item, selectedCategoryIds())"
+            [class.is-new]="item.isNew"
+            [disabled]="isBusy(item.name)"
+            (click)="onCategoryClick(item)"
+          >
+            @if (isBusy(item.name)) {
+            <i class="pi pi-spin pi-spinner"></i>
+            } @else if (isApplied(item, selectedCategoryIds())) {
+            <i class="pi pi-check"></i>
+            } @else if (item.isNew) {
+            <i class="pi pi-plus"></i>
+            }
+            <span>{{ item.name }}</span>
+            @if (item.isNew) {
+            <span class="new-badge">new</span>
+            }
+          </button>
+          }
+        </div>
+      </div>
+      } @if (tagSuggestions().length > 0) {
+      <div class="ai-suggest-group">
+        <span class="ai-suggest-label">Tags</span>
+        <div class="ai-suggest-chips">
+          @for (item of tagSuggestions(); track item.name) {
+          <button
+            type="button"
+            class="suggest-chip"
+            [class.applied]="isApplied(item, selectedTagIds())"
+            [class.is-new]="item.isNew"
+            [disabled]="isBusy(item.name)"
+            (click)="onTagClick(item)"
+          >
+            @if (isBusy(item.name)) {
+            <i class="pi pi-spin pi-spinner"></i>
+            } @else if (isApplied(item, selectedTagIds())) {
+            <i class="pi pi-check"></i>
+            } @else if (item.isNew) {
+            <i class="pi pi-plus"></i>
+            }
+            <span>{{ item.name }}</span>
+            @if (item.isNew) {
+            <span class="new-badge">new</span>
+            }
+          </button>
+          }
+        </div>
+      </div>
+      } @if (hasRun() && !loading() && !error() && categorySuggestions().length
+      === 0 && tagSuggestions().length === 0) {
+      <div class="ai-suggest-empty">No suggestions for this recipe.</div>
+      }
+    </div>
+  `,
+  styles: `
+    @use 'styles/shared' as *;
+
+    .ai-suggest {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .ai-suggest-bar {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+
+    .ai-suggest-hint,
+    .ai-suggest-empty {
+      font-size: 0.8rem;
+      color: var(--p-text-muted-color);
+    }
+
+    .ai-suggest-error {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 0.82rem;
+      color: #ef4444;
+    }
+
+    .ai-suggest-group {
+      display: flex;
+      flex-direction: column;
+      gap: 6px;
+    }
+
+    .ai-suggest-label {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--p-text-muted-color);
+    }
+
+    .ai-suggest-chips {
+      @include chip-row;
+      gap: 8px;
+    }
+
+    .suggest-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 5px 12px;
+      border-radius: 16px;
+      border: 1px solid var(--p-surface-600);
+      background: var(--p-surface-800);
+      color: var(--p-text-color);
+      font-size: 0.8rem;
+      font-family: inherit;
+      cursor: pointer;
+      transition: all 0.15s ease;
+
+      i {
+        font-size: 0.75rem;
+      }
+
+      &:hover:not(:disabled) {
+        border-color: var(--p-primary-color);
+        color: var(--p-primary-color);
+      }
+
+      &.applied {
+        background: color-mix(in srgb, var(--p-primary-color) 18%, transparent);
+        border-color: var(--p-primary-color);
+        color: var(--p-primary-color);
+        font-weight: 600;
+      }
+
+      &.is-new:not(.applied) {
+        border-style: dashed;
+      }
+
+      &:disabled {
+        opacity: 0.7;
+        cursor: default;
+      }
+    }
+
+    .new-badge {
+      font-size: 0.6rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      padding: 1px 5px;
+      border-radius: 6px;
+      background: var(--p-surface-600);
+      color: var(--p-text-muted-color);
+    }
+  `,
+})
+export class AiSuggestComponent {
+  private api = inject(RecipesApiService);
+
+  /** Current recipe content used to generate suggestions. */
+  content = input<SuggestionContent | null>(null);
+  /** Currently selected ids, used to render the "applied" state. */
+  selectedCategoryIds = input<string[]>([]);
+  selectedTagIds = input<string[]>([]);
+
+  applyCategory = output<string>();
+  removeCategory = output<string>();
+  applyTag = output<string>();
+  removeTag = output<string>();
+  categoryCreated = output<Category>();
+  tagCreated = output<Tag>();
+
+  loading = signal(false);
+  hasRun = signal(false);
+  error = signal('');
+  categorySuggestions = signal<SuggestionItem[]>([]);
+  tagSuggestions = signal<SuggestionItem[]>([]);
+  private busyNames = signal<ReadonlySet<string>>(new Set());
+
+  canSuggest = computed(() => !!this.content()?.title?.trim());
+
+  isApplied(item: SuggestionItem, selected: string[]): boolean {
+    return item.id !== null && selected.includes(item.id);
+  }
+
+  isBusy(name: string): boolean {
+    return this.busyNames().has(name);
+  }
+
+  suggest() {
+    const content = this.content();
+    if (!content?.title?.trim() || this.loading()) return;
+
+    this.loading.set(true);
+    this.error.set('');
+
+    this.api.suggestTagsAndCategoriesForContent(content).subscribe({
+      next: (result) => {
+        this.categorySuggestions.set(result.suggestedCategories);
+        this.tagSuggestions.set(result.suggestedTags);
+        this.loading.set(false);
+        this.hasRun.set(true);
+      },
+      error: () => {
+        this.error.set('Could not get suggestions. Please try again.');
+        this.loading.set(false);
+        this.hasRun.set(true);
+      },
+    });
+  }
+
+  onCategoryClick(item: SuggestionItem) {
+    if (this.isBusy(item.name)) return;
+
+    if (item.id !== null) {
+      if (this.selectedCategoryIds().includes(item.id)) {
+        this.removeCategory.emit(item.id);
+      } else {
+        this.applyCategory.emit(item.id);
+      }
+      return;
+    }
+
+    // Brand-new category: create it, then apply.
+    this.setBusy(item.name, true);
+    this.api.createCategory({ name: item.name }).subscribe({
+      next: (created) => {
+        this.categoryCreated.emit(created);
+        this.applyCategory.emit(created.id);
+        this.markCreated(this.categorySuggestions, item.name, created.id);
+        this.setBusy(item.name, false);
+      },
+      error: () => {
+        this.error.set(`Could not create category "${item.name}".`);
+        this.setBusy(item.name, false);
+      },
+    });
+  }
+
+  onTagClick(item: SuggestionItem) {
+    if (this.isBusy(item.name)) return;
+
+    if (item.id !== null) {
+      if (this.selectedTagIds().includes(item.id)) {
+        this.removeTag.emit(item.id);
+      } else {
+        this.applyTag.emit(item.id);
+      }
+      return;
+    }
+
+    this.setBusy(item.name, true);
+    this.api.createTag({ name: item.name }).subscribe({
+      next: (created) => {
+        this.tagCreated.emit(created);
+        this.applyTag.emit(created.id);
+        this.markCreated(this.tagSuggestions, item.name, created.id);
+        this.setBusy(item.name, false);
+      },
+      error: () => {
+        this.error.set(`Could not create tag "${item.name}".`);
+        this.setBusy(item.name, false);
+      },
+    });
+  }
+
+  /** Reset suggestions (e.g. when the host content is replaced). */
+  reset() {
+    this.categorySuggestions.set([]);
+    this.tagSuggestions.set([]);
+    this.error.set('');
+    this.hasRun.set(false);
+  }
+
+  private setBusy(name: string, busy: boolean) {
+    this.busyNames.update((prev) => {
+      const next = new Set(prev);
+      if (busy) next.add(name);
+      else next.delete(name);
+      return next;
+    });
+  }
+
+  private markCreated(
+    list: typeof this.categorySuggestions,
+    name: string,
+    id: string
+  ) {
+    list.update((items) =>
+      items.map((i) => (i.name === name ? { ...i, id, isNew: false } : i))
+    );
+  }
+}

--- a/apps/recipes-frontend/src/app/pages/ai-import/ai-import.component.ts
+++ b/apps/recipes-frontend/src/app/pages/ai-import/ai-import.component.ts
@@ -204,9 +204,10 @@ import { Subscription } from 'rxjs';
     </div>
   `,
   styles: `
+    @use 'styles/shared' as *;
+
     .ai-import-page {
-      max-width: 800px;
-      margin: 0 auto;
+      @include page(800px);
     }
 
     .page-header {
@@ -214,8 +215,7 @@ import { Subscription } from 'rxjs';
     }
 
     .page-title {
-      font-size: 1.75rem;
-      font-weight: 700;
+      @include page-title;
       margin: 12px 0 0;
     }
 
@@ -431,6 +431,36 @@ import { Subscription } from 'rxjs';
       color: var(--p-text-muted-color);
       white-space: pre-wrap;
       margin: 0;
+    }
+
+    @include mobile {
+      .mode-toggle .mode-btn {
+        font-size: 0.82rem;
+        padding: 10px 8px;
+      }
+
+      .preview {
+        padding: 18px;
+      }
+
+      .ingredient-list {
+        grid-template-columns: max-content max-content 1fr;
+      }
+
+      .ingredient-list .ing-notes {
+        grid-column: 1 / -1;
+        padding-left: 0;
+      }
+    }
+
+    @include small {
+      .actions {
+        flex-direction: column-reverse;
+      }
+
+      .actions :where(p-button) {
+        width: 100%;
+      }
     }
   `,
 })

--- a/apps/recipes-frontend/src/app/pages/ai-import/ai-import.component.ts
+++ b/apps/recipes-frontend/src/app/pages/ai-import/ai-import.component.ts
@@ -2,21 +2,36 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
+  OnDestroy,
   signal,
 } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
-import { FormsModule } from '@angular/forms';
+import {
+  FormArray,
+  FormBuilder,
+  FormGroup,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from '@angular/forms';
 import { ButtonModule } from 'primeng/button';
 import { InputGroupModule } from 'primeng/inputgroup';
 import { InputGroupAddonModule } from 'primeng/inputgroupaddon';
 import { InputTextModule } from 'primeng/inputtext';
+import { InputNumberModule } from 'primeng/inputnumber';
+import { MultiSelectModule } from 'primeng/multiselect';
+import { CardModule } from 'primeng/card';
 import { ProgressBarModule } from 'primeng/progressbar';
 import { TextareaModule } from 'primeng/textarea';
 import {
   RecipesApiService,
   ParsedRecipe,
-  ImportProgressEvent,
+  Category,
+  Tag,
+  RecipeInput,
+  SuggestionContent,
 } from '../../services/recipes-api.service';
+import { AiSuggestComponent } from '../../components/ai-suggest/ai-suggest.component';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -25,12 +40,17 @@ import { Subscription } from 'rxjs';
   imports: [
     RouterModule,
     FormsModule,
+    ReactiveFormsModule,
     ButtonModule,
     InputGroupModule,
     InputGroupAddonModule,
     InputTextModule,
+    InputNumberModule,
+    MultiSelectModule,
+    CardModule,
     ProgressBarModule,
     TextareaModule,
+    AiSuggestComponent,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
@@ -59,14 +79,16 @@ import { Subscription } from 'rxjs';
           [showValue]="false"
           [style]="{ height: '6px' }"
         />
-        <p class="progress-detail">{{ progressDetail() }}</p>
+        <p class="progress-detail">
+          {{ progressDetail() || 'This can take up to a minute for big pages.' }}
+        </p>
       </div>
       } @else if (!parsed()) {
       <!-- Input Phase -->
       <div class="input-section">
         <p class="intro-text">
           Import a recipe from a URL or paste recipe text and AI will parse it
-          into a structured recipe for you.
+          into a structured recipe you can review and tweak before saving.
         </p>
 
         <!-- Mode Toggle -->
@@ -97,6 +119,7 @@ import { Subscription } from 'rxjs';
             [(ngModel)]="urlText"
             placeholder="https://www.allrecipes.com/recipe/..."
             class="full-width"
+            (keydown.enter)="parseUrl()"
           />
         </p-inputgroup>
         <p class="helper-text">
@@ -115,7 +138,12 @@ import { Subscription } from 'rxjs';
         } @if (error()) {
         <div class="error-banner">
           <i class="pi pi-exclamation-triangle"></i>
-          {{ error() }}
+          <span>{{ error() }}</span>
+          @if (mode() === 'url') {
+          <button class="link-btn" (click)="switchToText()">
+            Paste text instead
+          </button>
+          }
         </div>
         }
 
@@ -129,74 +157,210 @@ import { Subscription } from 'rxjs';
         </div>
       </div>
       } @else {
-      <!-- Preview Phase -->
+      <!-- Editable Preview Phase -->
       <div class="preview-section">
         <div class="success-indicator">
           <i class="pi pi-check-circle"></i>
-          Recipe parsed successfully!
+          Recipe parsed — review and edit anything before saving.
         </div>
 
-        <div class="preview">
-          <h2 class="preview-title">{{ parsed()!.title }}</h2>
-          @if (parsed()!.description) {
-          <p class="preview-desc">{{ parsed()!.description }}</p>
-          }
+        <form [formGroup]="form">
+          <p-card header="Details" styleClass="form-card">
+            <div class="form-grid">
+              <div class="form-field full-width">
+                <label for="title">Title *</label>
+                <input
+                  pInputText
+                  id="title"
+                  formControlName="title"
+                  placeholder="Recipe title"
+                />
+              </div>
+              <div class="form-field full-width">
+                <label for="description">Description</label>
+                <textarea
+                  pTextarea
+                  [autoResize]="true"
+                  id="description"
+                  formControlName="description"
+                  rows="2"
+                ></textarea>
+              </div>
+              <div class="form-field">
+                <label for="servings">Servings</label>
+                <p-inputnumber
+                  id="servings"
+                  formControlName="servings"
+                  [min]="1"
+                  [showButtons]="true"
+                  [fluid]="true"
+                />
+              </div>
+              <div class="form-field">
+                <label for="prep">Prep (min)</label>
+                <p-inputnumber
+                  id="prep"
+                  formControlName="prepTimeMinutes"
+                  [min]="0"
+                  [showButtons]="true"
+                  [fluid]="true"
+                />
+              </div>
+              <div class="form-field">
+                <label for="cook">Cook (min)</label>
+                <p-inputnumber
+                  id="cook"
+                  formControlName="cookTimeMinutes"
+                  [min]="0"
+                  [showButtons]="true"
+                  [fluid]="true"
+                />
+              </div>
+              <div class="form-field">
+                <label for="source">Source</label>
+                <input
+                  pInputText
+                  id="source"
+                  formControlName="source"
+                  placeholder="URL or reference"
+                />
+              </div>
+            </div>
+          </p-card>
 
-          <div class="preview-meta">
-            @if (parsed()!.prepTimeMinutes) {
-            <div class="meta-badge">
-              <i class="pi pi-stopwatch"></i>
-              <span>{{ parsed()!.prepTimeMinutes }}m prep</span>
-            </div>
-            } @if (parsed()!.cookTimeMinutes) {
-            <div class="meta-badge">
-              <i class="pi pi-clock"></i>
-              <span>{{ parsed()!.cookTimeMinutes }}m cook</span>
-            </div>
-            } @if (parsed()!.servings) {
-            <div class="meta-badge">
-              <i class="pi pi-users"></i>
-              <span>{{ parsed()!.servings }} servings</span>
-            </div>
+          <p-card header="Ingredients" styleClass="form-card">
+            @if (ingredients.length === 0) {
+            <p class="empty-message">No ingredients parsed — add some below.</p>
             }
-          </div>
-
-          <div class="preview-detail">
-            <h3>Ingredients</h3>
-            <ul class="ingredient-list">
-              @for (ing of parsed()!.ingredients; track $index) {
-              <li>
-                <span class="ing-qty">{{ ing.quantity }}</span>
-                <span class="ing-unit">{{ ing.unit }}</span>
-                <span class="ing-name">{{ ing.name }}</span>
-                @if (ing.notes) {
-                <span class="ing-notes">({{ ing.notes }})</span>
-                }
-              </li>
+            <div class="ingredients-list" formArrayName="ingredients">
+              @for (ing of ingredients.controls; track $index; let i = $index) {
+              <div class="ingredient-row" [formGroupName]="i">
+                <p-inputnumber
+                  formControlName="quantity"
+                  placeholder="Qty"
+                  [min]="0"
+                  [fluid]="true"
+                  class="ing-qty-input"
+                />
+                <input
+                  pInputText
+                  formControlName="unit"
+                  placeholder="Unit"
+                  class="ing-unit-input"
+                />
+                <input
+                  pInputText
+                  formControlName="name"
+                  placeholder="Ingredient name"
+                  class="ing-name-input"
+                />
+                <input
+                  pInputText
+                  formControlName="notes"
+                  placeholder="Notes"
+                  class="ing-notes-input"
+                />
+                <p-button
+                  icon="pi pi-trash"
+                  severity="danger"
+                  [text]="true"
+                  [rounded]="true"
+                  (click)="removeIngredient(i)"
+                />
+              </div>
               }
-            </ul>
-          </div>
+            </div>
+            <p-button
+              label="Add Ingredient"
+              icon="pi pi-plus"
+              severity="secondary"
+              [outlined]="true"
+              (click)="addIngredient()"
+              styleClass="mt-3"
+            />
+          </p-card>
 
-          @if (parsed()!.instructions) {
-          <div class="preview-detail">
-            <h3>Instructions</h3>
-            <p class="instructions-text">{{ parsed()!.instructions }}</p>
-          </div>
+          <p-card header="Instructions" styleClass="form-card">
+            <textarea
+              pTextarea
+              [autoResize]="true"
+              formControlName="instructions"
+              rows="10"
+              placeholder="Recipe instructions (Markdown supported)"
+              class="full-width"
+            ></textarea>
+          </p-card>
+
+          <p-card header="Categories & Tags" styleClass="form-card">
+            <div class="form-grid">
+              <div class="form-field">
+                <label>Categories</label>
+                <p-multiselect
+                  [options]="categories()"
+                  formControlName="categoryIds"
+                  optionLabel="name"
+                  optionValue="id"
+                  placeholder="Select categories"
+                  display="chip"
+                  [fluid]="true"
+                />
+              </div>
+              <div class="form-field">
+                <label>Tags</label>
+                <p-multiselect
+                  [options]="tags()"
+                  formControlName="tagIds"
+                  optionLabel="name"
+                  optionValue="id"
+                  placeholder="Select tags"
+                  display="chip"
+                  [fluid]="true"
+                />
+              </div>
+              <div class="form-field full-width ai-suggest-field">
+                <app-ai-suggest
+                  [content]="suggestionContent()"
+                  [selectedCategoryIds]="form.value.categoryIds || []"
+                  [selectedTagIds]="form.value.tagIds || []"
+                  (applyCategory)="toggleSelection('categoryIds', $event, true)"
+                  (removeCategory)="
+                    toggleSelection('categoryIds', $event, false)
+                  "
+                  (applyTag)="toggleSelection('tagIds', $event, true)"
+                  (removeTag)="toggleSelection('tagIds', $event, false)"
+                  (categoryCreated)="categories.set([...categories(), $event])"
+                  (tagCreated)="tags.set([...tags(), $event])"
+                />
+              </div>
+            </div>
+          </p-card>
+
+          @if (imageUrls().length > 0) {
+          <p-card header="Photos" styleClass="form-card">
+            <p class="photos-note">
+              <i class="pi pi-image"></i>
+              {{ imageUrls().length }} photo{{
+                imageUrls().length === 1 ? '' : 's'
+              }}
+              will be imported from the source.
+            </p>
+          </p-card>
           }
-        </div>
+        </form>
 
         <div class="actions">
           <p-button
-            label="Try Again"
+            label="Start Over"
             severity="secondary"
             [outlined]="true"
             icon="pi pi-refresh"
-            (click)="parsed.set(null)"
+            (click)="reset()"
           />
           <p-button
             label="Create Recipe"
             icon="pi pi-check"
             (click)="create()"
+            [disabled]="form.invalid"
           />
         </div>
       </div>
@@ -314,6 +478,17 @@ import { Subscription } from 'rxjs';
       display: flex;
       align-items: center;
       gap: 8px;
+      flex-wrap: wrap;
+    }
+
+    .link-btn {
+      background: none;
+      border: none;
+      color: #ef4444;
+      text-decoration: underline;
+      cursor: pointer;
+      font: inherit;
+      padding: 0;
     }
 
     .actions {
@@ -336,136 +511,130 @@ import { Subscription } from 'rxjs';
       margin-bottom: 20px;
     }
 
-    .preview {
-      background: var(--p-surface-800);
-      border-radius: 12px;
-      padding: 24px;
+    :host ::ng-deep .form-card {
+      margin-bottom: 16px;
     }
 
-    .preview-title {
-      margin: 0 0 8px;
-      font-size: 1.4rem;
-      font-weight: 700;
+    .form-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 16px;
     }
 
-    .preview-desc {
-      color: var(--p-text-muted-color);
-      margin: 0 0 16px;
-      font-size: 0.95rem;
+    .full-width {
+      grid-column: 1 / -1;
     }
 
-    .preview-meta {
+    .ai-suggest-field {
+      padding-top: 12px;
+      border-top: 1px dashed var(--p-surface-700);
+    }
+
+    .form-field {
       display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-      margin-bottom: 20px;
+      flex-direction: column;
+      gap: 6px;
+
+      label {
+        font-size: 0.85rem;
+        font-weight: 500;
+        color: var(--p-text-muted-color);
+      }
+
+      input,
+      textarea {
+        width: 100%;
+      }
     }
 
-    .meta-badge {
-      display: inline-flex;
+    .ingredients-list {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .ingredient-row {
+      display: flex;
+      gap: 8px;
       align-items: center;
-      gap: 6px;
-      padding: 6px 14px;
-      border-radius: 20px;
-      background: var(--p-surface-700);
-      font-size: 0.85rem;
+    }
+
+    .ing-qty-input,
+    .ing-unit-input {
+      width: 80px;
+      min-width: 80px;
+      max-width: 80px;
+      flex-shrink: 0;
+    }
+
+    .ing-name-input {
+      flex: 1;
+      min-width: 0;
+    }
+
+    .ing-notes-input {
+      width: 120px;
+      min-width: 120px;
+      max-width: 120px;
+      flex-shrink: 0;
+    }
+
+    .empty-message {
       color: var(--p-text-muted-color);
+      text-align: center;
+      padding: 16px;
+      margin: 0;
+    }
+
+    .photos-note {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin: 0;
+      color: var(--p-text-muted-color);
+      font-size: 0.9rem;
 
       i {
         color: var(--p-primary-color);
       }
     }
 
-    .preview-detail {
-      margin-bottom: 20px;
-
-      h3 {
-        font-size: 1rem;
-        font-weight: 600;
-        margin: 0 0 10px;
-      }
-    }
-
-    .ingredient-list {
-      list-style: none;
-      padding: 0;
-      margin: 0;
-      display: grid;
-      grid-template-columns: max-content max-content 1fr max-content;
-      gap: 6px 0;
-
-      li {
-        display: grid;
-        grid-template-columns: subgrid;
-        grid-column: 1 / -1;
-        gap: 0 10px;
-        padding: 8px 12px;
-        background: var(--p-surface-700);
-        border-radius: 6px;
-        font-size: 0.9rem;
-      }
-    }
-
-    .ing-qty {
-      font-weight: 600;
-      color: var(--p-primary-color);
-      text-align: right;
-    }
-
-    .ing-unit {
-      color: var(--p-text-muted-color);
-    }
-
-    .ing-name {
-      font-weight: 600;
-    }
-
-    .ing-notes {
-      color: var(--p-text-muted-color);
-      font-style: italic;
-    }
-
-    .instructions-text {
-      font-size: 0.95rem;
-      line-height: 1.7;
-      color: var(--p-text-muted-color);
-      white-space: pre-wrap;
-      margin: 0;
-    }
-
-    @include mobile {
-      .mode-toggle .mode-btn {
-        font-size: 0.82rem;
-        padding: 10px 8px;
-      }
-
-      .preview {
-        padding: 18px;
-      }
-
-      .ingredient-list {
-        grid-template-columns: max-content max-content 1fr;
-      }
-
-      .ingredient-list .ing-notes {
-        grid-column: 1 / -1;
-        padding-left: 0;
-      }
-    }
-
     @include small {
+      .form-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .ingredient-row {
+        flex-wrap: wrap;
+      }
+
+      .ing-qty-input,
+      .ing-unit-input {
+        width: calc(50% - 4px);
+        min-width: 0;
+        max-width: none;
+      }
+
+      .ing-name-input {
+        flex-basis: 100%;
+      }
+
+      .ing-notes-input {
+        flex: 1;
+        width: auto;
+        min-width: 0;
+        max-width: none;
+      }
+
       .actions {
         flex-direction: column-reverse;
-      }
-
-      .actions :where(p-button) {
-        width: 100%;
       }
     }
   `,
 })
-export class AiImportComponent {
+export class AiImportComponent implements OnDestroy {
   private api = inject(RecipesApiService);
+  private fb = inject(FormBuilder);
   router = inject(Router);
 
   mode = signal<'url' | 'text'>('url');
@@ -479,7 +648,86 @@ export class AiImportComponent {
   progressMessage = signal('Starting...');
   progressDetail = signal('');
 
+  categories = signal<Category[]>([]);
+  tags = signal<Tag[]>([]);
+  imageUrls = signal<string[]>([]);
+
+  form: FormGroup = this.fb.group({
+    title: ['', Validators.required],
+    description: [''],
+    servings: [4],
+    prepTimeMinutes: [null as number | null],
+    cookTimeMinutes: [null as number | null],
+    source: [''],
+    categoryIds: [[] as string[]],
+    tagIds: [[] as string[]],
+    ingredients: this.fb.array([]),
+    instructions: [''],
+  });
+
   private streamSub?: Subscription;
+
+  constructor() {
+    this.api.getCategories().subscribe((c) => this.categories.set(c));
+    this.api.getTags().subscribe((t) => this.tags.set(t));
+  }
+
+  ngOnDestroy() {
+    this.streamSub?.unsubscribe();
+  }
+
+  get ingredients(): FormArray {
+    return this.form.get('ingredients') as FormArray;
+  }
+
+  suggestionContent(): SuggestionContent {
+    const v = this.form.value;
+    return {
+      title: v.title || '',
+      description: v.description || undefined,
+      instructions: v.instructions || undefined,
+      ingredients: (v.ingredients || [])
+        .map((i: { name?: string }) => ({ name: (i.name || '').trim() }))
+        .filter((i: { name: string }) => i.name.length > 0),
+    };
+  }
+
+  toggleSelection(
+    control: 'categoryIds' | 'tagIds',
+    id: string,
+    selected: boolean
+  ) {
+    const current: string[] = this.form.get(control)?.value || [];
+    const next = selected
+      ? current.includes(id)
+        ? current
+        : [...current, id]
+      : current.filter((x) => x !== id);
+    this.form.get(control)?.setValue(next);
+  }
+
+  addIngredient() {
+    this.ingredients.push(
+      this.fb.group({ quantity: [1], unit: [''], name: [''], notes: [''] })
+    );
+  }
+
+  removeIngredient(index: number) {
+    this.ingredients.removeAt(index);
+  }
+
+  switchToText() {
+    this.mode.set('text');
+    this.error.set('');
+  }
+
+  reset() {
+    this.streamSub?.unsubscribe();
+    this.parsed.set(null);
+    this.imageUrls.set([]);
+    this.error.set('');
+    this.resetProgress();
+  }
 
   private resetProgress() {
     this.progressPercent.set(0);
@@ -500,15 +748,15 @@ export class AiImportComponent {
           this.progressPercent.set(event.percent ?? 0);
           this.progressMessage.set(event.message ?? 'Processing...');
         } else if (event.type === 'result' && event.result) {
-          this.parsed.set(event.result);
+          this.populateForm(event.result);
           this.parsing.set(false);
         }
       },
       error: (err) => {
-        const message =
+        this.error.set(
           err?.message ||
-          'Failed to import recipe from URL. Try pasting the text instead.';
-        this.error.set(message);
+            'Failed to import recipe from URL. Try pasting the text instead.'
+        );
         this.parsing.set(false);
       },
     });
@@ -529,7 +777,7 @@ export class AiImportComponent {
             this.progressPercent.set(event.percent ?? 0);
             this.progressMessage.set(event.message ?? 'Processing...');
           } else if (event.type === 'result' && event.result) {
-            this.parsed.set(event.result);
+            this.populateForm(event.result);
             this.parsing.set(false);
           }
         },
@@ -540,68 +788,106 @@ export class AiImportComponent {
       });
   }
 
+  private populateForm(recipe: ParsedRecipe) {
+    this.ingredients.clear();
+    (recipe.ingredients || []).forEach((ing) => {
+      this.ingredients.push(
+        this.fb.group({
+          quantity: [ing.quantity ?? 1],
+          unit: [ing.unit ?? ''],
+          name: [ing.name ?? ''],
+          notes: [ing.notes ?? ''],
+        })
+      );
+    });
+
+    this.form.patchValue({
+      title: recipe.title || '',
+      description: recipe.description || '',
+      servings: recipe.servings ?? 4,
+      prepTimeMinutes: recipe.prepTimeMinutes ?? null,
+      cookTimeMinutes: recipe.cookTimeMinutes ?? null,
+      source: recipe.source || '',
+      categoryIds: [],
+      tagIds: [],
+      instructions: recipe.instructions || '',
+    });
+
+    this.imageUrls.set(recipe.imageUrls ?? []);
+    this.parsed.set(recipe);
+  }
+
   create() {
-    const recipe = this.parsed();
-    if (!recipe) return;
+    if (this.form.invalid) return;
+    const v = this.form.value;
 
     this.creating.set(true);
     this.progressPercent.set(30);
     this.progressMessage.set('Creating recipe...');
     this.progressDetail.set('');
 
-    this.api
-      .createRecipe({
-        title: recipe.title,
-        description: recipe.description,
-        instructions: recipe.instructions,
-        servings: recipe.servings,
-        prepTimeMinutes: recipe.prepTimeMinutes,
-        cookTimeMinutes: recipe.cookTimeMinutes,
-        source: recipe.source,
-        ingredients: recipe.ingredients.map((ing, idx) => ({
-          name: ing.name,
-          quantity: ing.quantity,
-          unit: ing.unit,
-          notes: ing.notes,
+    const input: RecipeInput = {
+      title: v.title,
+      description: v.description || undefined,
+      instructions: v.instructions || undefined,
+      servings: v.servings || undefined,
+      prepTimeMinutes: v.prepTimeMinutes || undefined,
+      cookTimeMinutes: v.cookTimeMinutes || undefined,
+      source: v.source || undefined,
+      categoryIds: v.categoryIds || [],
+      tagIds: v.tagIds || [],
+      ingredients: (v.ingredients || []).map(
+        (
+          i: { quantity: number; unit: string; name: string; notes: string },
+          idx: number
+        ) => ({
+          name: i.name,
+          quantity: i.quantity,
+          unit: i.unit,
+          notes: i.notes || undefined,
           orderIndex: idx,
-        })),
-      })
-      .subscribe((created) => {
+        })
+      ),
+    };
+
+    this.api.createRecipe(input).subscribe({
+      next: (created) => {
         const navigateToRecipe = () => {
           this.creating.set(false);
           this.router.navigate(['/recipes', created.id]);
         };
 
-        // Import photos from URLs if available
-        if (recipe.imageUrls?.length) {
+        const urls = this.imageUrls();
+        if (urls.length) {
           this.progressPercent.set(65);
           this.progressMessage.set('Importing photos...');
           this.progressDetail.set(
-            `Downloading ${recipe.imageUrls.length} image${
-              recipe.imageUrls.length > 1 ? 's' : ''
-            }...`
+            `Downloading ${urls.length} image${urls.length > 1 ? 's' : ''}...`
           );
 
-          this.api
-            .importPhotosFromUrls(created.id, recipe.imageUrls)
-            .subscribe({
-              next: (result) => {
-                this.progressPercent.set(100);
-                this.progressMessage.set('Done!');
-                this.progressDetail.set(
-                  `Imported ${result.imported} photo${
-                    result.imported !== 1 ? 's' : ''
-                  }`
-                );
-                setTimeout(() => navigateToRecipe(), 400);
-              },
-              error: () => navigateToRecipe(),
-            });
+          this.api.importPhotosFromUrls(created.id, urls).subscribe({
+            next: (result) => {
+              this.progressPercent.set(100);
+              this.progressMessage.set('Done!');
+              this.progressDetail.set(
+                `Imported ${result.imported} photo${
+                  result.imported !== 1 ? 's' : ''
+                }`
+              );
+              setTimeout(navigateToRecipe, 400);
+            },
+            error: navigateToRecipe,
+          });
         } else {
           this.progressPercent.set(100);
           this.progressMessage.set('Done!');
-          setTimeout(() => navigateToRecipe(), 300);
+          setTimeout(navigateToRecipe, 300);
         }
-      });
+      },
+      error: () => {
+        this.creating.set(false);
+        this.error.set('Could not create the recipe. Please try again.');
+      },
+    });
   }
 }

--- a/apps/recipes-frontend/src/app/pages/categories/categories.component.ts
+++ b/apps/recipes-frontend/src/app/pages/categories/categories.component.ts
@@ -98,8 +98,9 @@ import {
         [(visible)]="formVisible"
         [header]="editing() ? 'Edit Category' : 'New Category'"
         [modal]="true"
-        [style]="{ width: '400px' }"
+        [style]="{ width: '90vw', maxWidth: '420px' }"
         [closable]="true"
+        [dismissableMask]="true"
       >
         <div class="form-fields">
           <div class="form-field">
@@ -148,64 +149,50 @@ import {
     </div>
   `,
   styles: `
+    @use 'styles/shared' as *;
+    @include fade-in-keyframes;
+
     .categories-page {
-      max-width: 1000px;
-      margin: 0 auto;
+      @include page(1000px);
     }
 
     .page-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 24px;
+      @include page-header;
 
       h1 {
-        margin: 0 0 4px;
-        font-size: 1.5rem;
-        font-weight: 700;
+        @include page-title;
       }
 
       .subtitle {
-        margin: 0;
-        color: var(--p-text-muted-color);
-        font-size: 0.9rem;
+        @include page-subtitle;
       }
     }
 
     .loading-container {
-      display: flex;
-      justify-content: center;
-      padding: 64px 0;
+      @include loading-container;
     }
 
     .empty-state {
-      text-align: center;
-      padding: 64px 0;
-      color: var(--p-text-muted-color);
-
-      i {
-        font-size: 3rem;
-        margin-bottom: 16px;
-      }
+      @include empty-state;
     }
 
     .categories-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
       gap: 16px;
     }
 
     .category-card {
+      @include card;
+      @include fade-in;
       display: flex;
-      background: var(--p-surface-800);
-      border-radius: 12px;
       overflow: hidden;
-      animation: fadeIn 0.3s ease-out both;
-      transition: transform 0.2s, box-shadow 0.2s;
+      transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
 
       &:hover {
         transform: translateY(-2px);
         box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+        border-color: var(--p-surface-600);
       }
     }
 
@@ -267,17 +254,6 @@ import {
       display: flex;
       gap: 8px;
       justify-content: flex-end;
-    }
-
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
-        transform: translateY(8px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
     }
   `,
 })

--- a/apps/recipes-frontend/src/app/pages/grocery-list/grocery-list.component.ts
+++ b/apps/recipes-frontend/src/app/pages/grocery-list/grocery-list.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
   inject,
   OnInit,
   signal,
@@ -57,7 +58,11 @@ interface RecipeSelection {
           <div class="recipe-selection-list">
             @for (sel of recipeSelections(); track sel.recipe.id) {
             <div class="recipe-selection-row">
-              <p-checkbox [(ngModel)]="sel.selected" [binary]="true" />
+              <p-checkbox
+                [(ngModel)]="sel.selected"
+                [binary]="true"
+                (ngModelChange)="bumpSelections()"
+              />
               <label>{{ sel.recipe.title }}</label>
               @if (sel.selected) {
               <div class="servings-input">
@@ -303,7 +308,19 @@ export class GroceryListComponent implements OnInit {
   groceryList = signal<GroceryList | null>(null);
   checkedItems = signal<Array<GroceryItem & { checked: boolean }>>([]);
 
-  selectedCount = signal(0);
+  // Recomputed whenever the selection set changes (see bumpSelections).
+  selectedCount = computed(
+    () => this.recipeSelections().filter((s) => s.selected).length
+  );
+
+  /**
+   * The checkbox mutates `sel.selected` in place via ngModel; reassign the
+   * signal's array so the `selectedCount` computed (and the Generate button's
+   * disabled state) re-evaluate.
+   */
+  bumpSelections() {
+    this.recipeSelections.update((list) => [...list]);
+  }
 
   ngOnInit() {
     this.api.getRecipes().subscribe((recipes) => {

--- a/apps/recipes-frontend/src/app/pages/grocery-list/grocery-list.component.ts
+++ b/apps/recipes-frontend/src/app/pages/grocery-list/grocery-list.component.ts
@@ -137,31 +137,26 @@ interface RecipeSelection {
     </div>
   `,
   styles: `
+    @use 'styles/shared' as *;
+
     .grocery-page {
-      max-width: 1100px;
-      margin: 0 auto;
+      @include page(1100px);
     }
 
     .page-header {
       margin-bottom: 24px;
 
       h1 {
-        margin: 0 0 4px;
-        font-size: 1.5rem;
-        font-weight: 700;
+        @include page-title;
       }
 
       .subtitle {
-        margin: 0;
-        color: var(--p-text-muted-color);
-        font-size: 0.9rem;
+        @include page-subtitle;
       }
     }
 
     .loading-container {
-      display: flex;
-      justify-content: center;
-      padding: 64px 0;
+      @include loading-container;
     }
 
     .grocery-layout {
@@ -288,9 +283,13 @@ interface RecipeSelection {
       border-top: 1px solid var(--p-surface-700);
     }
 
-    @media (max-width: 768px) {
+    @include mobile {
       .grocery-layout {
         grid-template-columns: 1fr;
+      }
+
+      .list-actions {
+        flex-wrap: wrap;
       }
     }
   `,

--- a/apps/recipes-frontend/src/app/pages/random/random.component.ts
+++ b/apps/recipes-frontend/src/app/pages/random/random.component.ts
@@ -130,9 +130,10 @@ import {
     </div>
   `,
   styles: `
+    @use 'styles/shared' as *;
+
     .random-page {
-      max-width: 600px;
-      margin: 0 auto;
+      @include page(600px);
       text-align: center;
     }
 
@@ -254,6 +255,20 @@ import {
       to {
         opacity: 1;
         transform: translateY(0);
+      }
+    }
+
+    @include small {
+      .hero h1 {
+        font-size: 1.6rem;
+      }
+
+      .result-card {
+        padding: 24px 18px;
+      }
+
+      .result-actions {
+        flex-direction: column;
       }
     }
   `,

--- a/apps/recipes-frontend/src/app/pages/recipe-detail/recipe-detail.component.ts
+++ b/apps/recipes-frontend/src/app/pages/recipe-detail/recipe-detail.component.ts
@@ -33,8 +33,10 @@ import {
   RecipePhoto,
   Category,
   Tag,
+  SuggestionContent,
 } from '../../services/recipes-api.service';
 import { marked } from 'marked';
+import { AiSuggestComponent } from '../../components/ai-suggest/ai-suggest.component';
 
 @Component({
   selector: 'app-recipe-detail',
@@ -51,6 +53,7 @@ import { marked } from 'marked';
     GalleriaModule,
     MultiSelectModule,
     TooltipModule,
+    AiSuggestComponent,
   ],
   providers: [ConfirmationService],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -178,6 +181,19 @@ import { marked } from 'marked';
               [filter]="true"
               filterPlaceholder="Search..."
               [fluid]="true"
+            />
+          </div>
+          <div class="chips-edit-suggest">
+            <app-ai-suggest
+              [content]="suggestionContent()"
+              [selectedCategoryIds]="selectedCategoryIds"
+              [selectedTagIds]="selectedTagIds"
+              (applyCategory)="toggleChip('category', $event, true)"
+              (removeCategory)="toggleChip('category', $event, false)"
+              (applyTag)="toggleChip('tag', $event, true)"
+              (removeTag)="toggleChip('tag', $event, false)"
+              (categoryCreated)="allCategories.set([...allCategories(), $event])"
+              (tagCreated)="allTags.set([...allTags(), $event])"
             />
           </div>
           <div class="chips-edit-actions">
@@ -661,6 +677,11 @@ import { marked } from 'marked';
         font-weight: 500;
         color: var(--p-text-muted-color);
       }
+    }
+
+    .chips-edit-suggest {
+      padding-top: 12px;
+      border-top: 1px dashed var(--p-surface-700);
     }
 
     .chips-edit-actions {
@@ -1608,6 +1629,33 @@ export class RecipeDetailComponent implements OnInit, OnDestroy {
 
   cancelEditingChips() {
     this.editingChips.set(false);
+  }
+
+  /** Recipe content used to drive AI category/tag suggestions. */
+  suggestionContent(): SuggestionContent {
+    const r = this.recipe();
+    return {
+      title: r?.title || '',
+      description: r?.description || undefined,
+      instructions: r?.instructions || undefined,
+      ingredients: (r?.ingredients || []).map((i) => ({ name: i.name })),
+    };
+  }
+
+  /** Add or remove an id from the in-progress category/tag selection. */
+  toggleChip(kind: 'category' | 'tag', id: string, selected: boolean) {
+    const current =
+      kind === 'category' ? this.selectedCategoryIds : this.selectedTagIds;
+    const next = selected
+      ? current.includes(id)
+        ? current
+        : [...current, id]
+      : current.filter((x) => x !== id);
+    if (kind === 'category') {
+      this.selectedCategoryIds = next;
+    } else {
+      this.selectedTagIds = next;
+    }
   }
 
   saveChips() {

--- a/apps/recipes-frontend/src/app/pages/recipe-detail/recipe-detail.component.ts
+++ b/apps/recipes-frontend/src/app/pages/recipe-detail/recipe-detail.component.ts
@@ -340,7 +340,7 @@ import { marked } from 'marked';
           <div class="section">
             <h2 class="section-title">Instructions</h2>
             <div
-              class="markdown-content"
+              class="markdown-content instructions"
               [innerHTML]="renderedInstructions()"
             ></div>
           </div>
@@ -550,15 +550,14 @@ import { marked } from 'marked';
     }
   `,
   styles: `
+    @use 'styles/shared' as *;
+
     .loading-container {
-      display: flex;
-      justify-content: center;
-      padding: 64px 0;
+      @include loading-container;
     }
 
     .recipe-detail {
-      max-width: 1800px;
-      margin: 0 auto;
+      @include page(1200px);
     }
 
     .detail-header {
@@ -621,27 +620,18 @@ import { marked } from 'marked';
     }
 
     .chips-section {
-      display: flex;
-      flex-wrap: wrap;
+      @include chip-row;
       gap: 8px;
       margin-bottom: 24px;
       align-items: center;
     }
 
     .category-chip {
-      padding: 4px 12px;
-      border-radius: 12px;
-      font-size: 0.8rem;
-      font-weight: 600;
+      @include chip-category;
     }
 
     .tag-chip {
-      padding: 4px 12px;
-      border: 1.5px solid;
-      border-radius: 12px;
-      font-size: 0.8rem;
-      font-weight: 500;
-      background: transparent;
+      @include chip-tag;
     }
 
     .no-chips-hint {
@@ -737,13 +727,8 @@ import { marked } from 'marked';
       min-width: 0;
     }
 
-    .instructions-section {
-      .section-title {
-        margin-bottom: 20px;
-      }
-    }
-
-    .instructions-content {
+    // Instructions: render an ordered list as numbered "step" cards.
+    .markdown-content.instructions {
       :deep(ol) {
         padding-left: 0;
         list-style: none;
@@ -1285,7 +1270,7 @@ import { marked } from 'marked';
     }
 
     .tips-section-header:has(.pi-exclamation-triangle) i {
-      color: var(--p-orange-400);
+      color: #f59e0b;
     }
 
     .tip-card {
@@ -1305,7 +1290,7 @@ import { marked } from 'marked';
       }
 
       &.mistake {
-        border-left: 3px solid var(--p-orange-400);
+        border-left: 3px solid #f59e0b;
       }
     }
 
@@ -1392,7 +1377,7 @@ import { marked } from 'marked';
     }
 
     // ===== RESPONSIVE: Tablet =====
-    @media (max-width: 1024px) {
+    @include tablet {
       .recipe-body {
         grid-template-columns: 1fr;
         gap: 24px;
@@ -1409,11 +1394,7 @@ import { marked } from 'marked';
     }
 
     // ===== RESPONSIVE: Mobile =====
-    @media (max-width: 640px) {
-      .recipe-detail {
-        margin: 0 -4px;
-      }
-
+    @include mobile {
       .recipe-title {
         font-size: 1.5rem;
       }
@@ -1465,7 +1446,7 @@ import { marked } from 'marked';
         gap: 8px;
       }
 
-      .instructions-content {
+      .markdown-content.instructions {
         :deep(ol li) {
           padding: 10px 12px 10px 42px;
 

--- a/apps/recipes-frontend/src/app/pages/recipe-form/recipe-form.component.ts
+++ b/apps/recipes-frontend/src/app/pages/recipe-form/recipe-form.component.ts
@@ -28,7 +28,9 @@ import {
   Category,
   Tag,
   RecipeInput,
+  SuggestionContent,
 } from '../../services/recipes-api.service';
+import { AiSuggestComponent } from '../../components/ai-suggest/ai-suggest.component';
 
 @Component({
   selector: 'app-recipe-form',
@@ -44,6 +46,7 @@ import {
     ConfirmDialogModule,
     ProgressSpinnerModule,
     TextareaModule,
+    AiSuggestComponent,
   ],
   providers: [ConfirmationService],
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -155,6 +158,19 @@ import {
                 placeholder="Select tags"
                 display="chip"
                 [fluid]="true"
+              />
+            </div>
+            <div class="form-field full-width ai-suggest-field">
+              <app-ai-suggest
+                [content]="suggestionContent()"
+                [selectedCategoryIds]="form.value.categoryIds || []"
+                [selectedTagIds]="form.value.tagIds || []"
+                (applyCategory)="toggleSelection('categoryIds', $event, true)"
+                (removeCategory)="toggleSelection('categoryIds', $event, false)"
+                (applyTag)="toggleSelection('tagIds', $event, true)"
+                (removeTag)="toggleSelection('tagIds', $event, false)"
+                (categoryCreated)="categories.set([...categories(), $event])"
+                (tagCreated)="tags.set([...tags(), $event])"
               />
             </div>
           </div>
@@ -334,6 +350,11 @@ import {
       grid-column: 1 / -1;
     }
 
+    .ai-suggest-field {
+      padding-top: 12px;
+      border-top: 1px dashed var(--p-surface-700);
+    }
+
     .form-field {
       display: flex;
       flex-direction: column;
@@ -496,6 +517,34 @@ export class RecipeFormComponent implements OnInit {
 
   get ingredients(): FormArray {
     return this.form.get('ingredients') as FormArray;
+  }
+
+  /** Snapshot of the form content used to drive AI category/tag suggestions. */
+  suggestionContent(): SuggestionContent {
+    const v = this.form.value;
+    return {
+      title: v.title || '',
+      description: v.description || undefined,
+      instructions: v.instructions || undefined,
+      ingredients: (v.ingredients || [])
+        .map((i: { name?: string }) => ({ name: (i.name || '').trim() }))
+        .filter((i: { name: string }) => i.name.length > 0),
+    };
+  }
+
+  /** Add or remove an id from a multiselect-backed form control. */
+  toggleSelection(
+    control: 'categoryIds' | 'tagIds',
+    id: string,
+    selected: boolean
+  ) {
+    const current: string[] = this.form.get(control)?.value || [];
+    const next = selected
+      ? current.includes(id)
+        ? current
+        : [...current, id]
+      : current.filter((x) => x !== id);
+    this.form.get(control)?.setValue(next);
   }
 
   ngOnInit() {

--- a/apps/recipes-frontend/src/app/pages/recipe-form/recipe-form.component.ts
+++ b/apps/recipes-frontend/src/app/pages/recipe-form/recipe-form.component.ts
@@ -298,28 +298,26 @@ import {
     </div>
   `,
   styles: `
+    @use 'styles/shared' as *;
+
     .recipe-form-page {
-      max-width: 800px;
-      margin: 0 auto;
+      @include page(800px);
     }
 
     .form-header {
       display: flex;
       align-items: center;
-      gap: 16px;
+      gap: 12px;
       margin-bottom: 24px;
     }
 
     .form-title {
+      @include page-title;
       font-size: 1.5rem;
-      font-weight: 700;
-      margin: 0;
     }
 
     .loading-container {
-      display: flex;
-      justify-content: center;
-      padding: 64px 0;
+      @include loading-container;
     }
 
     :host ::ng-deep .form-card {
@@ -437,7 +435,7 @@ import {
       padding: 16px 0;
     }
 
-    @media (max-width: 640px) {
+    @include small {
       .form-grid {
         grid-template-columns: 1fr;
       }
@@ -446,8 +444,22 @@ import {
         flex-wrap: wrap;
       }
 
+      .ing-qty-input,
+      .ing-unit-input {
+        width: calc(50% - 4px);
+        min-width: 0;
+        max-width: none;
+      }
+
+      .ing-name-input {
+        flex-basis: 100%;
+      }
+
       .ing-notes-input {
-        width: 100%;
+        flex: 1;
+        width: auto;
+        min-width: 0;
+        max-width: none;
       }
     }
   `,

--- a/apps/recipes-frontend/src/app/pages/recipes/recipes.component.ts
+++ b/apps/recipes-frontend/src/app/pages/recipes/recipes.component.ts
@@ -195,35 +195,28 @@ import {
     </div>
   `,
   styles: `
+    @use 'styles/shared' as *;
+    @include fade-in-keyframes;
+
     .recipes-page {
-      max-width: 1200px;
-      margin: 0 auto;
+      @include page(1200px);
     }
 
     .page-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 24px;
-      flex-wrap: wrap;
-      gap: 16px;
+      @include page-header;
     }
 
     .page-title {
-      font-size: 1.75rem;
-      font-weight: 700;
-      margin: 0;
-      color: var(--p-text-color);
+      @include page-title;
     }
 
     .page-subtitle {
-      font-size: 0.875rem;
-      color: var(--p-text-muted-color);
+      @include page-subtitle;
+      margin: 0;
     }
 
     .header-actions {
-      display: flex;
-      gap: 8px;
+      @include header-actions;
     }
 
     .filters {
@@ -250,70 +243,44 @@ import {
       min-width: 180px;
     }
 
+    @include mobile {
+      .filter-row {
+        flex-direction: column;
+        align-items: stretch;
+      }
+
+      .filter-search,
+      .filter-select {
+        min-width: 0;
+        width: 100%;
+      }
+    }
+
     .loading-container {
-      display: flex;
-      justify-content: center;
-      padding: 64px 0;
+      @include loading-container;
     }
 
     .empty-state {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      padding: 64px 24px;
-      text-align: center;
-      gap: 8px;
-    }
-
-    .empty-icon {
-      font-size: 3rem;
-      color: var(--p-text-muted-color);
-      margin-bottom: 8px;
-    }
-
-    .empty-state h2 {
-      margin: 0;
-      font-size: 1.25rem;
-      color: var(--p-text-color);
-    }
-
-    .empty-state p {
-      margin: 0;
-      color: var(--p-text-muted-color);
+      @include empty-state;
     }
 
     .recipe-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
       gap: 16px;
     }
 
     .recipe-card {
-      background: var(--p-surface-800);
-      border: 1px solid var(--p-surface-700);
-      border-radius: 12px;
+      @include card;
+      @include fade-in;
       padding: 20px;
       cursor: pointer;
-      transition: all 0.2s ease;
-      animation: fadeIn 0.3s ease forwards;
-      opacity: 0;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 
       &:hover {
         border-color: var(--p-primary-color);
         box-shadow: 0 0 20px color-mix(in srgb, var(--p-primary-color) 15%, transparent);
         transform: translateY(-2px);
-      }
-    }
-
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
-        transform: translateY(8px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
       }
     }
 
@@ -353,35 +320,21 @@ import {
     }
 
     .card-chips {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 6px;
+      @include chip-row;
       margin-top: 8px;
     }
 
     .category-chip {
-      padding: 2px 10px;
-      border-radius: 12px;
-      font-size: 0.75rem;
-      font-weight: 600;
+      @include chip-category;
     }
 
     .tag-chip {
-      padding: 2px 10px;
-      border: 1.5px solid;
-      border-radius: 12px;
-      font-size: 0.75rem;
-      font-weight: 500;
-      background: transparent;
+      @include chip-tag;
     }
 
-    @media (max-width: 640px) {
+    @include mobile {
       .recipe-grid {
         grid-template-columns: 1fr;
-      }
-
-      .header-actions {
-        width: 100%;
       }
     }
   `,

--- a/apps/recipes-frontend/src/app/pages/tags/tags.component.ts
+++ b/apps/recipes-frontend/src/app/pages/tags/tags.component.ts
@@ -100,8 +100,9 @@ import {
         [(visible)]="formVisible"
         [header]="editing() ? 'Edit Tag' : 'New Tag'"
         [modal]="true"
-        [style]="{ width: '400px' }"
+        [style]="{ width: '90vw', maxWidth: '420px' }"
         [closable]="true"
+        [dismissableMask]="true"
       >
         <div class="form-fields">
           <div class="form-field">
@@ -159,63 +160,49 @@ import {
     </div>
   `,
   styles: `
+    @use 'styles/shared' as *;
+    @include fade-in-keyframes;
+
     .tags-page {
-      max-width: 1000px;
-      margin: 0 auto;
+      @include page(1000px);
     }
 
     .page-header {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      margin-bottom: 24px;
+      @include page-header;
 
       h1 {
-        margin: 0 0 4px;
-        font-size: 1.5rem;
-        font-weight: 700;
+        @include page-title;
       }
 
       .subtitle {
-        margin: 0;
-        color: var(--p-text-muted-color);
-        font-size: 0.9rem;
+        @include page-subtitle;
       }
     }
 
     .loading-container {
-      display: flex;
-      justify-content: center;
-      padding: 64px 0;
+      @include loading-container;
     }
 
     .empty-state {
-      text-align: center;
-      padding: 64px 0;
-      color: var(--p-text-muted-color);
-
-      i {
-        font-size: 3rem;
-        margin-bottom: 16px;
-      }
+      @include empty-state;
     }
 
     .tags-grid {
       display: grid;
-      grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
       gap: 16px;
     }
 
     .tag-card {
-      background: var(--p-surface-800);
-      border-radius: 12px;
+      @include card;
+      @include fade-in;
       overflow: hidden;
-      animation: fadeIn 0.3s ease-out both;
-      transition: transform 0.2s, box-shadow 0.2s;
+      transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
 
       &:hover {
         transform: translateY(-2px);
         box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+        border-color: var(--p-surface-600);
       }
     }
 
@@ -290,17 +277,6 @@ import {
       display: flex;
       gap: 8px;
       justify-content: flex-end;
-    }
-
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
-        transform: translateY(8px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
     }
   `,
 })

--- a/apps/recipes-frontend/src/app/services/recipes-api.service.ts
+++ b/apps/recipes-frontend/src/app/services/recipes-api.service.ts
@@ -161,14 +161,24 @@ export interface Message {
 }
 
 export interface SuggestionItem {
-  id: string;
+  /** Existing id, or null when the suggestion is a brand-new category/tag. */
+  id: string | null;
   name: string;
   confidence: number;
+  /** True when selecting this suggestion would create a new category/tag. */
+  isNew: boolean;
 }
 
 export interface TagsAndCategoriesSuggestion {
   suggestedCategories: SuggestionItem[];
   suggestedTags: SuggestionItem[];
+}
+
+export interface SuggestionContent {
+  title: string;
+  description?: string;
+  instructions?: string;
+  ingredients?: Array<{ name: string }>;
 }
 
 export interface ChatRequest {
@@ -390,6 +400,19 @@ export class RecipesApiService {
     return this.http.post<TagsAndCategoriesSuggestion>(
       `${this.baseUrl}/ai/suggest-tags/${recipeId}`,
       {}
+    );
+  }
+
+  /**
+   * Suggest categories and tags from raw recipe content, before the recipe is
+   * saved (used by the create form and the AI import preview).
+   */
+  suggestTagsAndCategoriesForContent(
+    content: SuggestionContent
+  ): Observable<TagsAndCategoriesSuggestion> {
+    return this.http.post<TagsAndCategoriesSuggestion>(
+      `${this.baseUrl}/ai/suggest-tags`,
+      content
     );
   }
 

--- a/apps/recipes-frontend/src/styles/_shared.scss
+++ b/apps/recipes-frontend/src/styles/_shared.scss
@@ -1,0 +1,171 @@
+// ============================================================
+// Shared design tokens & mixins for the Recipes app
+// Usable from component inline styles via:  @use 'styles/shared' as *;
+// (resolved through stylePreprocessorOptions.includePaths -> src/)
+// ============================================================
+
+// ----- Breakpoints -------------------------------------------------
+// Standardized across the whole app. Use these mixins instead of
+// hand-rolling @media queries so behaviour stays consistent.
+$bp-small: 480px; // phones
+$bp-mobile: 768px; // sidebar collapses below this (see layout)
+$bp-tablet: 1024px; // multi-column layouts collapse below this
+
+@mixin small {
+  @media (max-width: $bp-small) {
+    @content;
+  }
+}
+
+@mixin mobile {
+  @media (max-width: $bp-mobile) {
+    @content;
+  }
+}
+
+@mixin tablet {
+  @media (max-width: $bp-tablet) {
+    @content;
+  }
+}
+
+// ----- Page scaffold ----------------------------------------------
+@mixin page($max: 1200px) {
+  max-width: $max;
+  margin: 0 auto;
+}
+
+// Standard page header: title on the left, actions on the right,
+// wraps gracefully and goes full-width on mobile.
+@mixin page-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+@mixin page-title {
+  margin: 0;
+  font-size: 1.75rem;
+  font-weight: 700;
+  color: var(--p-text-color);
+  letter-spacing: -0.01em;
+
+  @include small {
+    font-size: 1.4rem;
+  }
+}
+
+@mixin page-subtitle {
+  margin: 4px 0 0;
+  font-size: 0.9rem;
+  color: var(--p-text-muted-color);
+}
+
+// Header action button group: aligns right on desktop, stretches on
+// mobile so the buttons are easy tap targets.
+@mixin header-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+
+  @include small {
+    width: 100%;
+
+    > * {
+      flex: 1;
+    }
+  }
+}
+
+// ----- Surfaces ----------------------------------------------------
+@mixin card {
+  background: var(--p-surface-800);
+  border: 1px solid var(--p-surface-700);
+  border-radius: 12px;
+}
+
+@mixin loading-container {
+  display: flex;
+  justify-content: center;
+  padding: 64px 0;
+}
+
+@mixin empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 64px 24px;
+  text-align: center;
+  color: var(--p-text-muted-color);
+
+  .empty-icon,
+  > i {
+    font-size: 3rem;
+    color: var(--p-text-muted-color);
+    margin-bottom: 8px;
+  }
+
+  h2 {
+    margin: 0;
+    font-size: 1.25rem;
+    color: var(--p-text-color);
+  }
+
+  p {
+    margin: 0;
+  }
+}
+
+// ----- Chips -------------------------------------------------------
+// Category chips: solid fill (color set inline per-category).
+@mixin chip-category {
+  display: inline-block;
+  padding: 4px 12px;
+  border-radius: 12px;
+  font-size: 0.78rem;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+// Tag chips: outlined (border/text color set inline per-tag).
+@mixin chip-tag {
+  display: inline-block;
+  padding: 4px 12px;
+  border: 1.5px solid;
+  border-radius: 12px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  line-height: 1.4;
+  background: transparent;
+}
+
+@mixin chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+// ----- Animations --------------------------------------------------
+// Emits the fade-in keyframes + applies the staggered entrance.
+@mixin fade-in {
+  animation: sharedFadeIn 0.3s ease forwards;
+  opacity: 0;
+}
+
+@mixin fade-in-keyframes {
+  @keyframes sharedFadeIn {
+    from {
+      opacity: 0;
+      transform: translateY(8px);
+    }
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+}

--- a/apps/recipes/src/app/ai/ai.router.ts
+++ b/apps/recipes/src/app/ai/ai.router.ts
@@ -6,14 +6,26 @@ import { AiService } from './ai.service';
 
 // Response schemas
 const SuggestionItemSchema = z.object({
-  id: z.string().uuid(),
+  id: z.string().uuid().nullable(),
   name: z.string(),
   confidence: z.number().min(0).max(1),
+  isNew: z.boolean(),
 });
 
 const SuggestTagsAndCategoriesResponseSchema = z.object({
   suggestedCategories: z.array(SuggestionItemSchema),
   suggestedTags: z.array(SuggestionItemSchema),
+});
+
+// Content-based suggestion (works before a recipe is saved)
+const SuggestForContentRequestSchema = z.object({
+  title: z.string().min(1).max(300),
+  description: z.string().max(5000).optional(),
+  instructions: z.string().max(20000).optional(),
+  ingredients: z
+    .array(z.object({ name: z.string() }))
+    .optional()
+    .default([]),
 });
 
 // Chat schemas
@@ -87,6 +99,23 @@ export async function AiRouter(fastify: FastifyInstance) {
     },
     async (request) => {
       return aiService.suggestTagsAndCategories(request.params.recipeId);
+    }
+  );
+
+  // Suggest tags and categories from raw recipe content (before a recipe is
+  // saved — used by the create form and the AI import preview)
+  fastify.withTypeProvider<ZodTypeProvider>().post(
+    '/suggest-tags',
+    {
+      schema: {
+        body: SuggestForContentRequestSchema,
+        response: {
+          200: SuggestTagsAndCategoriesResponseSchema,
+        },
+      },
+    },
+    async (request) => {
+      return aiService.suggestForContent(request.body);
     }
   );
 

--- a/apps/recipes/src/app/ai/ai.service.ts
+++ b/apps/recipes/src/app/ai/ai.service.ts
@@ -139,14 +139,25 @@ const FLAVOR_PROFILE_SCHEMA: JsonSchema = {
 };
 
 export interface SuggestionItem {
-  id: string;
+  /** Existing category/tag id, or null when the suggestion is brand new. */
+  id: string | null;
   name: string;
   confidence: number;
+  /** True when this category/tag does not exist yet and would be created. */
+  isNew: boolean;
 }
 
 export interface TagsAndCategoriesSuggestion {
   suggestedCategories: SuggestionItem[];
   suggestedTags: SuggestionItem[];
+}
+
+/** Recipe content used to generate category/tag suggestions. */
+export interface SuggestionContent {
+  title: string;
+  description?: string | null;
+  instructions?: string | null;
+  ingredients: Array<{ name: string }>;
 }
 
 export interface ChatResponse {
@@ -203,14 +214,29 @@ export class AiService {
   private readonly _ollamaClient = new OllamaClient();
 
   /**
-   * Suggest tags and categories for a recipe based on its content
+   * Suggest tags and categories for an already-saved recipe.
    */
   async suggestTagsAndCategories(
     recipeId: string
   ): Promise<TagsAndCategoriesSuggestion> {
-    // Get recipe details
     const recipe = await this._recipesService.getById(recipeId);
+    return this.suggestForContent({
+      title: recipe.title,
+      description: recipe.description,
+      instructions: recipe.instructions,
+      ingredients: recipe.ingredients ?? [],
+    });
+  }
 
+  /**
+   * Suggest tags and categories from raw recipe content (used before a recipe
+   * is saved, e.g. the create form and the AI import preview). The AI prefers
+   * existing categories/tags but may also propose brand-new ones, which are
+   * flagged with `isNew` so the client can offer to create them.
+   */
+  async suggestForContent(
+    content: SuggestionContent
+  ): Promise<TagsAndCategoriesSuggestion> {
     // Get all available categories and tags
     const [categories, tags] = await Promise.all([
       this._categoriesService.getAll(),
@@ -218,13 +244,13 @@ export class AiService {
     ]);
 
     // Build the prompt
-    const prompt = this.buildPrompt(recipe, categories, tags);
+    const prompt = this.buildPrompt(content, categories, tags);
 
     // Get AI suggestions
     const messages: Message[] = [
       {
         role: 'system',
-        content: `You are a recipe classification assistant. Your task is to analyze recipes and suggest the most appropriate categories and tags from a given list. Always respond with valid JSON only, no additional text or explanation.`,
+        content: `You are a recipe classification assistant. Your task is to analyze recipes and suggest the most appropriate categories and tags. Strongly prefer reusing the existing categories and tags provided, but you may propose a small number of new ones when none of the existing options fit. Always respond with valid JSON only, no additional text or explanation.`,
       },
       {
         role: 'user',
@@ -238,9 +264,7 @@ export class AiService {
     });
 
     // Parse the response
-    const suggestions = this.parseResponse(response, categories, tags);
-
-    return suggestions;
+    return this.parseResponse(response, categories, tags);
   }
 
   /**
@@ -269,11 +293,11 @@ Description: ${recipe.description || 'No description'}
 Ingredients: ${ingredientsList || 'No ingredients listed'}
 Instructions: ${recipe.instructions || 'No instructions'}
 
-AVAILABLE CATEGORIES (choose from these only):
-${categoryNames || 'None available'}
+EXISTING CATEGORIES (strongly prefer these):
+${categoryNames || 'None yet'}
 
-AVAILABLE TAGS (choose from these only):
-${tagNames || 'None available'}
+EXISTING TAGS (strongly prefer these):
+${tagNames || 'None yet'}
 
 Respond with a JSON object in this exact format:
 {
@@ -282,11 +306,14 @@ Respond with a JSON object in this exact format:
 }
 
 Rules:
-- Only suggest categories and tags from the available lists above
+- Strongly prefer reusing the existing categories and tags listed above, matching their exact spelling
+- Only propose a NEW category or tag when none of the existing ones reasonably fit
+- Keep any new names short, generic and reusable (e.g. "Dessert", "Vegetarian", "Quick"), not specific to this one dish
+- Use Title Case for new names
 - Confidence should be between 0.0 and 1.0
 - Only include suggestions with confidence > 0.5
 - Sort by confidence descending
-- Maximum 3 categories and 5 tags`;
+- Maximum 3 categories and 6 tags total`;
   }
 
   /**
@@ -311,48 +338,59 @@ Rules:
       };
     }
 
-    // Map category names to IDs
     const categoryMap = new Map(
       categories.map((c) => [c.name.toLowerCase(), c])
     );
-    const suggestedCategories: SuggestionItem[] = (parsed.categories || [])
-      .map((suggestion) => {
-        const category = categoryMap.get(suggestion.name.toLowerCase());
-        if (category && suggestion.confidence > 0.5) {
-          return {
-            id: category.id,
-            name: category.name,
-            confidence: Math.round(suggestion.confidence * 100) / 100,
-          };
-        }
-        return null;
-      })
-      .filter((item): item is SuggestionItem => item !== null)
-      .sort((a, b) => b.confidence - a.confidence)
-      .slice(0, 3);
-
-    // Map tag names to IDs
     const tagMap = new Map(tags.map((t) => [t.name.toLowerCase(), t]));
-    const suggestedTags: SuggestionItem[] = (parsed.tags || [])
-      .map((suggestion) => {
-        const tag = tagMap.get(suggestion.name.toLowerCase());
-        if (tag && suggestion.confidence > 0.5) {
-          return {
-            id: tag.id,
-            name: tag.name,
-            confidence: Math.round(suggestion.confidence * 100) / 100,
-          };
-        }
-        return null;
-      })
-      .filter((item): item is SuggestionItem => item !== null)
-      .sort((a, b) => b.confidence - a.confidence)
-      .slice(0, 5);
 
     return {
-      suggestedCategories,
-      suggestedTags,
+      suggestedCategories: this.mapSuggestions(
+        parsed.categories,
+        categoryMap,
+        3
+      ),
+      suggestedTags: this.mapSuggestions(parsed.tags, tagMap, 6),
     };
+  }
+
+  /**
+   * Map raw AI suggestions to suggestion items. Names matching an existing
+   * category/tag (case-insensitive) reuse its id; unmatched names become
+   * "new" suggestions the client can create on demand.
+   */
+  private mapSuggestions(
+    raw: Array<{ name: string; confidence: number }> | undefined,
+    existingByName: Map<string, { id: string; name: string }>,
+    limit: number
+  ): SuggestionItem[] {
+    const seen = new Set<string>();
+
+    return (raw || [])
+      .map((suggestion): SuggestionItem | null => {
+        const name = (suggestion.name || '').trim();
+        const key = name.toLowerCase();
+
+        // Filter junk: empty, too long, or below the confidence threshold.
+        if (!name || name.length > 50 || suggestion.confidence <= 0.5) {
+          return null;
+        }
+        if (seen.has(key)) return null;
+        seen.add(key);
+
+        const confidence = Math.round(suggestion.confidence * 100) / 100;
+        const existing = existingByName.get(key);
+        if (existing) {
+          return { id: existing.id, name: existing.name, confidence, isNew: false };
+        }
+        return { id: null, name, confidence, isNew: true };
+      })
+      .filter((item): item is SuggestionItem => item !== null)
+      // Surface existing matches before brand-new proposals, then by confidence.
+      .sort((a, b) => {
+        if (a.isNew !== b.isNew) return a.isNew ? 1 : -1;
+        return b.confidence - a.confidence;
+      })
+      .slice(0, limit);
   }
 
   /**

--- a/apps/recipes/src/app/ai/ai.service.ts
+++ b/apps/recipes/src/app/ai/ai.service.ts
@@ -548,43 +548,67 @@ Guidelines:
       }
     }
 
-    if (!recipeData) {
+    if (recipeData) {
+      logger.info(
+        { url, recipeName: recipeData.name },
+        'Extracted recipe from JSON-LD'
+      );
+      const mapped = await this.mapJsonLdToRecipe(recipeData, url);
+      // JSON-LD is sometimes present but incomplete (e.g. empty ingredients).
+      // Only trust it when it actually produced a usable recipe.
+      if (this.isUsableRecipe(mapped)) return mapped;
+      logger.warn(
+        { url },
+        'JSON-LD recipe was incomplete, falling back to content extraction'
+      );
+    } else {
       logger.warn(
         { url },
         'No JSON-LD recipe data found, falling back to content extraction + LLM'
       );
-
-      // Fallback: extract readable content from the page and use LLM to parse
-      const recipeText = this.extractRecipeContent(root);
-      if (!recipeText || recipeText.length < 50) {
-        throw HttpErrors.UnprocessableEntity(
-          'Could not find recipe content on this page. Try copying and pasting the recipe text instead.'
-        );
-      }
-
-      logger.info(
-        { url, contentLength: recipeText.length },
-        'Extracted page content, sending to LLM for parsing'
-      );
-      const parsed = await this.parseRecipeFromText(recipeText);
-      // Attach source URL if not already set
-      if (!parsed.source) {
-        parsed.source = url;
-      }
-      // Extract images from the HTML for the LLM fallback path
-      const imageUrls = this.extractImageUrlsFromHtml(root, url);
-      if (imageUrls.length > 0) {
-        parsed.imageUrls = imageUrls;
-      }
-      return parsed;
     }
 
-    // Map schema.org Recipe to our format
+    return this.parseViaContentExtraction(root, url);
+  }
+
+  /**
+   * Fallback parsing path: extract readable content from the page and use the
+   * LLM to structure it. Shared by the JSON-LD-missing and JSON-LD-incomplete
+   * cases.
+   */
+  private async parseViaContentExtraction(
+    root: ReturnType<typeof parseHTML>,
+    url: string
+  ): Promise<ParsedRecipe> {
+    const recipeText = this.extractRecipeContent(root);
+    if (!recipeText || recipeText.length < 50) {
+      throw HttpErrors.UnprocessableEntity(
+        'Could not find recipe content on this page. Try copying and pasting the recipe text instead.'
+      );
+    }
+
     logger.info(
-      { url, recipeName: recipeData.name },
-      'Extracted recipe from JSON-LD'
+      { url, contentLength: recipeText.length },
+      'Extracted page content, sending to LLM for parsing'
     );
-    return this.mapJsonLdToRecipe(recipeData, url);
+    const parsed = await this.parseRecipeFromText(recipeText);
+    if (!parsed.source) parsed.source = url;
+
+    const imageUrls = this.extractImageUrlsFromHtml(root, url);
+    if (imageUrls.length > 0) parsed.imageUrls = imageUrls;
+
+    return parsed;
+  }
+
+  /**
+   * A recipe is usable if it has at least one ingredient or some instructions.
+   * Used to decide whether to trust JSON-LD or fall back to content extraction.
+   */
+  private isUsableRecipe(recipe: ParsedRecipe): boolean {
+    return (
+      recipe.ingredients.length > 0 ||
+      (!!recipe.instructions && recipe.instructions.trim().length > 20)
+    );
   }
 
   /**
@@ -625,69 +649,68 @@ Guidelines:
       }
     }
 
-    if (!recipeData) {
+    // Try JSON-LD first; fall back to content extraction when it is missing
+    // or produced an incomplete recipe.
+    if (recipeData) {
       yield {
         type: 'progress',
-        step: 'extract-content',
-        message: 'No structured data found — extracting content...',
-        percent: 35,
+        step: 'extract-recipe',
+        message: 'Found structured recipe data — extracting...',
+        percent: 45,
       };
 
-      const recipeText = this.extractRecipeContent(root);
-      if (!recipeText || recipeText.length < 50) {
+      const result = await this.mapJsonLdToRecipe(recipeData, url);
+      if (this.isUsableRecipe(result)) {
         yield {
-          type: 'error',
-          error:
-            'Could not find recipe content on this page. Try pasting the text instead.',
+          type: 'progress',
+          step: 'done',
+          message: 'Recipe parsed!',
+          percent: 100,
         };
+        yield { type: 'result', result };
         return;
       }
+      logger.warn({ url }, 'JSON-LD incomplete, falling back to content (stream)');
+    }
 
+    yield {
+      type: 'progress',
+      step: 'extract-content',
+      message: recipeData
+        ? 'Structured data was incomplete — reading the page...'
+        : 'No structured data found — extracting content...',
+      percent: 35,
+    };
+
+    const recipeText = this.extractRecipeContent(root);
+    if (!recipeText || recipeText.length < 50) {
       yield {
-        type: 'progress',
-        step: 'llm-parse',
-        message: 'AI is reading the recipe...',
-        percent: 50,
+        type: 'error',
+        error:
+          'Could not find recipe content on this page. Try pasting the text instead.',
       };
-
-      const parsed = await this.parseRecipeFromText(recipeText);
-      if (!parsed.source) parsed.source = url;
-
-      yield {
-        type: 'progress',
-        step: 'extract-images',
-        message: 'Looking for photos...',
-        percent: 85,
-      };
-
-      const imageUrls = this.extractImageUrlsFromHtml(root, url);
-      if (imageUrls.length > 0) parsed.imageUrls = imageUrls;
-
-      yield {
-        type: 'progress',
-        step: 'done',
-        message: 'Recipe parsed!',
-        percent: 100,
-      };
-      yield { type: 'result', result: parsed };
       return;
     }
 
     yield {
       type: 'progress',
-      step: 'extract-recipe',
-      message: 'Found structured recipe data — extracting...',
-      percent: 40,
+      step: 'llm-parse',
+      message: 'AI is reading the recipe...',
+      percent: 50,
     };
+
+    const parsed = await this.parseRecipeFromText(recipeText);
+    if (!parsed.source) parsed.source = url;
 
     yield {
       type: 'progress',
-      step: 'map-recipe',
-      message: 'Structuring recipe details...',
-      percent: 55,
+      step: 'extract-images',
+      message: 'Looking for photos...',
+      percent: 85,
     };
 
-    const result = await this.mapJsonLdToRecipe(recipeData, url);
+    const imageUrls = this.extractImageUrlsFromHtml(root, url);
+    if (imageUrls.length > 0) parsed.imageUrls = imageUrls;
 
     yield {
       type: 'progress',
@@ -695,7 +718,7 @@ Guidelines:
       message: 'Recipe parsed!',
       percent: 100,
     };
-    yield { type: 'result', result };
+    yield { type: 'result', result: parsed };
   }
 
   /**


### PR DESCRIPTION
Improvements to the recipe system across consistency, AI tagging, import, and responsive design, delivered as reviewable per-phase commits.

## Phase 1 — Responsive & visual consistency
- New `styles/_shared.scss` with standardized breakpoints (`small` 480 / `mobile` 768 / `tablet` 1024) and reusable mixins for page scaffold, headers, cards, chips, and empty/loading states.
- Refactored all 8 pages onto it so titles, chips, cards, and breakpoints are consistent app-wide (titles were a mix of 1.5/1.75/2/2.2rem; breakpoints were 640/768/1024).
- Mobile: filters and header actions stack; category/tag dialogs are now responsive (were fixed 400px) and dismissable; ingredient rows reflow.
- Fixes: instruction "step card" styling targeted `.instructions-content` but the template renders `.markdown-content`, so it never showed — now scoped correctly. Replaced the undefined `--p-orange-400` token.

## Phase 2 — AI category & tag suggestions
- Backend can suggest from **raw recipe content** (works before a recipe is saved) and may now **propose brand-new** categories/tags (flagged `isNew`), not just match existing. New `POST /ai/suggest-tags` content endpoint.
- Reusable `<app-ai-suggest>` panel: existing + new suggestions as toggle chips; selecting a "new" one **creates it** and applies it. Wired into the create/edit form and the detail-page inline editor.

## Phase 3 — Recipe import
- Import preview is now **fully editable** (title, description, times, ingredient rows, instructions, categories/tags) before saving, with the AI-suggest panel embedded.
- Better UX: URL failures offer a one-tap "paste text instead", inline create errors, responsive layout.
- Reliability: URL parsing falls back to content-extraction + LLM when JSON-LD is **present but incomplete**, not only when absent (both blocking and streaming paths).

## Bug fix — Grocery list
- The "Generate List" button was permanently disabled: `selectedCount` was a signal stuck at 0 and never updated. Made it a `computed` over the selection that re-evaluates on checkbox toggle.

## Verification
- `recipes` and `recipes-frontend` build (dev + production; bundle budgets OK).
- `recipes-frontend` lints with 0 errors (pre-existing warnings only).
- Not runtime-verified against a live Ollama instance — happy to exercise the AI/import flows live if wanted.

## Note
- Deliberate change: recipe-detail `max-width` 1800 → 1200px for consistency/readability; easy to revert.

https://claude.ai/code/session_0128mTbtGKaoixrvDgamCV7L

---
_Generated by [Claude Code](https://claude.ai/code/session_0128mTbtGKaoixrvDgamCV7L)_