### PR TITLE
feat(ai-gateway,chat-frontend): improve streaming robustness and chat UX

### DIFF
--- a/apps/ai-gateway/src/app/agents/agent.ts
+++ b/apps/ai-gateway/src/app/agents/agent.ts
@@ -66,20 +66,24 @@ export class Agent {
   protected async streamChat(
     messages: OllamaMessage[],
     tools: OllamaTool[] | undefined,
-    emitter: StreamEmitter
+    emitter: StreamEmitter,
+    signal?: AbortSignal
   ): Promise<OllamaChatResponse> {
     let content = '';
     let toolCalls: OllamaChatResponse['message']['tool_calls'] = undefined;
     let lastChunk: any = null;
 
-    for await (const chunk of this.ollama.chatStream({
-      model: this.config.model || 'functiongemma',
-      messages,
-      tools,
-      options: {
-        temperature: this.config.temperature,
+    for await (const chunk of this.ollama.chatStream(
+      {
+        model: this.config.model || 'functiongemma',
+        messages,
+        tools,
+        options: {
+          temperature: this.config.temperature,
+        },
       },
-    })) {
+      { signal }
+    )) {
       lastChunk = chunk;
 
       // Ollama surfaces thinking in a dedicated field
@@ -129,8 +133,13 @@ export class Agent {
    * Run the agent with a task/prompt
    * @param task The task or question to process
    * @param emitter Optional stream emitter for real-time updates including token streaming
+   * @param signal Optional abort signal (e.g. client disconnected)
    */
-  async run(task: string, emitter?: StreamEmitter): Promise<AgentResult> {
+  async run(
+    task: string,
+    emitter?: StreamEmitter,
+    signal?: AbortSignal
+  ): Promise<AgentResult> {
     const startTime = Date.now();
     const toolCalls: AgentToolCall[] = [];
     let iterations = 0;
@@ -148,6 +157,7 @@ export class Agent {
     try {
       while (iterations < (this.config.maxIterations || 10)) {
         iterations++;
+        signal?.throwIfAborted();
 
         // Emit thinking event
         emitter?.agentThinking(
@@ -162,16 +172,20 @@ export class Agent {
           ? await this.streamChat(
               messages,
               tools.length > 0 ? tools : undefined,
-              emitter
+              emitter,
+              signal
             )
-          : await this.ollama.chat({
-              model: this.config.model || 'functiongemma',
-              messages,
-              tools: tools.length > 0 ? tools : undefined,
-              options: {
-                temperature: this.config.temperature,
+          : await this.ollama.chat(
+              {
+                model: this.config.model || 'functiongemma',
+                messages,
+                tools: tools.length > 0 ? tools : undefined,
+                options: {
+                  temperature: this.config.temperature,
+                },
               },
-            });
+              { signal }
+            );
 
         messages.push(response.message);
 
@@ -311,17 +325,23 @@ export class Agent {
       // Max iterations reached - get final response without tools
       emitter?.status(`Max iterations reached, generating final response...`);
 
-      const finalResponse = await this.ollama.chat({
-        model: this.config.model || 'functiongemma',
-        messages: [
-          ...messages,
-          {
-            role: 'user',
-            content:
-              'Please provide a final summary response based on the information gathered.',
+      const finalResponse = await this.ollama.chat(
+        {
+          model: this.config.model || 'functiongemma',
+          messages: [
+            ...messages,
+            {
+              role: 'user',
+              content:
+                'Please provide a final summary response based on the information gathered.',
+            },
+          ],
+          options: {
+            temperature: this.config.temperature,
           },
-        ],
-      });
+        },
+        { signal }
+      );
 
       this.conversationHistory.push(
         { role: 'user', content: task },
@@ -338,6 +358,12 @@ export class Agent {
         totalDurationMs: Date.now() - startTime,
       };
     } catch (error) {
+      // Let aborts propagate so the orchestrator stops immediately instead of
+      // treating the cancellation as a recoverable agent failure
+      if (signal?.aborted || (error as Error)?.name === 'AbortError') {
+        throw error;
+      }
+
       const errorMsg = error instanceof Error ? error.message : 'Unknown error';
       emitter?.error(`Agent error: ${errorMsg}`);
 

--- a/apps/ai-gateway/src/app/agents/orchestrator.ts
+++ b/apps/ai-gateway/src/app/agents/orchestrator.ts
@@ -71,7 +71,8 @@ export class OrchestratorAgent {
       type: 'function';
       function: { name: string; description: string; parameters: any };
     }[],
-    emitter: StreamEmitter
+    emitter: StreamEmitter,
+    signal?: AbortSignal
   ): Promise<OllamaChatResponse> {
     const ollama = getOllamaClient();
     let content = '';
@@ -83,11 +84,15 @@ export class OrchestratorAgent {
     let thinkingEnd: number | undefined;
     let thinkingTokenCount = 0;
 
-    for await (const chunk of ollama.chatStream({
-      model: this.config.model || 'functiongemma',
-      messages,
-      tools,
-    })) {
+    for await (const chunk of ollama.chatStream(
+      {
+        model: this.config.model || 'functiongemma',
+        messages,
+        tools,
+        options: { temperature: this.config.temperature },
+      },
+      { signal }
+    )) {
       lastChunk = chunk;
 
       // Ollama surfaces thinking in a dedicated field
@@ -164,11 +169,13 @@ export class OrchestratorAgent {
    * @param query The user's question or request
    * @param emitter Optional stream emitter for real-time updates
    * @param images Optional base64-encoded images for vision models
+   * @param signal Optional abort signal (e.g. client disconnected)
    */
   async run(
     query: string,
     emitter?: StreamEmitter,
-    images?: string[]
+    images?: string[],
+    signal?: AbortSignal
   ): Promise<OrchestratorResult> {
     const startTime = Date.now();
     const delegations: DelegationResult[] = [];
@@ -190,7 +197,7 @@ export class OrchestratorAgent {
     ];
 
     // Create the delegation tool with emitter support
-    const delegateTool = this.createDelegationTool(delegations, emitter);
+    const delegateTool = this.createDelegationTool(delegations, emitter, signal);
     const registry = getToolRegistry();
 
     // Temporarily register the delegation tool
@@ -215,6 +222,7 @@ export class OrchestratorAgent {
 
       while (iterations < maxIterations) {
         iterations++;
+        signal?.throwIfAborted();
 
         emitter?.thinking(
           `Orchestrator thinking (iteration ${iterations}/${maxIterations})...`
@@ -223,12 +231,21 @@ export class OrchestratorAgent {
         // Use streaming when we have an emitter so tokens arrive in real-time
         // streamOrchestratorChat handles both text and tool_call responses
         const response = emitter
-          ? await this.streamOrchestratorChat(messages, delegateTools, emitter)
-          : await ollama.chat({
-              model: this.config.model || 'functiongemma',
+          ? await this.streamOrchestratorChat(
               messages,
-              tools: delegateTools,
-            });
+              delegateTools,
+              emitter,
+              signal
+            )
+          : await ollama.chat(
+              {
+                model: this.config.model || 'functiongemma',
+                messages,
+                tools: delegateTools,
+                options: { temperature: this.config.temperature },
+              },
+              { signal }
+            );
 
         messages.push(response.message);
 
@@ -295,11 +312,15 @@ export class OrchestratorAgent {
       ];
 
       const finalResponse = emitter
-        ? await this.streamOrchestratorChat(finalMessages, [], emitter)
-        : await ollama.chat({
-            model: this.config.model || 'functiongemma',
-            messages: finalMessages,
-          });
+        ? await this.streamOrchestratorChat(finalMessages, [], emitter, signal)
+        : await ollama.chat(
+            {
+              model: this.config.model || 'functiongemma',
+              messages: finalMessages,
+              options: { temperature: this.config.temperature },
+            },
+            { signal }
+          );
 
       this.conversationHistory.push(
         { role: 'user', content: query },
@@ -366,7 +387,8 @@ Use your best judgment. When in doubt about whether an agent would add value, go
    */
   private createDelegationTool(
     delegations: DelegationResult[],
-    emitter?: StreamEmitter
+    emitter?: StreamEmitter,
+    signal?: AbortSignal
   ) {
     const agentNames = Array.from(this.subAgents.keys());
 
@@ -410,7 +432,7 @@ Use your best judgment. When in doubt about whether an agent would add value, go
 
         // Run the sub-agent with the same emitter for full visibility
         const delegationStart = Date.now();
-        const result = await agent.run(task, emitter);
+        const result = await agent.run(task, emitter, signal);
         const delegationDuration = Date.now() - delegationStart;
 
         emitter?.delegationEnd(

--- a/apps/ai-gateway/src/app/chat/chat.router.ts
+++ b/apps/ai-gateway/src/app/chat/chat.router.ts
@@ -308,6 +308,9 @@ export const ChatRouter: FastifyPluginAsync = async (
       if (config?.model) {
         orchestratorConfig.model = config.model;
       }
+      if (config?.temperature !== undefined) {
+        orchestratorConfig.temperature = config.temperature;
+      }
 
       // Filter tools based on config
       const { getToolRegistry } = await import('../mcp');
@@ -324,7 +327,8 @@ export const ChatRouter: FastifyPluginAsync = async (
         );
       }
 
-      // Update sub-agent tools based on filtered list
+      // Update sub-agent tools based on filtered list, and propagate the
+      // session temperature so sub-agents honour it too
       orchestratorConfig = {
         ...orchestratorConfig,
         subAgents: orchestratorConfig.subAgents.map(
@@ -332,6 +336,7 @@ export const ChatRouter: FastifyPluginAsync = async (
             ...sa,
             agent: {
               ...sa.agent,
+              temperature: config?.temperature ?? sa.agent.temperature,
               tools: sa.agent.tools?.filter((t: string) =>
                 enabledTools.includes(t)
               ),
@@ -381,23 +386,47 @@ export const ChatRouter: FastifyPluginAsync = async (
         return;
       }
 
+      // Abort the whole pipeline (LLM calls, delegations) when the client
+      // disconnects — e.g. the user hit "stop" or closed the tab
+      const abortController = new AbortController();
+      reply.raw.on('close', () => {
+        if (!reply.raw.writableEnded) {
+          abortController.abort();
+        }
+      });
+
       // Create stream emitter
       const emitter = new StreamEmitter();
+
+      const writeLine = (line: string) => {
+        if (!reply.raw.destroyed && !reply.raw.writableEnded) {
+          reply.raw.write(line + '\n');
+        }
+      };
+
+      // Send events to client as NDJSON (one JSON object per line)
+      const unsubscribe = emitter.on((event) => {
+        writeLine(
+          JSON.stringify({
+            event: event.type,
+            timestamp: event.timestamp,
+            data: event.data,
+          })
+        );
+      });
 
       // Send session info first
       emitter.status(
         `Session started with ${enabledTools.length} tools enabled`
       );
 
-      // Send events to client as NDJSON (one JSON object per line)
-      const unsubscribe = emitter.on((event) => {
-        const line = JSON.stringify({
-          event: event.type,
-          timestamp: event.timestamp,
-          data: event.data,
-        });
-        reply.raw.write(line + '\n');
-      });
+      // Keep-alive ping so idle-timeout proxies don't kill the connection
+      // during long tool executions or model loads
+      const heartbeat = setInterval(() => {
+        writeLine(
+          JSON.stringify({ event: 'ping', timestamp: Date.now(), data: {} })
+        );
+      }, 15000);
 
       try {
         // Run the orchestrator with streaming
@@ -406,7 +435,8 @@ export const ChatRouter: FastifyPluginAsync = async (
         const result = await orchestrator.run(
           lastMessage.content,
           emitter,
-          userImages
+          userImages,
+          abortController.signal
         );
 
         // Build the response messages in Ollama's native format
@@ -463,10 +493,19 @@ export const ChatRouter: FastifyPluginAsync = async (
           stats: result.stats,
         });
       } catch (error) {
-        emitter.error(error instanceof Error ? error.message : 'Unknown error');
+        // A client disconnect aborts the run — nobody is listening, so don't
+        // report it as an error
+        if (!abortController.signal.aborted) {
+          emitter.error(
+            error instanceof Error ? error.message : 'Unknown error'
+          );
+        }
       } finally {
+        clearInterval(heartbeat);
         unsubscribe();
-        reply.raw.end();
+        if (!reply.raw.destroyed && !reply.raw.writableEnded) {
+          reply.raw.end();
+        }
       }
     }
   );

--- a/apps/ai-gateway/src/app/ollama/ollama-client.ts
+++ b/apps/ai-gateway/src/app/ollama/ollama-client.ts
@@ -66,19 +66,26 @@ export class OllamaClient {
     );
 
     // Link external signal if provided
+    let onExternalAbort: (() => void) | undefined;
     if (externalSignal) {
       if (externalSignal.aborted) {
         controller.abort(externalSignal.reason);
       } else {
-        externalSignal.addEventListener('abort', () => {
-          controller.abort(externalSignal.reason);
+        onExternalAbort = () => controller.abort(externalSignal.reason);
+        externalSignal.addEventListener('abort', onExternalAbort, {
+          once: true,
         });
       }
     }
 
     return {
       signal: controller.signal,
-      cleanup: () => clearTimeout(timeoutId),
+      cleanup: () => {
+        clearTimeout(timeoutId);
+        if (externalSignal && onExternalAbort) {
+          externalSignal.removeEventListener('abort', onExternalAbort);
+        }
+      },
     };
   }
 

--- a/apps/ai-gateway/src/app/types.ts
+++ b/apps/ai-gateway/src/app/types.ts
@@ -169,6 +169,7 @@ export interface OrchestratorConfig {
   subAgents: SubAgentDefinition[];
   routerModel?: string; // Model for fast tool/agent selection
   maxDelegations?: number;
+  temperature?: number;
 }
 
 export interface DelegationResult {

--- a/apps/chat-frontend/src/app/pages/chat/chat-input.component.ts
+++ b/apps/chat-frontend/src/app/pages/chat/chat-input.component.ts
@@ -295,6 +295,9 @@ export class ChatInputComponent {
 
   onKeydown(event: KeyboardEvent): void {
     if (event.key === 'Enter' && !event.shiftKey) {
+      // Don't send while an IME composition is in progress (e.g. Japanese,
+      // Chinese input) — Enter there confirms the composition, not the message
+      if (event.isComposing || event.keyCode === 229) return;
       event.preventDefault();
       this.send();
     }

--- a/apps/chat-frontend/src/app/pages/chat/chat-page.component.ts
+++ b/apps/chat-frontend/src/app/pages/chat/chat-page.component.ts
@@ -88,6 +88,7 @@ const IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
         [isStreaming]="conversationService.isStreaming()"
         [statusText]="statusText()"
         (suggestionSelected)="onSuggestionSelected($event)"
+        (regenerateRequested)="onRegenerate()"
       />
       <app-chat-input
         #chatInput
@@ -362,7 +363,26 @@ export class ChatPageComponent implements OnInit, OnDestroy {
     };
     this.conversationService.addMessage(convoId, userMessage, userDisplay);
 
-    // Prepare assistant display message
+    this.beginAssistantStream(convoId);
+  }
+
+  /**
+   * Re-run the last user message. Drops the trailing assistant reply and
+   * streams a fresh one.
+   */
+  onRegenerate(): void {
+    if (this.conversationService.isStreaming()) return;
+    const convoId = this.conversationService.activeConversationId();
+    if (!convoId) return;
+    if (!this.conversationService.prepareRegenerate(convoId)) return;
+    this.beginAssistantStream(convoId);
+  }
+
+  /**
+   * Add an empty assistant display message and stream the model's reply into
+   * it, using the conversation's current message history.
+   */
+  private beginAssistantStream(convoId: string): void {
     const assistantDisplay: DisplayMessage = {
       id: crypto.randomUUID(),
       role: 'assistant',
@@ -384,9 +404,15 @@ export class ChatPageComponent implements OnInit, OnDestroy {
     if (systemPrompt) {
       messagesToSend.push({ role: 'system', content: systemPrompt });
     }
-    const currentConvo = this.conversationService.activeConversation();
+    const currentConvo = this.conversationService
+      .conversations()
+      .find((c) => c.id === convoId);
     if (currentConvo) {
-      messagesToSend.push(...currentConvo.messages);
+      // Strip system messages already stored in history (the done event
+      // echoes them back) so the prompt doesn't accumulate once per turn
+      messagesToSend.push(
+        ...currentConvo.messages.filter((m) => m.role !== 'system')
+      );
     }
 
     const config = {
@@ -396,10 +422,10 @@ export class ChatPageComponent implements OnInit, OnDestroy {
 
     this.streamSub = this.chatApi.streamChat(messagesToSend, config).subscribe({
       next: (event: StreamEvent) => {
-        this.handleStreamEvent(convoId!, event);
+        this.handleStreamEvent(convoId, event);
       },
       complete: () => {
-        this.finalizeStream(convoId!);
+        this.finalizeStream(convoId);
       },
       error: (error) => {
         console.error('Stream error:', error);
@@ -410,10 +436,10 @@ export class ChatPageComponent implements OnInit, OnDestroy {
           life: 5000,
         });
         this.conversationService.updateLastAssistantMessage(
-          convoId!,
+          convoId,
           '\n\n*Error: Failed to get response. Please try again.*'
         );
-        this.finalizeStream(convoId!);
+        this.finalizeStream(convoId);
       },
     });
   }
@@ -423,6 +449,8 @@ export class ChatPageComponent implements OnInit, OnDestroy {
     this.streamSub = null;
     const convoId = this.conversationService.activeConversationId();
     if (convoId) {
+      // Keep the partial reply in the model's context for the next turn
+      this.conversationService.commitPartialAssistant(convoId);
       this.finalizeStream(convoId);
     }
   }

--- a/apps/chat-frontend/src/app/pages/chat/message-bubble.component.ts
+++ b/apps/chat-frontend/src/app/pages/chat/message-bubble.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   input,
+  output,
   inject,
   computed,
   signal,
@@ -154,6 +155,33 @@ import { ToolCallChipComponent } from './tool-call-chip.component';
           class="message-text markdown-content"
           [innerHTML]="renderedContent()"
         ></div>
+        }
+
+        <!-- Actions row (hover-revealed) -->
+        @if (message().content && !isStreaming()) {
+        <div class="message-actions">
+          <button
+            class="action-btn"
+            (click)="copyMessage()"
+            [title]="copied() ? 'Copied!' : 'Copy message'"
+          >
+            <i
+              class="pi"
+              [class.pi-copy]="!copied()"
+              [class.pi-check]="copied()"
+              [class.copied]="copied()"
+            ></i>
+          </button>
+          @if (isLast()) {
+          <button
+            class="action-btn"
+            (click)="regenerate.emit()"
+            title="Regenerate response"
+          >
+            <i class="pi pi-refresh"></i>
+          </button>
+          }
+        </div>
         }
 
         <!-- Stats bar (hover-revealed) -->
@@ -424,6 +452,45 @@ import { ToolCallChipComponent } from './tool-call-chip.component';
       }
     }
 
+    /* Message actions (copy / regenerate) */
+    .message-actions {
+      display: flex;
+      gap: 2px;
+      margin-top: 6px;
+      opacity: 0;
+      transition: opacity 0.2s ease;
+    }
+
+    .bubble:hover .message-actions {
+      opacity: 1;
+    }
+
+    .action-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: none;
+      border: none;
+      color: var(--p-text-muted-color);
+      cursor: pointer;
+      padding: 4px 6px;
+      border-radius: 6px;
+      transition: color 0.15s ease, background 0.15s ease;
+
+      &:hover {
+        color: var(--p-text-color);
+        background: var(--p-surface-700);
+      }
+
+      i {
+        font-size: 0.8rem;
+
+        &.copied {
+          color: #22c55e;
+        }
+      }
+    }
+
     /* Message stats bar */
     .message-stats {
       display: flex;
@@ -662,10 +729,14 @@ import { ToolCallChipComponent } from './tool-call-chip.component';
 export class MessageBubbleComponent {
   readonly message = input.required<DisplayMessage>();
   readonly isStreaming = input(false);
+  readonly isLast = input(false);
+  readonly regenerate = output<void>();
 
   private readonly markdown = inject(MarkdownService);
 
   thinkingExpanded = signal(false);
+  readonly copied = signal(false);
+  private copiedTimer: ReturnType<typeof setTimeout> | null = null;
   private expandedDelegations = signal<Set<string>>(new Set());
 
   readonly isThinkingVisible = computed(() => {
@@ -685,6 +756,16 @@ export class MessageBubbleComponent {
     if (msg.renderedHtml) return msg.renderedHtml;
     return this.markdown.render(msg.content);
   });
+
+  copyMessage(): void {
+    const content = this.message().content;
+    if (!content || !navigator.clipboard) return;
+    navigator.clipboard.writeText(content).then(() => {
+      this.copied.set(true);
+      if (this.copiedTimer) clearTimeout(this.copiedTimer);
+      this.copiedTimer = setTimeout(() => this.copied.set(false), 2000);
+    });
+  }
 
   toggleDelegation(agentName: string): void {
     this.expandedDelegations.update((set) => {

--- a/apps/chat-frontend/src/app/pages/chat/message-list.component.ts
+++ b/apps/chat-frontend/src/app/pages/chat/message-list.component.ts
@@ -38,6 +38,8 @@ import { ButtonModule } from 'primeng/button';
         <app-message-bubble
           [message]="msg"
           [isStreaming]="last && isStreaming()"
+          [isLast]="last"
+          (regenerate)="regenerateRequested.emit()"
         />
         } @if (statusText()) {
         <div class="status-indicator">
@@ -53,7 +55,7 @@ import { ButtonModule } from 'primeng/button';
         severity="secondary"
         size="small"
         class="scroll-to-bottom"
-        (click)="scrollToBottom()"
+        (click)="scrollToBottom('smooth')"
       />
       }
     </div>
@@ -67,11 +69,13 @@ import { ButtonModule } from 'primeng/button';
       position: relative;
     }
 
+    /* No CSS smooth scrolling: per-token scrollTop updates during streaming
+       fight the animation and cause jank. Smooth behaviour is applied
+       programmatically only for the scroll-to-bottom button. */
     .message-list-container {
       flex: 1;
       overflow-y: auto;
       padding: 16px;
-      scroll-behavior: smooth;
     }
 
     .messages-wrapper {
@@ -154,6 +158,7 @@ export class MessageListComponent implements AfterViewInit {
   readonly isStreaming = input(false);
   readonly statusText = input('');
   readonly suggestionSelected = output<string>();
+  readonly regenerateRequested = output<void>();
 
   showScrollButton = signal(false);
   private readonly scrollContainer =
@@ -190,10 +195,10 @@ export class MessageListComponent implements AfterViewInit {
     this.showScrollButton.set(!isNearBottom && this.messages().length > 0);
   }
 
-  scrollToBottom(): void {
+  scrollToBottom(behavior: ScrollBehavior = 'auto'): void {
     const el = this.scrollContainer()?.nativeElement;
     if (!el) return;
-    el.scrollTop = el.scrollHeight;
+    el.scrollTo({ top: el.scrollHeight, behavior });
     this.autoScroll = true;
     this.showScrollButton.set(false);
   }

--- a/apps/chat-frontend/src/app/services/conversation.service.ts
+++ b/apps/chat-frontend/src/app/services/conversation.service.ts
@@ -264,6 +264,72 @@ export class ConversationService {
     );
   }
 
+  /**
+   * Commit the partially streamed assistant reply into the API message
+   * history. Used when generation is stopped early — without this the model
+   * would never see its own partial answer on the next turn.
+   */
+  commitPartialAssistant(conversationId: string): void {
+    this.conversations.update((convos) =>
+      convos.map((c) => {
+        if (c.id !== conversationId) return c;
+        const lastDisplay = c.displayMessages[c.displayMessages.length - 1];
+        const lastMessage = c.messages[c.messages.length - 1];
+        if (
+          !lastDisplay ||
+          lastDisplay.role !== 'assistant' ||
+          !lastDisplay.content ||
+          lastMessage?.role !== 'user'
+        ) {
+          return c;
+        }
+        return {
+          ...c,
+          messages: [
+            ...c.messages,
+            { role: 'assistant' as const, content: lastDisplay.content },
+          ],
+          updatedAt: Date.now(),
+        };
+      })
+    );
+  }
+
+  /**
+   * Drop the trailing assistant turn (display + API messages) so the last
+   * user message can be re-sent. Returns true when there is a user message
+   * to regenerate from.
+   */
+  prepareRegenerate(conversationId: string): boolean {
+    let canRegenerate = false;
+    this.conversations.update((convos) =>
+      convos.map((c) => {
+        if (c.id !== conversationId) return c;
+
+        const messages = [...c.messages];
+        while (
+          messages.length &&
+          messages[messages.length - 1].role !== 'user'
+        ) {
+          messages.pop();
+        }
+        if (!messages.some((m) => m.role === 'user')) return c;
+
+        const displayMessages = [...c.displayMessages];
+        while (
+          displayMessages.length &&
+          displayMessages[displayMessages.length - 1].role === 'assistant'
+        ) {
+          displayMessages.pop();
+        }
+
+        canRegenerate = true;
+        return { ...c, messages, displayMessages, updatedAt: Date.now() };
+      })
+    );
+    return canRegenerate;
+  }
+
   setMessagesFromDone(conversationId: string, messages: ChatMessage[]): void {
     this.conversations.update((convos) =>
       convos.map((c) => {


### PR DESCRIPTION
## Summary

A batch of correctness and UX improvements across the AI gateway and chat frontend, found by auditing the streaming path end-to-end.

### AI gateway

- **Temperature actually works now** — `/chat/stream` accepted `config.temperature` in its schema but never applied it, so the temperature slider in settings did nothing. It's now applied to the orchestrator's LLM calls and propagated to sub-agents.
- **Client disconnects abort the pipeline** — hitting Stop (or closing the tab) aborted the fetch on the client, but the server kept running the orchestrator, delegations, and Ollama generations to completion against a dead socket. An `AbortController` wired to the response `close` event now flows through `orchestrator.run` → `agent.run` → the Ollama client, so generation stops promptly.
- **Safe writes + keep-alive** — NDJSON writes are guarded against a closed/ended response, and a `ping` event is written every 15s so idle-timeout proxies don't drop the connection during long tool executions or model loads.
- **"Session started" status was never delivered** — it was emitted before the stream listener was attached; ordering fixed.
- **Ollama client abort-listener leak** — the external abort listener added by `createTimeoutSignal` is now removed on cleanup instead of accumulating on long-lived signals.

### Chat frontend

- **Copy & regenerate actions** — hover actions on assistant messages: copy the raw markdown, and regenerate the last response (drops the trailing assistant turn and re-streams from the same user message).
- **Stopped replies stay in context** — stopping generation kept the partial text on screen but dropped it from the API message history, so the model never saw its own partial answer on the next turn. The partial reply is now committed to history on stop.
- **Global system prompt no longer duplicates** — the `done` event echoes the system message back into stored history, and each turn prepended it again, accumulating one copy per turn. Stored system messages are now stripped before sending.
- **IME-safe Enter** — Enter no longer sends mid-composition (Japanese/Chinese input); it confirms the composition as expected.
- **Smoother streaming scroll** — removed CSS `scroll-behavior: smooth`, which fought the per-token auto-scroll and caused jank; smooth scrolling is applied programmatically only for the scroll-to-bottom button.

## Testing

- `nx build ai-gateway` and `tsc --noEmit` on the gateway pass
- `nx build chat-frontend` (full Angular typecheck) passes
- Booted the gateway locally and smoke-tested `/chat/stream` request validation and NDJSON output; full end-to-end LLM streaming couldn't be exercised from this environment (no route to the Ollama host)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSGVqZ4mn4fKTWLFmbRFqi

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSGVqZ4mn4fKTWLFmbRFqi)_