### PR TITLE
Exclude discontinued variants from product price ranges

### DIFF
--- a/apps/aritzia-scanner/src/ai-routes.ts
+++ b/apps/aritzia-scanner/src/ai-routes.ts
@@ -113,12 +113,21 @@ router.get(
         return;
       }
 
-      // Fetch variant price range
+      // Fetch variant price range. Restrict to active (non-discontinued)
+      // variants so the "current price" reflects what's actually available —
+      // discontinued variants are usually marked down before being dropped and
+      // would otherwise drag the range below the buyable price. Falls back to
+      // all variants when a product is fully discontinued.
+      const lastScanTime = await getLastScanTime(db);
       const priceInfo = await getPromise.call(
         db,
-        `SELECT MIN(price) as min_price, MAX(price) as max_price, MIN(list_price) as min_list, MAX(list_price) as max_list
+        `SELECT
+           COALESCE(MIN(CASE WHEN last_seen_at >= ? THEN price END), MIN(price)) as min_price,
+           COALESCE(MAX(CASE WHEN last_seen_at >= ? THEN price END), MAX(price)) as max_price,
+           COALESCE(MIN(CASE WHEN last_seen_at >= ? THEN list_price END), MIN(list_price)) as min_list,
+           COALESCE(MAX(CASE WHEN last_seen_at >= ? THEN list_price END), MAX(list_price)) as max_list
        FROM variants WHERE product_id = ?`,
-        [productId]
+        [lastScanTime, lastScanTime, lastScanTime, lastScanTime, productId]
       );
 
       // Fetch price history for trend analysis

--- a/apps/aritzia-scanner/src/routes/web.ts
+++ b/apps/aritzia-scanner/src/routes/web.ts
@@ -302,14 +302,14 @@ router.get('/products', async (req, res) => {
     `SELECT p.id, p.name, p.display_name, p.slug, p.brand, p.rating, p.review_count,
             (SELECT thumbnail_id FROM variants WHERE product_id = p.id AND thumbnail_id IS NOT NULL LIMIT 1) as thumbnail_id,
             CASE WHEN MAX(v.last_seen_at) >= ? THEN 0 ELSE 1 END as isDiscontinued,
-            MIN(v.price) as min_price
+            COALESCE(MIN(CASE WHEN v.last_seen_at >= ? THEN v.price END), MIN(v.price)) as min_price
      FROM products p
      LEFT JOIN variants v ON p.id = v.product_id
      ${whereClauses}
      GROUP BY p.id
      ORDER BY isDiscontinued ASC, ${PRODUCT_SORTS[sortBy]}
      LIMIT ? OFFSET ?`,
-    [lastScanTime, ...params, PER_PAGE, (safePage - 1) * PER_PAGE]
+    [lastScanTime, lastScanTime, ...params, PER_PAGE, (safePage - 1) * PER_PAGE]
   );
 
   const cards: Card[] = products.map((p: any) => ({
@@ -778,7 +778,10 @@ router.get('/colors/:color', async (req, res) => {
             (SELECT v2.color_id FROM variants v2
              WHERE v2.product_id = p.id AND v2.color = ?
              LIMIT 1) as variant_color_id,
-            (SELECT MIN(v2.price) FROM variants v2
+            (SELECT COALESCE(
+               MIN(CASE WHEN v2.last_seen_at >= ? THEN v2.price END),
+               MIN(v2.price)
+             ) FROM variants v2
              WHERE v2.product_id = p.id AND v2.color = ?) as price,
             CASE WHEN MAX(v3.last_seen_at) >= ? THEN 0 ELSE 1 END as isDiscontinued
      FROM products p
@@ -787,7 +790,7 @@ router.get('/colors/:color', async (req, res) => {
      WHERE v.color = ?
      GROUP BY p.id
      ORDER BY isDiscontinued ASC, p.review_count DESC, p.name`,
-    [color, color, color, lastScanTime, color]
+    [color, color, lastScanTime, color, lastScanTime, color]
   );
 
   const cards: Card[] = products.map((p: any) => ({
@@ -872,13 +875,13 @@ router.get('/categories/:category', async (req, res) => {
     `SELECT p.id, p.name, p.display_name, p.slug, p.brand, p.rating, p.review_count,
             (SELECT thumbnail_id FROM variants WHERE product_id = p.id AND thumbnail_id IS NOT NULL LIMIT 1) as thumbnail_id,
             CASE WHEN MAX(v.last_seen_at) >= ? THEN 0 ELSE 1 END as isDiscontinued,
-            MIN(v.price) as price
+            COALESCE(MIN(CASE WHEN v.last_seen_at >= ? THEN v.price END), MIN(v.price)) as price
      FROM products p
      LEFT JOIN variants v ON p.id = v.product_id
      WHERE p.category LIKE ?
      GROUP BY p.id
      ORDER BY isDiscontinued ASC, ${orderBy}`,
-    [lastScanTime, `%${category}%`]
+    [lastScanTime, lastScanTime, `%${category}%`]
   );
 
   const cards: Card[] = products.map((p: any) => ({


### PR DESCRIPTION
Product-level price aggregates were computed with MIN/MAX over all
variants, including discontinued ones. Since variants are typically
marked down before being discontinued, this dragged the displayed
"From $X" price and AI price ranges below what's actually buyable.

Restrict price aggregation to active variants (last_seen_at >=
last completed scan), falling back to all variants only when a product
is fully discontinued so those still show a price:

- /products listing (min_price + price sort)
- /categories/:category (price + price sort)
- /colors/:color (per-color min price)
- AI product summary price range

The sale, related-products, outfit, and deals queries already filtered
on last_seen_at and were left unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PUuBfaJ4wypUstDkirsk8h