### PR TITLE
feat(chat): add HTML artifact canvas for LLM-authored artifacts

### DIFF
--- a/apps/ai-gateway/src/app/agents/orchestrator.ts
+++ b/apps/ai-gateway/src/app/agents/orchestrator.ts
@@ -355,6 +355,7 @@ ${agentDescriptions}
 - User: "Hello, how are you?" → Respond directly (simple greeting, no tools needed)
 - User: "What's the capital of France?" → Respond directly (general knowledge)
 - User: "Search for the latest news about AI" → Delegate (requires web access)
+- User: "Build me a snake game" / "Make an interactive chart of this data" / "Design a landing page" → Delegate to the artisan-agent (it renders live HTML artifacts in the canvas)
 - User: "Summarize this text for me: ..." → Respond directly (you can do this yourself)
 
 Use your best judgment. When in doubt about whether an agent would add value, go ahead and delegate.`;
@@ -902,6 +903,39 @@ Never store or log sensitive values beyond what the tool returns.`,
           'check_password_strength',
           'generate_totp_uri',
         ],
+      },
+    },
+    {
+      name: 'artisan-agent',
+      description:
+        'Creates and iterates on rich, interactive HTML artifacts (apps, games, data visualisations, charts, diagrams, simulations, landing pages) that render live in a canvas beside the chat',
+      capabilities: [
+        'Build self-contained HTML/CSS/JS artifacts',
+        'Create interactive apps, games, and simulations',
+        'Generate data visualisations and charts',
+        'Design diagrams, dashboards, and landing pages',
+        'Update and iterate on the current artifact',
+      ],
+      agent: {
+        name: 'artisan-agent',
+        description: 'HTML artifact and canvas specialist',
+        systemPrompt: `You are a world-class creative front-end engineer. You build rich, interactive HTML artifacts that render live in a sandboxed iframe canvas next to the chat.
+
+## How to work
+- To create something new, call the create_artifact tool. To change the existing artifact, call update_artifact.
+- ALWAYS produce a COMPLETE, self-contained HTML document: <!DOCTYPE html>, <html>, <head> with ALL CSS in <style> tags, and <body> with ALL JavaScript in <script> tags. Everything must be inline because the iframe is sandboxed and isolated.
+- You MAY pull libraries from public CDNs via <script src> / <link href> (e.g. https://cdn.jsdelivr.net, https://unpkg.com, https://cdnjs.cloudflare.com) — use them for charts (Chart.js, D3), 3D (three.js), animation, etc.
+- The iframe has no access to the parent page or its storage. Keep state in memory or use the artifact's own JS.
+- Make it look great: thoughtful layout, spacing, colour, and responsive design. Prefer a polished, modern aesthetic.
+- When updating, send the FULL new HTML document, never a diff or fragment.
+
+## After building
+- Do NOT paste the raw HTML into your text response. The artifact is already shown in the canvas.
+- Reply with a short, friendly summary of what you built and how to use it, and offer to iterate.
+
+Use create_artifact / update_artifact for ANY request to build, make, design, visualise, or render something visual or interactive.`,
+        model: 'gemma4:e2b',
+        tools: ['create_artifact', 'update_artifact'],
       },
     },
   ],

