### PR TITLE
Add a colour legend to the trip schedule

### DIFF
--- a/apps/trip-frontend/src/app/core/api.service.ts
+++ b/apps/trip-frontend/src/app/core/api.service.ts
@@ -8,6 +8,8 @@ import {
   CreateExpenseRequest,
   CreateTripRequest,
   Expense,
+  LegendCategory,
+  LegendCategoryRequest,
   PackingContainer,
   PackingItem,
   PackingList,
@@ -145,6 +147,43 @@ export class ApiService {
   deleteTag(tripId: string, tagId: string): Observable<{ success: boolean }> {
     return this.http.delete<{ success: boolean }>(
       `${this.base}/trips/${tripId}/tags/${tagId}`
+    );
+  }
+
+  // ── Legend categories ──
+  getLegend(tripId: string): Observable<LegendCategory[]> {
+    return this.http.get<LegendCategory[]>(
+      `${this.base}/trips/${tripId}/legend`
+    );
+  }
+
+  createLegendCategory(
+    tripId: string,
+    body: LegendCategoryRequest
+  ): Observable<LegendCategory> {
+    return this.http.post<LegendCategory>(
+      `${this.base}/trips/${tripId}/legend`,
+      body
+    );
+  }
+
+  updateLegendCategory(
+    tripId: string,
+    categoryId: string,
+    body: Partial<LegendCategoryRequest>
+  ): Observable<LegendCategory> {
+    return this.http.put<LegendCategory>(
+      `${this.base}/trips/${tripId}/legend/${categoryId}`,
+      body
+    );
+  }
+
+  deleteLegendCategory(
+    tripId: string,
+    categoryId: string
+  ): Observable<{ success: boolean }> {
+    return this.http.delete<{ success: boolean }>(
+      `${this.base}/trips/${tripId}/legend/${categoryId}`
     );
   }
 

--- a/apps/trip-frontend/src/app/core/models.ts
+++ b/apps/trip-frontend/src/app/core/models.ts
@@ -130,12 +130,24 @@ export interface SegmentRequest {
 export interface Tag {
   id: string;
   name: string;
-  color: string;
   createdAt: string;
   updatedAt: string;
 }
 
 export interface TagRequest {
+  name: string;
+}
+
+/** A named colour in a trip's legend (e.g. "Restaurants" → purple). */
+export interface LegendCategory {
+  id: string;
+  name: string;
+  color: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface LegendCategoryRequest {
   name: string;
   color: string;
 }
@@ -149,6 +161,7 @@ export interface Activity {
   startAt: string;
   endAt: string;
   color?: string | null;
+  legendCategory?: LegendCategory | null;
   lat?: number | null;
   lng?: number | null;
   locationLabel?: string | null;
@@ -163,7 +176,8 @@ export interface CreateActivityRequest {
   segmentId?: string | null;
   startAt: string;
   endAt: string;
-  color?: string;
+  color?: string | null;
+  legendCategoryId?: string | null;
   lat?: number | null;
   lng?: number | null;
   locationLabel?: string | null;

--- a/apps/trip-frontend/src/app/pages/map/map.component.ts
+++ b/apps/trip-frontend/src/app/pages/map/map.component.ts
@@ -173,7 +173,7 @@ export class MapComponent implements OnInit, AfterViewInit, OnDestroy {
         order: i + 1,
         title: a.title,
         time: `${mm}/${dd} ${formatMinutes(s.minutes)}`,
-        color: a.color || a.tags[0]?.color || '#4f46e5',
+        color: a.legendCategory?.color || a.color || '#4f46e5',
       };
     });
   });

--- a/apps/trip-frontend/src/app/pages/schedule/schedule.component.ts
+++ b/apps/trip-frontend/src/app/pages/schedule/schedule.component.ts
@@ -23,6 +23,7 @@ import {
   Activity,
   CreateActivityRequest,
   LatLng,
+  LegendCategory,
   Tag,
   Trip,
 } from '../../core/models';
@@ -61,6 +62,7 @@ interface EditorForm {
   title: string;
   notes: string;
   segmentId: string | null;
+  legendCategoryId: string | null;
   color: string;
   tagIds: string[];
   startDate: string;
@@ -137,6 +139,7 @@ interface PendingPress {
           />
         }
         <p-button label="Add" icon="pi pi-plus" size="small" (onClick)="openCreateDefault()" />
+        <p-button label="Legend" icon="pi pi-palette" severity="secondary" [outlined]="true" size="small" (onClick)="openLegendManager()" />
         <p-button label="Tags" icon="pi pi-tag" severity="secondary" [outlined]="true" size="small" (onClick)="openTagManager()" />
       </div>
 
@@ -298,24 +301,48 @@ interface PendingPress {
             <div class="dt"><input type="date" [(ngModel)]="form.endDate" /><input type="time" [(ngModel)]="form.endTime" /></div>
           </div>
         </div>
-        <div class="field-row">
-          <div class="field">
-            <label>City / stay</label>
+        <div class="field">
+          <label>City / stay</label>
+          <p-select
+            [options]="segmentOptions()"
+            [(ngModel)]="form.segmentId"
+            optionLabel="label"
+            optionValue="value"
+            [showClear]="true"
+            placeholder="None"
+            appendTo="body"
+            styleClass="w-full"
+          />
+        </div>
+        <div class="field">
+          <label>Category</label>
+          <div class="cat-row">
             <p-select
-              [options]="segmentOptions()"
-              [(ngModel)]="form.segmentId"
-              optionLabel="label"
-              optionValue="value"
+              [options]="legend()"
+              [(ngModel)]="form.legendCategoryId"
+              optionLabel="name"
+              optionValue="id"
               [showClear]="true"
-              placeholder="None"
+              placeholder="Custom colour"
               appendTo="body"
               styleClass="w-full"
-            />
+            >
+              <ng-template #selectedItem let-cat>
+                <span class="cat-opt"><span class="tag-dot" [style.background]="cat.color"></span>{{ cat.name }}</span>
+              </ng-template>
+              <ng-template let-cat #item>
+                <span class="cat-opt"><span class="tag-dot" [style.background]="cat.color"></span>{{ cat.name }}</span>
+              </ng-template>
+            </p-select>
+            @if (!form.legendCategoryId) {
+              <input type="color" [(ngModel)]="form.color" title="Custom colour" />
+            }
+            <button class="link-btn" type="button" (click)="openLegendManager()">Manage</button>
           </div>
-          <div class="field swatch-field">
-            <label>Colour</label>
-            <input type="color" [(ngModel)]="form.color" />
-          </div>
+          <small class="muted">
+            Pick a legend category to colour this item, or leave it on “Custom
+            colour” to choose a one-off colour.
+          </small>
         </div>
         <div class="field">
           <label>Location</label>
@@ -359,6 +386,41 @@ interface PendingPress {
       </ng-template>
     </p-dialog>
 
+    <!-- Legend manager -->
+    <p-dialog
+      [(visible)]="legendManagerVisible"
+      [modal]="true"
+      [draggable]="false"
+      header="Legend"
+      [style]="{ width: '380px' }"
+    >
+      <p class="muted dialog-hint">
+        A legend pairs a colour with a label (e.g. “Restaurants” in purple).
+        Assign a category to a schedule item and it takes on that colour.
+      </p>
+      <div class="tag-list">
+        @for (c of legend(); track c.id) {
+          <div class="tag-row">
+            <input
+              type="color"
+              [ngModel]="c.color"
+              (ngModelChange)="recolorCategory(c, $event)"
+              title="Change colour"
+            />
+            <span class="tag-name">{{ c.name }}</span>
+            <button class="icon-btn danger" (click)="deleteLegendCategory(c)"><i class="pi pi-trash"></i></button>
+          </div>
+        } @empty {
+          <p class="muted">No categories yet.</p>
+        }
+      </div>
+      <div class="add-tag">
+        <input type="color" [(ngModel)]="newCategoryColor" />
+        <input pInputText placeholder="New category" [(ngModel)]="newCategoryName" (keyup.enter)="addLegendCategory()" />
+        <p-button icon="pi pi-plus" (onClick)="addLegendCategory()" />
+      </div>
+    </p-dialog>
+
     <!-- Tag manager -->
     <p-dialog
       [(visible)]="tagManagerVisible"
@@ -367,10 +429,14 @@ interface PendingPress {
       header="Tags"
       [style]="{ width: '380px' }"
     >
+      <p class="muted dialog-hint">
+        Tags are plain text labels for filtering and notes. Colour comes from
+        the legend, not from tags.
+      </p>
       <div class="tag-list">
         @for (t of tags(); track t.id) {
           <div class="tag-row">
-            <span class="tag-dot" [style.background]="t.color"></span>
+            <i class="pi pi-tag tag-icon"></i>
             <span class="tag-name">{{ t.name }}</span>
             <button class="icon-btn danger" (click)="deleteTag(t)"><i class="pi pi-trash"></i></button>
           </div>
@@ -379,7 +445,6 @@ interface PendingPress {
         }
       </div>
       <div class="add-tag">
-        <input type="color" [(ngModel)]="newTagColor" />
         <input pInputText placeholder="New tag" [(ngModel)]="newTagName" (keyup.enter)="addTag()" />
         <p-button icon="pi pi-plus" (onClick)="addTag()" />
       </div>
@@ -512,11 +577,17 @@ interface PendingPress {
     .field-row .field { flex: 1; }
     .dt { display: flex; gap: 6px; }
     .dt input { padding: 8px 10px; border: 1px solid var(--border); border-radius: var(--radius-sm); font: inherit; }
-    .swatch-field { flex: 0 0 64px; }
-    .swatch-field input[type='color'] { width: 100%; height: 40px; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; cursor: pointer; }
+    .cat-row { display: flex; align-items: center; gap: 8px; }
+    .cat-row .w-full { flex: 1; min-width: 0; }
+    .cat-row input[type='color'] { width: 40px; height: 40px; flex: 0 0 40px; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; cursor: pointer; }
+    .cat-opt { display: inline-flex; align-items: center; gap: 8px; }
+    .link-btn { border: none; background: none; color: var(--brand); font: inherit; font-weight: 600; cursor: pointer; white-space: nowrap; padding: 0 2px; }
+    .dialog-hint { margin: 0 0 12px; font-size: 12px; line-height: 1.4; }
     .tag-list { display: flex; flex-direction: column; gap: 6px; margin-bottom: 14px; }
     .tag-row { display: flex; align-items: center; gap: 8px; }
-    .tag-dot { width: 14px; height: 14px; border-radius: 50%; }
+    .tag-row input[type='color'] { width: 28px; height: 28px; flex: 0 0 28px; padding: 0; border: 1px solid var(--border); border-radius: var(--radius-sm); background: none; cursor: pointer; }
+    .tag-dot { width: 14px; height: 14px; border-radius: 50%; flex: 0 0 14px; }
+    .tag-icon { color: var(--text-muted); }
     .tag-name { flex: 1; }
     .add-tag { display: flex; gap: 8px; align-items: center; }
     .add-tag input[pInputText] { flex: 1; }
@@ -544,6 +615,7 @@ export class ScheduleComponent implements OnInit {
   readonly trip = signal<Trip | null>(null);
   readonly activities = signal<Activity[]>([]);
   readonly tags = signal<Tag[]>([]);
+  readonly legend = signal<LegendCategory[]>([]);
   readonly loading = signal(true);
 
   readonly displayTz = signal<string>('UTC');
@@ -619,7 +691,8 @@ export class ScheduleComponent implements OnInit {
     const tz = this.displayTz();
     const byCol: RenderedPiece[][] = dates.map(() => []);
     for (const a of this.activities()) {
-      const color = a.color || a.tags[0]?.color || this.colColor(a) || '#4f46e5';
+      const color =
+        a.legendCategory?.color || a.color || this.colColor(a) || '#4f46e5';
       for (const p of activityPieces(a.startAt, a.endAt, dates, tz)) {
         byCol[p.colIndex].push({ ...p, activity: a, color });
       }
@@ -634,7 +707,10 @@ export class ScheduleComponent implements OnInit {
 
   readonly tagManagerVisible = signal(false);
   newTagName = '';
-  newTagColor = '#4f46e5';
+
+  readonly legendManagerVisible = signal(false);
+  newCategoryName = '';
+  newCategoryColor = '#4f46e5';
 
   // ── Drag state ──
   readonly drag = signal<DragState | null>(null);
@@ -662,6 +738,7 @@ export class ScheduleComponent implements OnInit {
       error: () => this.loading.set(false),
     });
     this.api.getTags(tripId).subscribe((t) => this.tags.set(t));
+    this.api.getLegend(tripId).subscribe((l) => this.legend.set(l));
     this.api.getActivities(tripId).subscribe((a) => this.activities.set(a));
   }
 
@@ -945,6 +1022,7 @@ export class ScheduleComponent implements OnInit {
       title: '',
       notes: '',
       segmentId: null,
+      legendCategoryId: null,
       color: '#4f46e5',
       tagIds: [],
       startDate: '',
@@ -1027,7 +1105,8 @@ export class ScheduleComponent implements OnInit {
       title: a.title,
       notes: a.notes ?? '',
       segmentId: a.segmentId,
-      color: a.color || a.tags[0]?.color || '#4f46e5',
+      legendCategoryId: a.legendCategory?.id ?? null,
+      color: a.color || '#4f46e5',
       tagIds: a.tags.map((t) => t.id),
       startDate: s.date,
       startTime: formatMinutes(s.minutes),
@@ -1058,7 +1137,10 @@ export class ScheduleComponent implements OnInit {
       title: f.title.trim(),
       notes: f.notes.trim() || undefined,
       segmentId: f.segmentId,
-      color: f.color || undefined,
+      legendCategoryId: f.legendCategoryId,
+      // The legend drives the colour when a category is chosen; the custom
+      // colour only applies to uncategorised one-offs.
+      color: f.legendCategoryId ? null : f.color || undefined,
       tagIds: f.tagIds,
       startAt: startISO,
       endAt: endISO,
@@ -1117,7 +1199,7 @@ export class ScheduleComponent implements OnInit {
   addTag(): void {
     const name = this.newTagName.trim();
     if (!name) return;
-    this.api.createTag(this.id(), { name, color: this.newTagColor }).subscribe({
+    this.api.createTag(this.id(), { name }).subscribe({
       next: (tag) => {
         this.tags.set([...this.tags(), tag].sort((a, b) => a.name.localeCompare(b.name)));
         this.newTagName = '';
@@ -1130,6 +1212,53 @@ export class ScheduleComponent implements OnInit {
     this.api.deleteTag(this.id(), tag.id).subscribe({
       next: () => {
         this.tags.set(this.tags().filter((t) => t.id !== tag.id));
+        this.reloadActivities();
+      },
+      error: (e) => this.error(e),
+    });
+  }
+
+  // ── Legend ──
+  openLegendManager(): void {
+    this.legendManagerVisible.set(true);
+  }
+
+  addLegendCategory(): void {
+    const name = this.newCategoryName.trim();
+    if (!name) return;
+    this.api
+      .createLegendCategory(this.id(), { name, color: this.newCategoryColor })
+      .subscribe({
+        next: (cat) => {
+          this.legend.set(
+            [...this.legend(), cat].sort((a, b) => a.name.localeCompare(b.name))
+          );
+          this.newCategoryName = '';
+        },
+        error: (e) => this.error(e),
+      });
+  }
+
+  /** Recolour a category from the manager; recolours every item using it. */
+  recolorCategory(category: LegendCategory, color: string): void {
+    if (!color || color === category.color) return;
+    this.api
+      .updateLegendCategory(this.id(), category.id, { color })
+      .subscribe({
+        next: (updated) => {
+          this.legend.set(
+            this.legend().map((c) => (c.id === updated.id ? updated : c))
+          );
+          this.reloadActivities();
+        },
+        error: (e) => this.error(e),
+      });
+  }
+
+  deleteLegendCategory(category: LegendCategory): void {
+    this.api.deleteLegendCategory(this.id(), category.id).subscribe({
+      next: () => {
+        this.legend.set(this.legend().filter((c) => c.id !== category.id));
         this.reloadActivities();
       },
       error: (e) => this.error(e),

--- a/apps/trip/src/app/activity/activities.service.ts
+++ b/apps/trip/src/app/activity/activities.service.ts
@@ -7,6 +7,7 @@ import { Trip } from '../trip/trip.entity';
 import { TripsService } from '../trip/trips.service';
 import { Activity } from './activity.entity';
 import { toActivityDto } from './mappers';
+import { LegendService } from './legend.service';
 import { TagsService } from './tags.service';
 import { CreateActivityInput, UpdateActivityInput } from './activity.types';
 
@@ -17,6 +18,7 @@ export class ActivitiesService {
     inject(Database).repositoryFor(Segment);
   private readonly _tripsService = inject(TripsService);
   private readonly _tagsService = inject(TagsService);
+  private readonly _legendService = inject(LegendService);
 
   /** Validate that a segment (if given) belongs to the trip. */
   private async resolveSegment(
@@ -36,7 +38,7 @@ export class ActivitiesService {
   private loadOne(tripId: string, activityId: string) {
     return this._activityRepository.findOne({
       where: { id: activityId, trip: { id: tripId } },
-      relations: { tags: true, segment: true },
+      relations: { tags: true, segment: true, legendCategory: true },
     });
   }
 
@@ -54,7 +56,7 @@ export class ActivitiesService {
 
     const activities = await this._activityRepository.find({
       where,
-      relations: { tags: true, segment: true },
+      relations: { tags: true, segment: true, legendCategory: true },
       order: { startAt: 'ASC' },
     });
     return activities.map((a) => toActivityDto(a, tripId));
@@ -63,6 +65,10 @@ export class ActivitiesService {
   async create(tripId: string, userId: string, input: CreateActivityInput) {
     await this._tripsService.assertMember(tripId, userId);
     const segment = await this.resolveSegment(tripId, input.segmentId);
+    const legendCategory = await this._legendService.resolveForTrip(
+      tripId,
+      input.legendCategoryId
+    );
     const tags = await this._tagsService.resolveForTrip(
       tripId,
       input.tagIds ?? []
@@ -72,6 +78,7 @@ export class ActivitiesService {
       this._activityRepository.create({
         trip: { id: tripId } as Trip,
         segment,
+        legendCategory,
         title: input.title,
         notes: input.notes,
         startAt: new Date(input.startAt),
@@ -120,6 +127,12 @@ export class ActivitiesService {
       activity.locationLabel = input.locationLabel;
     if (input.segmentId !== undefined) {
       activity.segment = await this.resolveSegment(tripId, input.segmentId);
+    }
+    if (input.legendCategoryId !== undefined) {
+      activity.legendCategory = await this._legendService.resolveForTrip(
+        tripId,
+        input.legendCategoryId
+      );
     }
     if (input.tagIds !== undefined) {
       activity.tags = await this._tagsService.resolveForTrip(

--- a/apps/trip/src/app/activity/activity.entity.ts
+++ b/apps/trip/src/app/activity/activity.entity.ts
@@ -13,6 +13,7 @@ import {
 import { ENTITIES } from '../data-source';
 import { Segment } from '../trip/segment.entity';
 import { Trip } from '../trip/trip.entity';
+import { LegendCategory } from './legend.entity';
 import { Tag } from './tag.entity';
 
 /**
@@ -45,7 +46,12 @@ export class Activity {
   @Column('timestamptz')
   endAt!: Date;
 
-  // Optional explicit colour; falls back to the first tag's colour client-side.
+  // The legend category drives this activity's colour. Optional: an activity
+  // with no category falls back to its custom `color` (or a default).
+  @ManyToOne(() => LegendCategory, { onDelete: 'SET NULL', nullable: true })
+  legendCategory?: LegendCategory | null;
+
+  // Optional custom colour, used only when no legend category is assigned.
   @Column('text', { nullable: true })
   color?: string | null;
 

--- a/apps/trip/src/app/activity/activity.router.ts
+++ b/apps/trip/src/app/activity/activity.router.ts
@@ -3,13 +3,17 @@ import { FastifyInstance } from 'fastify';
 import { ZodTypeProvider } from 'fastify-type-provider-zod';
 import { z } from 'zod';
 import { ActivitiesService } from './activities.service';
+import { LegendService } from './legend.service';
 import { TagsService } from './tags.service';
 import {
   ActivitySchema,
   CreateActivitySchema,
+  CreateLegendCategorySchema,
   CreateTagSchema,
+  LegendCategorySchema,
   TagSchema,
   UpdateActivitySchema,
+  UpdateLegendCategorySchema,
   UpdateTagSchema,
 } from './activity.types';
 
@@ -21,6 +25,10 @@ const ActivityParams = z.object({
 const TagParams = z.object({
   id: z.string().uuid(),
   tagId: z.string().uuid(),
+});
+const LegendParams = z.object({
+  id: z.string().uuid(),
+  categoryId: z.string().uuid(),
 });
 const RangeQuery = z.object({
   from: z.string().datetime().optional(),
@@ -35,6 +43,7 @@ export async function ActivityRouter(fastify: FastifyInstance) {
 
   const _activities = inject(ActivitiesService);
   const _tags = inject(TagsService);
+  const _legend = inject(LegendService);
 
   // ── Tags ─────────────────────────────────────────────────────
   typedFastify.get(
@@ -109,6 +118,84 @@ export async function ActivityRouter(fastify: FastifyInstance) {
         await _tags.remove(
           request.params.id,
           request.params.tagId,
+          request.currentUser.id
+        )
+      )
+  );
+
+  // ── Legend categories ────────────────────────────────────────
+  typedFastify.get(
+    '/trips/:id/legend',
+    {
+      schema: {
+        tags: ['Schedule'],
+        description: 'List the legend categories of a trip',
+        params: TripParams,
+        response: { 200: z.array(LegendCategorySchema) },
+      },
+    },
+    async (request, reply) =>
+      reply.send(await _legend.list(request.params.id, request.currentUser.id))
+  );
+
+  typedFastify.post(
+    '/trips/:id/legend',
+    {
+      schema: {
+        tags: ['Schedule'],
+        description: 'Create a legend category',
+        params: TripParams,
+        body: CreateLegendCategorySchema,
+        response: { 201: LegendCategorySchema },
+      },
+    },
+    async (request, reply) => {
+      const category = await _legend.create(
+        request.params.id,
+        request.currentUser.id,
+        request.body
+      );
+      return reply.code(201).send(category);
+    }
+  );
+
+  typedFastify.put(
+    '/trips/:id/legend/:categoryId',
+    {
+      schema: {
+        tags: ['Schedule'],
+        description: 'Update a legend category',
+        params: LegendParams,
+        body: UpdateLegendCategorySchema,
+        response: { 200: LegendCategorySchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _legend.update(
+          request.params.id,
+          request.params.categoryId,
+          request.currentUser.id,
+          request.body
+        )
+      )
+  );
+
+  typedFastify.delete(
+    '/trips/:id/legend/:categoryId',
+    {
+      schema: {
+        tags: ['Schedule'],
+        description: 'Delete a legend category',
+        params: LegendParams,
+        response: { 200: SuccessSchema },
+      },
+    },
+    async (request, reply) =>
+      reply.send(
+        await _legend.remove(
+          request.params.id,
+          request.params.categoryId,
           request.currentUser.id
         )
       )

--- a/apps/trip/src/app/activity/activity.types.ts
+++ b/apps/trip/src/app/activity/activity.types.ts
@@ -8,10 +8,29 @@ const lat = z.number().min(-90).max(90);
 const lng = z.number().min(-180).max(180);
 
 // ─────────────────────────────────────────────────────────────
-// Tags
+// Tags (free-form text labels — colour lives on the legend)
 // ─────────────────────────────────────────────────────────────
 
 export const TagSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  createdAt: z.date(),
+  updatedAt: z.date(),
+});
+
+export const CreateTagSchema = z.object({
+  name: z.string().min(1).max(60),
+});
+
+export const UpdateTagSchema = z.object({
+  name: z.string().min(1).max(60).optional(),
+});
+
+// ─────────────────────────────────────────────────────────────
+// Legend categories (a named colour that activities can adopt)
+// ─────────────────────────────────────────────────────────────
+
+export const LegendCategorySchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
   color: z.string(),
@@ -19,12 +38,12 @@ export const TagSchema = z.object({
   updatedAt: z.date(),
 });
 
-export const CreateTagSchema = z.object({
+export const CreateLegendCategorySchema = z.object({
   name: z.string().min(1).max(60),
   color: hexColor.default('#4f46e5'),
 });
 
-export const UpdateTagSchema = z.object({
+export const UpdateLegendCategorySchema = z.object({
   name: z.string().min(1).max(60).optional(),
   color: hexColor.optional(),
 });
@@ -42,6 +61,7 @@ export const ActivitySchema = z.object({
   startAt: z.date(),
   endAt: z.date(),
   color: z.string().nullable().optional(),
+  legendCategory: LegendCategorySchema.nullable().optional(),
   lat: z.number().nullable(),
   lng: z.number().nullable(),
   locationLabel: z.string().nullable(),
@@ -57,7 +77,8 @@ export const CreateActivitySchema = z
     segmentId: z.string().uuid().nullable().optional(),
     startAt: z.string().datetime(),
     endAt: z.string().datetime(),
-    color: hexColor.optional(),
+    color: hexColor.nullable().optional(),
+    legendCategoryId: z.string().uuid().nullable().optional(),
     lat: lat.nullable().optional(),
     lng: lng.nullable().optional(),
     locationLabel: z.string().max(300).nullable().optional(),
@@ -76,6 +97,7 @@ export const UpdateActivitySchema = z
     startAt: z.string().datetime().optional(),
     endAt: z.string().datetime().optional(),
     color: hexColor.nullable().optional(),
+    legendCategoryId: z.string().uuid().nullable().optional(),
     lat: lat.nullable().optional(),
     lng: lng.nullable().optional(),
     locationLabel: z.string().max(300).nullable().optional(),
@@ -89,6 +111,13 @@ export const UpdateActivitySchema = z
 export type TagOut = z.infer<typeof TagSchema>;
 export type CreateTagInput = z.infer<typeof CreateTagSchema>;
 export type UpdateTagInput = z.infer<typeof UpdateTagSchema>;
+export type LegendCategoryOut = z.infer<typeof LegendCategorySchema>;
+export type CreateLegendCategoryInput = z.infer<
+  typeof CreateLegendCategorySchema
+>;
+export type UpdateLegendCategoryInput = z.infer<
+  typeof UpdateLegendCategorySchema
+>;
 export type ActivityOut = z.infer<typeof ActivitySchema>;
 export type CreateActivityInput = z.infer<typeof CreateActivitySchema>;
 export type UpdateActivityInput = z.infer<typeof UpdateActivitySchema>;

--- a/apps/trip/src/app/activity/index.ts
+++ b/apps/trip/src/app/activity/index.ts
@@ -1,3 +1,4 @@
 // Importing this module registers the activity-domain entities with TypeORM.
 import './tag.entity';
+import './legend.entity';
 import './activity.entity';

--- a/apps/trip/src/app/activity/legend.entity.ts
+++ b/apps/trip/src/app/activity/legend.entity.ts
@@ -12,12 +12,13 @@ import { ENTITIES } from '../data-source';
 import { Trip } from '../trip/trip.entity';
 
 /**
- * A free-form, per-trip text label. Activities reference tags for labelling
- * and (later) filtering. Colour lives on the legend, not on tags.
+ * A per-trip legend category: a named colour (e.g. "Restaurants" → purple).
+ * Activities pick a single legend category, which drives the colour they show
+ * on the schedule. Distinct from tags, which are free-form text-only labels.
  */
 @Entity()
 @Index(['trip', 'name'], { unique: true })
-export class Tag {
+export class LegendCategory {
   @PrimaryGeneratedColumn('uuid')
   id!: string;
 
@@ -27,6 +28,9 @@ export class Tag {
   @Column('text')
   name!: string;
 
+  @Column('text', { default: '#4f46e5' })
+  color!: string;
+
   @CreateDateColumn()
   createdAt!: Date;
 
@@ -34,4 +38,4 @@ export class Tag {
   updatedAt!: Date;
 }
 
-provide(ENTITIES, Tag);
+provide(ENTITIES, LegendCategory);

--- a/apps/trip/src/app/activity/legend.service.ts
+++ b/apps/trip/src/app/activity/legend.service.ts
@@ -1,0 +1,101 @@
+import { inject } from '@ee/di';
+import HttpErrors from 'http-errors';
+import { Database } from '../data-source';
+import { Trip } from '../trip/trip.entity';
+import { TripsService } from '../trip/trips.service';
+import { LegendCategory } from './legend.entity';
+import { toLegendCategoryDto } from './mappers';
+import {
+  CreateLegendCategoryInput,
+  UpdateLegendCategoryInput,
+} from './activity.types';
+
+export class LegendService {
+  private readonly _legendRepository =
+    inject(Database).repositoryFor(LegendCategory);
+  private readonly _tripsService = inject(TripsService);
+
+  /** Resolve a single legend category by id, scoped to a trip. */
+  async resolveForTrip(
+    tripId: string,
+    categoryId: string | null | undefined
+  ): Promise<LegendCategory | null> {
+    if (!categoryId) return null;
+    const category = await this._legendRepository.findOne({
+      where: { id: categoryId, trip: { id: tripId } },
+    });
+    if (!category) {
+      throw new HttpErrors.BadRequest(
+        'Legend category does not belong to this trip'
+      );
+    }
+    return category;
+  }
+
+  async list(tripId: string, userId: string) {
+    await this._tripsService.assertMember(tripId, userId);
+    const categories = await this._legendRepository.find({
+      where: { trip: { id: tripId } },
+      order: { name: 'ASC' },
+    });
+    return categories.map(toLegendCategoryDto);
+  }
+
+  async create(
+    tripId: string,
+    userId: string,
+    input: CreateLegendCategoryInput
+  ) {
+    await this._tripsService.assertMember(tripId, userId);
+    const existing = await this._legendRepository.findOne({
+      where: { trip: { id: tripId }, name: input.name },
+    });
+    if (existing) {
+      throw new HttpErrors.Conflict(
+        `A legend category named "${input.name}" already exists`
+      );
+    }
+    const category = await this._legendRepository.save(
+      this._legendRepository.create({
+        trip: { id: tripId } as Trip,
+        name: input.name,
+        color: input.color,
+      })
+    );
+    return toLegendCategoryDto(category);
+  }
+
+  async update(
+    tripId: string,
+    categoryId: string,
+    userId: string,
+    input: UpdateLegendCategoryInput
+  ) {
+    await this._tripsService.assertMember(tripId, userId);
+    const category = await this._legendRepository.findOne({
+      where: { id: categoryId, trip: { id: tripId } },
+    });
+    if (!category) {
+      throw new HttpErrors.NotFound('Legend category not found');
+    }
+    if (Object.keys(input).length > 0) {
+      await this._legendRepository.update(category.id, input);
+    }
+    const updated = await this._legendRepository.findOneByOrFail({
+      id: category.id,
+    });
+    return toLegendCategoryDto(updated);
+  }
+
+  async remove(tripId: string, categoryId: string, userId: string) {
+    await this._tripsService.assertMember(tripId, userId);
+    const category = await this._legendRepository.findOne({
+      where: { id: categoryId, trip: { id: tripId } },
+    });
+    if (!category) {
+      throw new HttpErrors.NotFound('Legend category not found');
+    }
+    await this._legendRepository.delete(category.id);
+    return { success: true };
+  }
+}

--- a/apps/trip/src/app/activity/mappers.ts
+++ b/apps/trip/src/app/activity/mappers.ts
@@ -1,14 +1,24 @@
 import { Activity } from './activity.entity';
+import { LegendCategory } from './legend.entity';
 import { Tag } from './tag.entity';
-import { ActivityOut, TagOut } from './activity.types';
+import { ActivityOut, LegendCategoryOut, TagOut } from './activity.types';
 
 export function toTagDto(tag: Tag): TagOut {
   return {
     id: tag.id,
     name: tag.name,
-    color: tag.color,
     createdAt: tag.createdAt,
     updatedAt: tag.updatedAt,
+  };
+}
+
+export function toLegendCategoryDto(category: LegendCategory): LegendCategoryOut {
+  return {
+    id: category.id,
+    name: category.name,
+    color: category.color,
+    createdAt: category.createdAt,
+    updatedAt: category.updatedAt,
   };
 }
 
@@ -22,6 +32,9 @@ export function toActivityDto(activity: Activity, tripId: string): ActivityOut {
     startAt: activity.startAt,
     endAt: activity.endAt,
     color: activity.color ?? null,
+    legendCategory: activity.legendCategory
+      ? toLegendCategoryDto(activity.legendCategory)
+      : null,
     lat: activity.lat ?? null,
     lng: activity.lng ?? null,
     locationLabel: activity.locationLabel ?? null,

--- a/apps/trip/src/app/activity/tags.service.ts
+++ b/apps/trip/src/app/activity/tags.service.ts
@@ -41,7 +41,6 @@ export class TagsService {
       this._tagRepository.create({
         trip: { id: tripId } as Trip,
         name: input.name,
-        color: input.color,
       })
     );
     return toTagDto(tag);


### PR DESCRIPTION
Introduce a per-trip Legend: named colour categories (e.g. "Restaurants" →
purple) that schedule activities can adopt. Assigning a legend category to an
activity drives its colour everywhere it renders (schedule grid, map pins).

- New LegendCategory entity + CRUD service and /trips/:id/legend routes.
- Activities link to a single legend category (SET NULL on delete); the custom
  colour now only applies to uncategorised one-offs.
- Tags become plain text labels — colour moved to the legend, so the editor no
  longer has a tag/colour conflict.
- Schedule editor: a Category select drives colour, with a custom-colour escape
  hatch; a Legend manager dialog adds/recolours/removes categories.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0125Scg7oVxFh6HgRrt3dVV6