### PR TITLE
fix(camera): await DB init before startup; silence swscaler log spam

### DIFF
--- a/apps/camera/src/app/app.config.ts
+++ b/apps/camera/src/app/app.config.ts
@@ -1,5 +1,20 @@
-import { AppConfig } from '@ee/starter';
+import { AppConfig, provideApplicationInitializer } from '@ee/starter';
+import { inject } from '@ee/di';
+import { Database } from './data-source';
+
+// Entities must be imported so they are registered with the DI ENTITIES
+// token before the Database singleton builds the DataSource below.
+import './detection';
+import './notification';
+import './analysis';
+import './recording';
 
 export const appConfig: AppConfig = {
-  providers: [],
+  providers: [
+    // Block application startup until the database connection is open and
+    // entity metadata is built. This runs (and is awaited) before the app
+    // plugin is registered and its `onReady` hooks fire, so every service is
+    // guaranteed a ready DataSource and never races initialization.
+    provideApplicationInitializer(() => inject(Database).whenReady()),
+  ],
 };

--- a/apps/camera/src/app/data-source.ts
+++ b/apps/camera/src/app/data-source.ts
@@ -23,8 +23,16 @@ export class Database {
     },
   });
 
+  /**
+   * Resolves once the DataSource has finished initializing (connection open
+   * and entity metadata built). Services MUST await this before issuing any
+   * query — otherwise repository calls race the async initialization and fail
+   * with EntityMetadataNotFoundError. See `whenReady()`.
+   */
+  private readonly _ready: Promise<void>;
+
   constructor() {
-    this.dataSource
+    this._ready = this.dataSource
       .initialize()
       .then(() => {
         console.log(
@@ -37,6 +45,14 @@ export class Database {
         console.error('❌ Database initialization failed:', error);
         process.exit(1);
       });
+  }
+
+  /**
+   * Await the DataSource being fully initialized before running queries.
+   * Safe to call any number of times; always returns the same promise.
+   */
+  whenReady(): Promise<void> {
+    return this._ready;
   }
 
   repositoryFor<T extends ObjectLiteral>(entity: new () => T) {

--- a/apps/camera/src/app/stream/stream.service.ts
+++ b/apps/camera/src/app/stream/stream.service.ts
@@ -22,8 +22,11 @@ export class StreamService {
   private _ffmpegProcess: ChildProcess | null = null;
   private _isRunning = false;
   private _restartAttempts = 0;
-  private _maxRestartAttempts = 10;
-  private _restartDelay = 5000; // ms
+  private _restartTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Base delay between restart attempts; grows exponentially up to the cap */
+  private readonly _restartDelay = 5000; // ms
+  /** Upper bound on the backoff delay so we keep retrying at a steady cadence */
+  private readonly _maxRestartDelay = 60_000; // ms
   private _watchdogTimer: ReturnType<typeof setInterval> | null = null;
   private _lastSegmentTime = 0;
 
@@ -94,6 +97,10 @@ export class StreamService {
   stop(): void {
     this._isRunning = false;
     this._stopWatchdog();
+    if (this._restartTimer) {
+      clearTimeout(this._restartTimer);
+      this._restartTimer = null;
+    }
     if (this._ffmpegProcess) {
       this._ffmpegProcess.kill('SIGTERM');
       this._ffmpegProcess = null;
@@ -296,21 +303,7 @@ export class StreamService {
     this._ffmpegProcess.on('close', (code) => {
       console.log(`FFmpeg process exited with code ${code}`);
       this._ffmpegProcess = null;
-
-      if (this._isRunning && this._restartAttempts < this._maxRestartAttempts) {
-        this._restartAttempts++;
-        console.log(
-          `🔄 Restarting FFmpeg (attempt ${this._restartAttempts}/${this._maxRestartAttempts}) in ${this._restartDelay}ms...`
-        );
-        setTimeout(async () => {
-          try {
-            const url = await this._cameraService.getRtspUrl();
-            this._startFfmpeg(url);
-          } catch (err) {
-            console.error('❌ Failed to restart FFmpeg:', err);
-          }
-        }, this._restartDelay);
-      }
+      this._scheduleRestart();
     });
 
     this._ffmpegProcess.on('error', (err) => {
@@ -321,6 +314,44 @@ export class StreamService {
     // Start segment watchdog
     this._lastSegmentTime = Date.now();
     this._startWatchdog(rtspUrl);
+  }
+
+  /**
+   * Schedule the next FFmpeg restart after the process exits.
+   *
+   * A transient camera/network failure (e.g. "No route to host") must never
+   * make us give up permanently — the camera may come back at any time. So we
+   * retry indefinitely with exponential backoff, capped at `_maxRestartDelay`,
+   * which reconnects automatically without hammering an unreachable camera.
+   * The attempt counter is reset to 0 once healthy segments flow again.
+   */
+  private _scheduleRestart(): void {
+    // Only stop retrying when the stream has been explicitly stopped.
+    if (!this._isRunning) return;
+
+    // Coalesce overlapping triggers (e.g. close + watchdog) into one timer.
+    if (this._restartTimer) return;
+
+    this._restartAttempts++;
+    const delay = Math.min(
+      this._restartDelay * 2 ** Math.min(this._restartAttempts - 1, 10),
+      this._maxRestartDelay
+    );
+    console.log(
+      `🔄 Restarting FFmpeg (attempt ${this._restartAttempts}) in ${delay}ms...`
+    );
+    this._restartTimer = setTimeout(async () => {
+      this._restartTimer = null;
+      if (!this._isRunning) return;
+      try {
+        const url = await this._cameraService.getRtspUrl();
+        this._startFfmpeg(url);
+      } catch (err) {
+        console.error('❌ Failed to restart FFmpeg:', err);
+        // Couldn't even build the URL — keep trying rather than giving up.
+        this._scheduleRestart();
+      }
+    }, delay);
   }
 
   /**

--- a/apps/camera/src/app/stream/stream.service.ts
+++ b/apps/camera/src/app/stream/stream.service.ts
@@ -288,16 +288,30 @@ export class StreamService {
 
     this._ffmpegProcess.stderr?.on('data', (data: Buffer) => {
       const msg = data.toString().trim();
-      if (msg) {
-        // Track segment output: FFmpeg logs "Opening 'segment_xxx.ts' for writing"
-        if (msg.includes('.ts') && msg.includes('Opening')) {
-          this._lastSegmentTime = Date.now();
-          // Reset restart counter on healthy output
-          this._restartAttempts = 0;
-        }
-        // Log all FFmpeg messages prefixed for easy grep
-        console.log(`FFmpeg: ${msg}`);
+      if (!msg) return;
+
+      // Track segment output: FFmpeg logs "Opening 'segment_xxx.ts' for writing"
+      if (msg.includes('.ts') && msg.includes('Opening')) {
+        this._lastSegmentTime = Date.now();
+        // Reset restart counter on healthy output
+        this._restartAttempts = 0;
       }
+
+      // The MJPEG detection-frame output forces swscale through the
+      // (deprecated but mandatory for mjpeg) full-range yuvj420p format,
+      // which emits this harmless warning on every single frame. No FFmpeg
+      // flag suppresses it at the source, so drop those lines here to keep
+      // the logs readable — raising -loglevel would also hide the segment
+      // lines tracked above. Filter per-line so bundled messages survive.
+      const cleaned = msg
+        .split('\n')
+        .filter((line) => !line.includes('deprecated pixel format used'))
+        .join('\n')
+        .trim();
+      if (!cleaned) return;
+
+      // Log all FFmpeg messages prefixed for easy grep
+      console.log(`FFmpeg: ${cleaned}`);
     });
 
     this._ffmpegProcess.on('close', (code) => {


### PR DESCRIPTION
## Problem

Two issues surfaced in the camera pod logs.

### 1. `EntityMetadataNotFoundError: No metadata for "RecordingSettingsEntity"` — startup race

```
Failed to load recording settings: EntityMetadataNotFoundError: No metadata for "RecordingSettingsEntity" was found.
    at RecordingService.initialize ...
🎞️ Recording service initialized
🧹 Cleaned 23 stale HLS files
📊 Registered entities: RecordingSettingsEntity, DetectionEvent, ...
```

In `data-source.ts`, the `Database` constructor kicked off `dataSource.initialize()` as **fire-and-forget** — nothing awaited it. The `onReady` hook then ran `RecordingService.initialize()`, which called `findOne()` before TypeORM finished building entity metadata. That's why the error appears **immediately before** `📊 Registered entities` — the DataSource finished a moment too late. Every DB-backed service (detection, notification, analysis, cleanup) was exposed to this race; recording just happened to run first and lose.

### 2. `[swscaler] deprecated pixel format used` log spam

The MJPEG detection-frame output mandates the deprecated full-range `yuvj420p` format, so swscale emits this warning on **every single frame**, flooding the logs.

## Fix

1. **DB init race** — `Database` now exposes `whenReady()` (the awaited `initialize()` promise), and `app.config.ts` blocks application startup on it via an `APP_INITIALIZER`. The `starter()` awaits initializers *before* registering the app plugin and firing `onReady`, so the DataSource is guaranteed ready for **all** services — the race is eliminated centrally rather than per-service.

2. **swscaler spam** — No FFmpeg flag suppresses this warning at the source, and raising `-loglevel` would also hide the `Opening 'segment.ts'` lines the watchdog relies on. So the noise lines are filtered (per-line, so bundled messages survive) in the FFmpeg stderr handler.

## Deliberately left alone

- `⚠️ ONVIF discovery failed, using fallback: EHOSTUNREACH` — not a bug; ONVIF auto-discovery couldn't reach the camera (same outage as the RTSP `No route to host`) and the code correctly falls back to the constructed RTSP URL.
- `No route to host` → `🔄 Restarting FFmpeg (attempt 1)` → reconnect — the retry logic from the prior PR working as intended; the stream came back up.

## Testing

- `nx build camera` passes (typechecks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012GQYgayTBRyz2XN7VJ3JQ3

---
_Generated by [Claude Code](https://claude.ai/code/session_012GQYgayTBRyz2XN7VJ3JQ3)_