--- a/apps/ai-gateway/src/app/mcp/tools/artifact-tools.ts
+++ b/apps/ai-gateway/src/app/mcp/tools/artifact-tools.ts
@@ -1,0 +1,131 @@
+import { createTool, getToolRegistry } from '../tool-registry';
+
+/**
+ * Artifact tools
+ *
+ * These tools let the LLM author arbitrary, self-contained HTML "artifacts"
+ * that the frontend renders live inside a sandboxed iframe (the "canvas").
+ *
+ * The tools themselves are intentionally thin: the actual HTML payload travels
+ * in the tool-call *input*, which the streaming layer already forwards to the
+ * client via `tool_call_start` events. The frontend reads `input.html` /
+ * `input.title` to (re)render the canvas. The tool result is kept small (it does
+ * NOT echo the HTML back) so we don't duplicate large payloads in the response.
+ */
+
+const HTML_HINT =
+  'A COMPLETE, self-contained HTML document. Include <!DOCTYPE html>, <html>, ' +
+  '<head> (with all CSS inside <style> tags) and <body> (with all JavaScript ' +
+  'inside <script> tags). The artifact runs in a sandboxed iframe with no access ' +
+  'to the parent page, so everything must be inline. You MAY load libraries from ' +
+  'public CDNs via <script src> / <link href> (e.g. https://cdn.jsdelivr.net, ' +
+  'https://unpkg.com, https://cdnjs.cloudflare.com).';
+
+const createArtifact = createTool(
+  {
+    name: 'create_artifact',
+    description:
+      'Create a new visual HTML artifact that is rendered live in a canvas ' +
+      'panel beside the chat. Use this for interactive apps, data ' +
+      'visualisations, games, diagrams, dashboards, landing pages, ' +
+      'simulations, or any rich visual/interactive content that is better ' +
+      'shown than described. You have total creative freedom over the HTML, ' +
+      'CSS and JavaScript. After creating the artifact, briefly tell the user ' +
+      'what you built — do NOT paste the raw HTML into the chat.',
+    category: 'Artifacts',
+    tags: ['artifact', 'canvas', 'html', 'ui', 'visual', 'interactive'],
+    parameters: {
+      type: 'object',
+      properties: {
+        title: {
+          type: 'string',
+          description:
+            'A short, descriptive title for the artifact, shown in the canvas header.',
+        },
+        html: {
+          type: 'string',
+          description: HTML_HINT,
+        },
+      },
+      required: ['title', 'html'],
+    },
+  },
+  async (params) => {
+    const title = ((params.title as string) || 'Untitled Artifact').trim();
+    const html = (params.html as string) || '';
+
+    if (!html.trim()) {
+      return {
+        success: false,
+        error: 'The "html" parameter is required and cannot be empty.',
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        title,
+        bytes: html.length,
+        rendered: true,
+        message: `Artifact "${title}" was rendered in the canvas (${html.length} bytes of HTML).`,
+      },
+    };
+  }
+);
+
+const updateArtifact = createTool(
+  {
+    name: 'update_artifact',
+    description:
+      'Replace the HTML of the current artifact shown in the canvas. Use this ' +
+      'to iterate on an artifact you (or the user) previously created — fixing ' +
+      'bugs, restyling, or adding features. Always provide the FULL updated ' +
+      'HTML document, not a diff or fragment. If no artifact exists yet, this ' +
+      'behaves like create_artifact.',
+    category: 'Artifacts',
+    tags: ['artifact', 'canvas', 'html', 'ui', 'visual', 'interactive'],
+    parameters: {
+      type: 'object',
+      properties: {
+        html: {
+          type: 'string',
+          description: 'The full updated HTML document. ' + HTML_HINT,
+        },
+        title: {
+          type: 'string',
+          description:
+            'Optional new title for the artifact. Omit to keep the existing title.',
+        },
+      },
+      required: ['html'],
+    },
+  },
+  async (params) => {
+    const html = (params.html as string) || '';
+    const title = (params.title as string | undefined)?.trim();
+
+    if (!html.trim()) {
+      return {
+        success: false,
+        error: 'The "html" parameter is required and cannot be empty.',
+      };
+    }
+
+    return {
+      success: true,
+      data: {
+        title,
+        bytes: html.length,
+        updated: true,
+        message: `Artifact updated in the canvas (${html.length} bytes of HTML).`,
+      },
+    };
+  }
+);
+
+// Register all artifact tools
+const registry = getToolRegistry();
+registry.register(createArtifact);
+registry.register(updateArtifact);
+
+export { createArtifact, updateArtifact };

--- a/apps/ai-gateway/src/app/mcp/tools/index.ts
+++ b/apps/ai-gateway/src/app/mcp/tools/index.ts
@@ -14,6 +14,7 @@ import './math-tools';
 import './formatter-tools';
 import './network-tools';
 import './security-tools';
+import './artifact-tools';
 
 export * from './system-tools';
 export * from './temporal-tools';
@@ -28,3 +29,4 @@ export * from './math-tools';
 export * from './formatter-tools';
 export * from './network-tools';
 export * from './security-tools';
+export * from './artifact-tools';

--- a/apps/chat-frontend/src/app/models/types.ts
+++ b/apps/chat-frontend/src/app/models/types.ts
@@ -6,6 +6,20 @@ export interface Conversation {
   messages: ChatMessage[];
   displayMessages: DisplayMessage[];
   config?: ChatConfig;
+  artifacts?: Artifact[];
+}
+
+/**
+ * An LLM-authored HTML artifact rendered live in the canvas (sandboxed iframe).
+ */
+export interface Artifact {
+  id: string;
+  title: string;
+  html: string;
+  createdAt: number;
+  updatedAt: number;
+  /** Incremented each time the artifact is updated, for version display. */
+  version: number;
 }
 
 export interface ChatMessage {

--- a/apps/chat-frontend/src/app/pages/chat/artifact-canvas.component.ts
+++ b/apps/chat-frontend/src/app/pages/chat/artifact-canvas.component.ts
@@ -1,0 +1,345 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
+import { MessageService } from 'primeng/api';
+import { Artifact } from '../../models/types';
+
+/**
+ * Renders an LLM-authored HTML artifact live inside a sandboxed iframe.
+ *
+ * The iframe uses `srcdoc` with a restrictive sandbox: scripts are allowed (so
+ * artifacts can be fully interactive) but the frame runs in an opaque origin
+ * with no access to the parent page, its cookies, or storage.
+ */
+@Component({
+  selector: 'app-artifact-canvas',
+  standalone: true,
+  imports: [ButtonModule, TooltipModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="canvas">
+      <div class="canvas-toolbar">
+        <div class="toolbar-left">
+          <i class="pi pi-palette canvas-icon"></i>
+          <div class="title-block">
+            <span class="canvas-title" [title]="active()?.title">{{
+              active()?.title || 'Artifact'
+            }}</span>
+            @if (active(); as a) { @if (a.version > 1) {
+            <span class="canvas-version">v{{ a.version }}</span>
+            } }
+          </div>
+        </div>
+
+        <div class="toolbar-right">
+          @if (artifacts().length > 1) {
+          <select
+            class="artifact-select"
+            [value]="active()?.id"
+            (change)="onSelect($event)"
+          >
+            @for (a of artifacts(); track a.id) {
+            <option [value]="a.id">{{ a.title }}</option>
+            }
+          </select>
+          }
+          <p-button
+            [icon]="showSource() ? 'pi pi-eye' : 'pi pi-code'"
+            [text]="true"
+            severity="secondary"
+            size="small"
+            [pTooltip]="showSource() ? 'Preview' : 'View source'"
+            (click)="showSource.set(!showSource())"
+          />
+          <p-button
+            icon="pi pi-refresh"
+            [text]="true"
+            severity="secondary"
+            size="small"
+            pTooltip="Reload"
+            (click)="reload()"
+          />
+          <p-button
+            icon="pi pi-copy"
+            [text]="true"
+            severity="secondary"
+            size="small"
+            pTooltip="Copy HTML"
+            (click)="copy()"
+          />
+          <p-button
+            icon="pi pi-download"
+            [text]="true"
+            severity="secondary"
+            size="small"
+            pTooltip="Download .html"
+            (click)="download()"
+          />
+          <p-button
+            icon="pi pi-external-link"
+            [text]="true"
+            severity="secondary"
+            size="small"
+            pTooltip="Open in new tab"
+            (click)="openInNewTab()"
+          />
+          <p-button
+            icon="pi pi-times"
+            [text]="true"
+            severity="secondary"
+            size="small"
+            pTooltip="Close canvas"
+            (click)="closePanel.emit()"
+          />
+        </div>
+      </div>
+
+      <div class="canvas-body">
+        @if (!active()) {
+        <div class="canvas-empty">
+          <i class="pi pi-palette"></i>
+          <span>No artifact yet</span>
+        </div>
+        } @else if (showSource()) {
+        <pre class="canvas-source">{{ active()!.html }}</pre>
+        } @else { @if (showFrame()) {
+        <iframe
+          class="canvas-frame"
+          [srcdoc]="srcdoc()"
+          sandbox="allow-scripts allow-forms allow-popups allow-modals allow-popups-to-escape-sandbox allow-pointer-lock allow-downloads"
+          referrerpolicy="no-referrer"
+          title="Artifact preview"
+        ></iframe>
+        } }
+      </div>
+    </div>
+  `,
+  styles: `
+    :host {
+      display: block;
+      height: 100%;
+      overflow: hidden;
+    }
+
+    .canvas {
+      display: flex;
+      flex-direction: column;
+      height: 100%;
+      background: var(--p-surface-950);
+      overflow: hidden;
+    }
+
+    .canvas-toolbar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+      padding: 6px 10px;
+      border-bottom: 1px solid var(--p-surface-800);
+      background: var(--p-surface-900);
+      flex-shrink: 0;
+    }
+
+    .toolbar-left {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      min-width: 0;
+    }
+
+    .canvas-icon {
+      color: var(--p-primary-color);
+      font-size: 1rem;
+      flex-shrink: 0;
+    }
+
+    .title-block {
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+      min-width: 0;
+    }
+
+    .canvas-title {
+      font-size: 0.9rem;
+      font-weight: 600;
+      color: var(--p-text-color);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .canvas-version {
+      font-size: 0.7rem;
+      color: var(--p-text-muted-color);
+      flex-shrink: 0;
+    }
+
+    .toolbar-right {
+      display: flex;
+      align-items: center;
+      gap: 2px;
+      flex-shrink: 0;
+    }
+
+    .artifact-select {
+      max-width: 140px;
+      background: var(--p-surface-800);
+      color: var(--p-text-color);
+      border: 1px solid var(--p-surface-700);
+      border-radius: 6px;
+      padding: 4px 6px;
+      font-size: 0.78rem;
+      margin-right: 4px;
+    }
+
+    .canvas-body {
+      flex: 1;
+      overflow: hidden;
+      position: relative;
+      background: #ffffff;
+    }
+
+    .canvas-frame {
+      width: 100%;
+      height: 100%;
+      border: 0;
+      display: block;
+      background: #ffffff;
+    }
+
+    .canvas-source {
+      width: 100%;
+      height: 100%;
+      margin: 0;
+      padding: 12px;
+      overflow: auto;
+      background: var(--p-surface-950);
+      color: var(--p-text-color);
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 0.75rem;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+
+    .canvas-empty {
+      position: absolute;
+      inset: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 10px;
+      color: var(--p-text-muted-color);
+      background: var(--p-surface-950);
+
+      i {
+        font-size: 2rem;
+        opacity: 0.5;
+      }
+    }
+  `,
+})
+export class ArtifactCanvasComponent {
+  private readonly sanitizer = inject(DomSanitizer);
+  private readonly messageService = inject(MessageService);
+
+  readonly artifacts = input.required<Artifact[]>();
+  readonly activeId = input<string | null>(null);
+
+  readonly closePanel = output<void>();
+  readonly activeIdChange = output<string>();
+
+  readonly showSource = signal(false);
+  readonly showFrame = signal(true);
+
+  readonly active = computed<Artifact | null>(() => {
+    const list = this.artifacts();
+    if (list.length === 0) return null;
+    const id = this.activeId();
+    if (id) {
+      const found = list.find((a) => a.id === id);
+      if (found) return found;
+    }
+    return list[list.length - 1];
+  });
+
+  readonly srcdoc = computed<SafeHtml>(() => {
+    const html = this.active()?.html ?? '';
+    return this.sanitizer.bypassSecurityTrustHtml(html);
+  });
+
+  onSelect(event: Event): void {
+    const value = (event.target as HTMLSelectElement).value;
+    if (value) this.activeIdChange.emit(value);
+  }
+
+  reload(): void {
+    // Recreate the iframe element to force a full reload of the document.
+    this.showFrame.set(false);
+    setTimeout(() => this.showFrame.set(true));
+  }
+
+  async copy(): Promise<void> {
+    const html = this.active()?.html;
+    if (!html) return;
+    try {
+      await navigator.clipboard.writeText(html);
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Copied',
+        detail: 'Artifact HTML copied to clipboard.',
+        life: 2000,
+      });
+    } catch {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Copy failed',
+        detail: 'Could not access the clipboard.',
+        life: 3000,
+      });
+    }
+  }
+
+  download(): void {
+    const artifact = this.active();
+    if (!artifact) return;
+    const blob = new Blob([artifact.html], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${this.slugify(artifact.title)}.html`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  openInNewTab(): void {
+    const artifact = this.active();
+    if (!artifact) return;
+    const blob = new Blob([artifact.html], { type: 'text/html' });
+    const url = URL.createObjectURL(blob);
+    window.open(url, '_blank', 'noopener,noreferrer');
+    // Revoke a bit later so the new tab has time to load the document.
+    setTimeout(() => URL.revokeObjectURL(url), 60000);
+  }
+
+  private slugify(title: string): string {
+    return (
+      title
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 50) || 'artifact'
+    );
+  }
+}

--- a/apps/chat-frontend/src/app/pages/chat/chat-page.component.ts
+++ b/apps/chat-frontend/src/app/pages/chat/chat-page.component.ts
@@ -16,16 +16,21 @@ import { ConversationService } from '../../services/conversation.service';
 import { ChatApiService } from '../../services/chat-api.service';
 import { MarkdownService } from '../../services/markdown.service';
 import { SettingsService } from '../../services/settings.service';
+import { CanvasService } from '../../services/canvas.service';
 import {
   ChatMessage,
   DisplayMessage,
   StreamEvent,
   DisplayToolCall,
   FileAttachment,
+  Artifact,
 } from '../../models/types';
 import { MessageListComponent } from './message-list.component';
 import { ChatInputComponent, SendMessageEvent } from './chat-input.component';
 import { ModelSelectorComponent } from './model-selector.component';
+import { ArtifactCanvasComponent } from './artifact-canvas.component';
+import { ButtonModule } from 'primeng/button';
+import { TooltipModule } from 'primeng/tooltip';
 import {
   ApprovalDialogComponent,
   ApprovalRequest,
@@ -48,9 +53,13 @@ const IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
     ModelSelectorComponent,
     ApprovalDialogComponent,
     QuestionnaireDialogComponent,
+    ArtifactCanvasComponent,
+    ButtonModule,
+    TooltipModule,
   ],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
+    <div class="chat-shell" [class.canvas-open]="canvasVisible()">
     <div
       class="chat-page"
       [class.drag-over]="isDragOver()"
@@ -59,6 +68,19 @@ const IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
       (drop)="onDrop($event)"
     >
       <div class="chat-header">
+        <div class="header-left">
+          @if (artifacts().length && !canvas.isOpen()) {
+          <p-button
+            icon="pi pi-palette"
+            label="Canvas"
+            [text]="true"
+            severity="secondary"
+            size="small"
+            pTooltip="Show artifact canvas"
+            (click)="canvas.open()"
+          />
+          }
+        </div>
         <app-model-selector />
       </div>
       <app-message-list
@@ -92,6 +114,16 @@ const IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
       </div>
       }
     </div>
+    @if (canvasVisible()) {
+    <app-artifact-canvas
+      class="canvas-pane"
+      [artifacts]="artifacts()"
+      [activeId]="canvas.activeArtifactId()"
+      (closePanel)="canvas.close()"
+      (activeIdChange)="canvas.activeArtifactId.set($event)"
+    />
+    }
+    </div>
   `,
   styles: `
     :host {
@@ -100,21 +132,54 @@ const IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
       overflow: hidden;
     }
 
+    .chat-shell {
+      display: flex;
+      flex-direction: row;
+      height: 100%;
+      overflow: hidden;
+    }
+
     .chat-page {
       display: flex;
       flex-direction: column;
       height: 100%;
+      flex: 1 1 0;
+      min-width: 0;
       overflow: hidden;
       position: relative;
+    }
+
+    .canvas-pane {
+      flex: 1 1 0;
+      min-width: 0;
+      height: 100%;
+      border-left: 1px solid var(--p-surface-800);
     }
 
     .chat-header {
       display: flex;
       align-items: center;
-      justify-content: flex-end;
+      justify-content: space-between;
+      gap: 8px;
       padding: 8px 16px;
       border-bottom: 1px solid var(--p-surface-800);
       flex-shrink: 0;
+    }
+
+    .header-left {
+      display: flex;
+      align-items: center;
+      min-height: 32px;
+    }
+
+    @media (max-width: 900px) {
+      .chat-shell.canvas-open .chat-page {
+        display: none;
+      }
+
+      .canvas-pane {
+        border-left: none;
+      }
     }
 
     .drop-overlay {
@@ -153,6 +218,7 @@ export class ChatPageComponent implements OnInit, OnDestroy {
   private readonly markdown = inject(MarkdownService);
   private readonly settings = inject(SettingsService);
   private readonly messageService = inject(MessageService);
+  readonly canvas = inject(CanvasService);
 
   readonly statusText = signal('');
   readonly pendingApproval = signal<ApprovalRequest | null>(null);
@@ -169,11 +235,22 @@ export class ChatPageComponent implements OnInit, OnDestroy {
     return convo?.displayMessages ?? [];
   });
 
+  readonly artifacts = computed<Artifact[]>(() => {
+    const convo = this.conversationService.activeConversation();
+    return convo?.artifacts ?? [];
+  });
+
+  readonly canvasVisible = computed(
+    () => this.canvas.isOpen() && this.artifacts().length > 0
+  );
+
   ngOnInit(): void {
     this.routeSub = this.route.paramMap.subscribe((params) => {
       const id = params.get('id');
       if (id) {
         this.conversationService.setActiveConversation(id);
+        // Show the latest artifact for the newly active conversation.
+        this.canvas.activeArtifactId.set(null);
       } else {
         // /chat with no id — check if there's an active conversation
         const active = this.conversationService.activeConversation();
@@ -513,6 +590,8 @@ export class ChatPageComponent implements OnInit, OnDestroy {
         };
         this.conversationService.addToolCallToLastAssistant(convoId, toolCall);
         this.statusText.set(`Using tool: ${toolCall.name}...`);
+        // Artifact tools render live in the canvas as soon as the HTML arrives.
+        this.handleArtifactTool(convoId, toolCall.name, toolCall.input);
         break;
       }
 
@@ -683,6 +762,54 @@ export class ChatPageComponent implements OnInit, OnDestroy {
         break;
       }
     }
+  }
+
+  /**
+   * Detect artifact tool calls and render/update the canvas live.
+   * The HTML payload rides in the tool-call input.
+   */
+  private handleArtifactTool(
+    convoId: string,
+    toolName: string,
+    input: Record<string, unknown> | undefined
+  ): void {
+    if (
+      !input ||
+      (toolName !== 'create_artifact' && toolName !== 'update_artifact')
+    ) {
+      return;
+    }
+
+    const html = typeof input['html'] === 'string' ? input['html'] : '';
+    if (!html.trim()) return;
+    const title =
+      typeof input['title'] === 'string'
+        ? (input['title'] as string)
+        : undefined;
+
+    let artifact;
+    if (toolName === 'update_artifact') {
+      artifact = this.conversationService.updateArtifact(convoId, {
+        html,
+        title,
+      });
+      // Fall back to creating one if there was nothing to update.
+      if (!artifact) {
+        artifact = this.conversationService.createArtifact(
+          convoId,
+          title || 'Artifact',
+          html
+        );
+      }
+    } else {
+      artifact = this.conversationService.createArtifact(
+        convoId,
+        title || 'Artifact',
+        html
+      );
+    }
+
+    this.canvas.open(artifact.id);
   }
 
   private finalizeStream(convoId: string): void {

--- a/apps/chat-frontend/src/app/services/canvas.service.ts
+++ b/apps/chat-frontend/src/app/services/canvas.service.ts
@@ -1,0 +1,32 @@
+import { Injectable, signal } from '@angular/core';
+
+/**
+ * Transient UI state for the artifact canvas panel.
+ *
+ * Artifacts themselves are persisted on the conversation (see
+ * ConversationService); this service only tracks ephemeral view state such as
+ * whether the panel is open and which artifact/version is currently shown.
+ */
+@Injectable({ providedIn: 'root' })
+export class CanvasService {
+  /** Whether the canvas side panel is visible. */
+  readonly isOpen = signal(false);
+
+  /** The id of the artifact currently shown in the canvas (null = latest). */
+  readonly activeArtifactId = signal<string | null>(null);
+
+  open(artifactId?: string | null): void {
+    if (artifactId !== undefined) {
+      this.activeArtifactId.set(artifactId);
+    }
+    this.isOpen.set(true);
+  }
+
+  close(): void {
+    this.isOpen.set(false);
+  }
+
+  toggle(): void {
+    this.isOpen.update((v) => !v);
+  }
+}

--- a/apps/chat-frontend/src/app/services/conversation.service.ts
+++ b/apps/chat-frontend/src/app/services/conversation.service.ts
@@ -7,6 +7,7 @@ import {
   DisplayDelegation,
   ChatConfig,
   MessageStats,
+  Artifact,
 } from '../models/types';
 
 const STORAGE_KEY = 'chat-conversations';
@@ -287,6 +288,72 @@ export class ConversationService {
         return { ...c, displayMessages, updatedAt: Date.now() };
       })
     );
+  }
+
+  /**
+   * Create a new artifact on a conversation and return it.
+   */
+  createArtifact(
+    conversationId: string,
+    title: string,
+    html: string
+  ): Artifact {
+    const artifact: Artifact = {
+      id: crypto.randomUUID(),
+      title: title || 'Untitled Artifact',
+      html,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      version: 1,
+    };
+    this.conversations.update((convos) =>
+      convos.map((c) => {
+        if (c.id !== conversationId) return c;
+        return {
+          ...c,
+          artifacts: [...(c.artifacts || []), artifact],
+          updatedAt: Date.now(),
+        };
+      })
+    );
+    return artifact;
+  }
+
+  /**
+   * Update an existing artifact's HTML (and optionally its title), bumping the
+   * version. If no artifactId is given, the most recently updated artifact is
+   * patched. Returns the affected artifact, or null if there was none.
+   */
+  updateArtifact(
+    conversationId: string,
+    patch: { html: string; title?: string; artifactId?: string }
+  ): Artifact | null {
+    let updated: Artifact | null = null;
+    this.conversations.update((convos) =>
+      convos.map((c) => {
+        if (c.id !== conversationId) return c;
+        const artifacts = [...(c.artifacts || [])];
+        if (artifacts.length === 0) return c;
+
+        let index = artifacts.length - 1;
+        if (patch.artifactId) {
+          const found = artifacts.findIndex((a) => a.id === patch.artifactId);
+          if (found >= 0) index = found;
+        }
+
+        const current = artifacts[index];
+        updated = {
+          ...current,
+          html: patch.html,
+          title: patch.title?.trim() || current.title,
+          updatedAt: Date.now(),
+          version: current.version + 1,
+        };
+        artifacts[index] = updated;
+        return { ...c, artifacts, updatedAt: Date.now() };
+      })
+    );
+    return updated;
   }
 
   setActiveConversation(id: string | null): void {


### PR DESCRIPTION
Gives the LLM the ability to author arbitrary, self-contained HTML artifacts that render live in a sandboxed iframe ("canvas") beside the chat, with full freedom to create and iteratively update them.

## Backend (ai-gateway)
- **`artifact-tools.ts`** — `create_artifact(title, html)` and `update_artifact(html, title?)` in a new `Artifacts` category. The tools are intentionally thin: the HTML payload rides in the tool-call **input**, which the existing streaming layer already forwards via `tool_call_start`, so results stay small (no duplicated HTML).
- Registered the tools and added an **`artisan-agent`** sub-agent to the orchestrator (with a front-end-engineer system prompt + delegation example) so "build / visualise / design" requests get routed to it.

## Frontend (chat-frontend)
- **`Artifact` type** persisted on the conversation (survives reloads), with versioning.
- **`ConversationService`** gains `createArtifact` / `updateArtifact` (update bumps the version; falls back to create if none exists).
- **`CanvasService`** — transient panel UI state.
- **`ArtifactCanvasComponent`** — renders HTML in a **sandboxed iframe** (`allow-scripts` but opaque origin — no access to the parent page, cookies, or storage) with a toolbar: reload, source/preview toggle, copy, download `.html`, open in new tab, version/artifact switcher, close.
- **`ChatPageComponent`** — detects artifact tool calls during streaming, upserts the artifact, opens a responsive split-pane canvas, and adds a header "Canvas" toggle.

## Verification
- `nx build chat-frontend` ✅
- `nx build ai-gateway` ✅
- `tsc --noEmit` on the gateway ✅

## Security note
The iframe sandbox deliberately omits `allow-same-origin` (artifacts can't read parent cookies/storage), but it does run untrusted model-generated scripts — inherent to the "total freedom" goal. A future hardening step could serve artifacts from a separate origin/subdomain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q9wJ4YUBknecyKRZmWuE2v)_